### PR TITLE
feat(kiosk): add wake-on-touch screen dimming

### DIFF
--- a/HADashboard.xcodeproj/project.pbxproj
+++ b/HADashboard.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -758,6 +758,7 @@
 		8EA02754759C1F548BDDA9B7 /* testHumidifierOn__gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 936DE61BF1CEBC0DD0422E9C /* testHumidifierOn__gradient@2x.png */; };
 		8EB3F7C18EF58738578C9E0F /* testVacuumCleaning_vacuumCleaning_dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 3E3C998B3C81B8B9385E764D /* testVacuumCleaning_vacuumCleaning_dark_gradient@2x.png */; };
 		8EF9973E30A35AA2B5C82DF8 /* testCoverSectionPartial_coverSectionPartial_dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8527863A8F64DF9C32B4E80E /* testCoverSectionPartial_coverSectionPartial_dark_gradient@2x.png */; };
+		8F8364A87419BED13E8974F6 /* HAProximityWakeController.m in Sources */ = {isa = PBXBuildFile; fileRef = 381DEC5D4D7D251DE64F58A4 /* HAProximityWakeController.m */; };
 		8F9091A8E13C9639619790FC /* testPersonGlance_default__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8D52A94DDE9F7BD1AD1C7732 /* testPersonGlance_default__dark_gradient@2x.png */; };
 		8FA4D81E5BB9C27823F99856 /* testAutomationTile_iconOverride__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 536DC1A09834B541D2766E26 /* testAutomationTile_iconOverride__dark_gradient@2x.png */; };
 		8FB612C832CEF14BE5B48EA0 /* HASoftwareBlur.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BF1A7E42F31D3E1633EE919 /* HASoftwareBlur.m */; };
@@ -1564,6 +1565,7 @@
 		24AF619091F89C0E867B6CEF /* testVacuumWithHeading_3col@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testVacuumWithHeading_3col@2x.png"; sourceTree = "<group>"; };
 		24B7AA90268E37D8EA333962 /* CGGeometry+LOTAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CGGeometry+LOTAdditions.h"; sourceTree = "<group>"; };
 		24C6181C30C23DE5F46603CC /* testGlanceStateColor_glanceStateColor_light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testGlanceStateColor_glanceStateColor_light@2x.png"; sourceTree = "<group>"; };
+		25440E4F5FCE1D8BD1FAFCA2 /* HAProximityWakeController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HAProximityWakeController.h; sourceTree = "<group>"; };
 		254B41AE2145E680BBECE90E /* testHeadingCellStandalone_12col@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testHeadingCellStandalone_12col@2x.png"; sourceTree = "<group>"; };
 		258F79C5609D3A6EB2835092 /* testSceneDefault_sceneDefault_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSceneDefault_sceneDefault_gradient@2x.png"; sourceTree = "<group>"; };
 		25A23BBB01EFF935B0E6A107 /* HATileFeatureTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HATileFeatureTests.m; sourceTree = "<group>"; };
@@ -1662,6 +1664,7 @@
 		372CAB09A3EF2221A1CEF46D /* HAEntity+Light.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "HAEntity+Light.m"; sourceTree = "<group>"; };
 		379DC05AF6C09238925111A5 /* testPersonTile_default__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testPersonTile_default__light@2x.png"; sourceTree = "<group>"; };
 		37A8236E8EDA7FD2E89C8678 /* HALockEntityCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HALockEntityCell.h; sourceTree = "<group>"; };
+		381DEC5D4D7D251DE64F58A4 /* HAProximityWakeController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HAProximityWakeController.m; sourceTree = "<group>"; };
 		382495084A1B966E78CF225E /* testTileSwitch__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testTileSwitch__light@2x.png"; sourceTree = "<group>"; };
 		382BF077E2DCABE92A508E63 /* testSideBySide_9plus3_Thermostat_Vacuum_9plus3_thermostat_vacuum_light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSideBySide_9plus3_Thermostat_Vacuum_9plus3_thermostat_vacuum_light@2x.png"; sourceTree = "<group>"; };
 		3874F216CF8574854509B9F8 /* testGaugeNarrowTextScaling__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testGaugeNarrowTextScaling__light@2x.png"; sourceTree = "<group>"; };
@@ -3824,6 +3827,8 @@
 				CA41892200059C8DFCB0D27B /* HAEntityDetailViewController.m */,
 				C8C85D0AA3AC9D59424B9AC7 /* HALoginViewController.h */,
 				6580FE39A826CE0764F1BC23 /* HALoginViewController.m */,
+				25440E4F5FCE1D8BD1FAFCA2 /* HAProximityWakeController.h */,
+				381DEC5D4D7D251DE64F58A4 /* HAProximityWakeController.m */,
 				86FBE42E1558876346C054CA /* HASettingsViewController.h */,
 				2AD88657773756D0FB73EABF /* HASettingsViewController.m */,
 			);
@@ -4806,7 +4811,7 @@
 				LastUpgradeCheck = 2600;
 				TargetAttributes = {
 					0B2DB332E2D264881C0F8202 = {
-						DevelopmentTeam = "";
+						DevelopmentTeam = V6B99E9S4E;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -4821,7 +4826,7 @@
 			);
 			mainGroup = 77CF34BDA4294E11B29D6909;
 			minimizedProjectReferenceProxies = 1;
-			preferredProjectObjectVersion = 77;
+			preferredProjectObjectVersion = 54;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -6043,6 +6048,7 @@
 				82B5571CD88681B98ADD49D7 /* HAPerfMonitor.m in Sources */,
 				38F8169FFA64FFA9635128A2 /* HAPersonEntityCell.m in Sources */,
 				75714986505624EA918DDACA /* HAPictureGlanceCardCell.m in Sources */,
+				8F8364A87419BED13E8974F6 /* HAProximityWakeController.m in Sources */,
 				22D12E429523F54D75C9801C /* HARemoteCommandHandler.m in Sources */,
 				1B67362D07BD8992BBA9EF37 /* HARemoteEntityCell.m in Sources */,
 				82BFD7ACD06BDDC9A662B2EE /* HASceneEntityCell.m in Sources */,

--- a/HADashboard/Auth/HAAuthManager.h
+++ b/HADashboard/Auth/HAAuthManager.h
@@ -25,6 +25,10 @@ typedef NS_ENUM(NSInteger, HAAuthMode) {
 /// Kiosk mode: hides nav bar, disables screen sleep
 @property (nonatomic, readonly, getter=isKioskMode) BOOL kioskMode;
 
+/// Wake on touch after idle: dims screen after 60 s inactivity, wakes on touch.
+/// Only active when kiosk mode is also enabled.
+@property (nonatomic, readonly) BOOL proximityWakeEnabled;
+
 /// Demo mode: uses bundled demo data instead of connecting to a real server
 @property (nonatomic, readonly, getter=isDemoMode) BOOL demoMode;
 
@@ -60,6 +64,7 @@ typedef NS_ENUM(NSInteger, HAAuthMode) {
 
 - (void)saveSelectedDashboardPath:(NSString *)urlPath;
 - (void)setKioskMode:(BOOL)enabled;
+- (void)setProximityWakeEnabled:(BOOL)enabled;
 - (void)setDemoMode:(BOOL)enabled;
 - (void)setAutoReloadDashboard:(BOOL)enabled;
 - (void)setCameraGlobalMute:(BOOL)muted;

--- a/HADashboard/Auth/HAAuthManager.m
+++ b/HADashboard/Auth/HAAuthManager.m
@@ -11,7 +11,8 @@ static NSString *const kAuthModeKey      = @"ha_auth_mode";
 static NSString *const kRefreshTokenKey  = @"ha_refresh_token";
 static NSString *const kTokenExpiryKey   = @"ha_token_expiry";
 static NSString *const kSelectedDashboardKey = @"ha_selected_dashboard";
-static NSString *const kKioskModeKey     = @"ha_kiosk_mode";
+static NSString *const kKioskModeKey         = @"ha_kiosk_mode";
+static NSString *const kProximityWakeKey     = @"ha_proximity_wake";
 static NSString *const kDemoModeKey      = @"ha_demo_mode";
 static NSString *const kAutoReloadDashboardKey = @"ha_auto_reload_dashboard";
 static NSString *const kCameraGlobalMuteKey = @"HACameraGlobalMute";
@@ -54,6 +55,7 @@ static NSString *const kCameraGlobalMuteKey = @"HACameraGlobalMute";
         HALogD(@"auth", @"  keychain: refreshToken done");
         _selectedDashboardPath = [[NSUserDefaults standardUserDefaults] stringForKey:kSelectedDashboardKey];
         _kioskMode = [[NSUserDefaults standardUserDefaults] boolForKey:kKioskModeKey];
+        _proximityWakeEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:kProximityWakeKey];
         _demoMode = [[NSUserDefaults standardUserDefaults] boolForKey:kDemoModeKey];
         // Default to YES when key hasn't been explicitly set
         if ([[NSUserDefaults standardUserDefaults] objectForKey:kAutoReloadDashboardKey] != nil) {
@@ -280,6 +282,13 @@ static NSString *const kCameraGlobalMuteKey = @"HACameraGlobalMute";
 - (void)setKioskMode:(BOOL)enabled {
     _kioskMode = enabled;
     [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kKioskModeKey];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+    [[NSNotificationCenter defaultCenter] postNotificationName:HAAuthManagerDidUpdateNotification object:self];
+}
+
+- (void)setProximityWakeEnabled:(BOOL)enabled {
+    _proximityWakeEnabled = enabled;
+    [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kProximityWakeKey];
     [[NSUserDefaults standardUserDefaults] synchronize];
     [[NSNotificationCenter defaultCenter] postNotificationName:HAAuthManagerDidUpdateNotification object:self];
 }

--- a/HADashboard/Controllers/HADashboardViewController.m
+++ b/HADashboard/Controllers/HADashboardViewController.m
@@ -44,6 +44,7 @@
 #import "HAHistoryManager.h"
 #import "HASunBasedTheme.h"
 #import "HAToastView.h"
+#import "HAProximityWakeController.h"
 #import <QuartzCore/QuartzCore.h>
 
 static NSString * const kSectionHeaderReuseId = @"HASectionHeader";
@@ -70,6 +71,7 @@ static NSString * const kSectionHeaderReuseId = @"HASectionHeader";
 @property (nonatomic, assign) BOOL usesColumnarLayout;
 @property (nonatomic, strong) UITapGestureRecognizer *kioskExitTap;
 @property (nonatomic, strong) NSTimer *kioskHideTimer;
+@property (nonatomic, strong) HAProximityWakeController *proximityWakeController;
 @property (nonatomic, strong) NSLayoutConstraint *viewPickerTopConstraint;
 @property (nonatomic, strong) NSLayoutConstraint *collectionViewTopToPickerConstraint;
 @property (nonatomic, strong) NSLayoutConstraint *collectionViewTopToViewConstraint;
@@ -294,11 +296,26 @@ static NSString * const kSectionHeaderReuseId = @"HASectionHeader";
     }
 }
 
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    // viewWillAppear may fire before the view is in a window on iOS 9 (self.view.window is nil).
+    // Start the proximity wake controller now if it wasn't started there.
+    if (!self.proximityWakeController
+            && [[HAAuthManager sharedManager] isKioskMode]
+            && [[HAAuthManager sharedManager] proximityWakeEnabled]) {
+        self.proximityWakeController = [[HAProximityWakeController alloc]
+            initWithWindow:self.view.window];
+        [self.proximityWakeController start];
+    }
+}
+
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [self.kioskHideTimer invalidate];
     self.kioskHideTimer = nil;
+    [self.proximityWakeController stop];
+    self.proximityWakeController = nil;
 
     // Restore idle timer and nav bar when leaving dashboard
 #if !TARGET_OS_MACCATALYST
@@ -1275,6 +1292,18 @@ static const CGFloat kRowUnitHeight = 56.0;
 
 - (void)applyKioskMode {
     BOOL kiosk = [[HAAuthManager sharedManager] isKioskMode];
+    BOOL wakeOnTouch = kiosk && [[HAAuthManager sharedManager] proximityWakeEnabled];
+
+    if (wakeOnTouch) {
+        if (!self.proximityWakeController && self.view.window) {
+            self.proximityWakeController = [[HAProximityWakeController alloc]
+                initWithWindow:self.view.window];
+            [self.proximityWakeController start];
+        }
+    } else {
+        [self.proximityWakeController stop];
+        self.proximityWakeController = nil;
+    }
 #if !TARGET_OS_MACCATALYST
     [UIApplication sharedApplication].idleTimerDisabled = kiosk;
 #endif

--- a/HADashboard/Controllers/HAProximityWakeController.h
+++ b/HADashboard/Controllers/HAProximityWakeController.h
@@ -1,0 +1,24 @@
+#import <UIKit/UIKit.h>
+
+/// Posted by HAThemeAwareWindow on every UITouchPhaseBegan event.
+/// HAProximityWakeController observes this to reset the idle timer.
+extern NSString *const HAWindowUserDidInteractNotification;
+
+/// Implements fake-sleep/wake for kiosk mode.
+///
+/// When started, a 60-second idle timer runs. If no touch occurs before it
+/// fires, the screen is dimmed to black (brightness → 0 + opaque overlay).
+/// Any subsequent touch instantly restores brightness and removes the overlay.
+/// Stops cleanly on app resign-active and restores state on become-active.
+@interface HAProximityWakeController : NSObject
+
+- (instancetype)initWithWindow:(UIWindow *)window NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Starts the idle timer. Call when kiosk + proximity wake are both enabled.
+- (void)start;
+
+/// Stops the idle timer and immediately restores the screen if sleeping.
+- (void)stop;
+
+@end

--- a/HADashboard/Controllers/HAProximityWakeController.m
+++ b/HADashboard/Controllers/HAProximityWakeController.m
@@ -1,0 +1,151 @@
+#import "HAProximityWakeController.h"
+
+NSString *const HAWindowUserDidInteractNotification = @"HAWindowUserDidInteractNotification";
+
+/// Seconds of inactivity before the screen dims.
+static const NSTimeInterval kDimDelay = 60.0;
+/// Duration of the dim-to-black animation.
+static const NSTimeInterval kDimDuration = 4.0;
+/// Duration of the wake (overlay fade-out) animation.
+static const NSTimeInterval kWakeDuration = 0.35;
+
+@interface HAProximityWakeController ()
+@property (nonatomic, weak)   UIWindow *window;
+@property (nonatomic, strong) NSTimer  *idleTimer;
+@property (nonatomic, strong) UIView   *sleepOverlay;
+@property (nonatomic, assign) CGFloat   savedBrightness;
+@property (nonatomic, assign) BOOL      sleeping;
+@end
+
+@implementation HAProximityWakeController
+
+- (instancetype)initWithWindow:(UIWindow *)window {
+    self = [super init];
+    if (self) {
+        _window = window;
+    }
+    return self;
+}
+
+#pragma mark - Public
+
+- (void)start {
+    [self scheduleIdleTimer];
+    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+    [nc addObserver:self selector:@selector(userDidInteract)
+               name:HAWindowUserDidInteractNotification object:nil];
+    [nc addObserver:self selector:@selector(appWillResignActive)
+               name:UIApplicationWillResignActiveNotification object:nil];
+    [nc addObserver:self selector:@selector(appDidBecomeActive)
+               name:UIApplicationDidBecomeActiveNotification object:nil];
+}
+
+- (void)stop {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [self.idleTimer invalidate];
+    self.idleTimer = nil;
+    [self wakeImmediately];
+}
+
+#pragma mark - Idle timer
+
+- (void)scheduleIdleTimer {
+    [self.idleTimer invalidate];
+    self.idleTimer = [NSTimer scheduledTimerWithTimeInterval:kDimDelay
+                                                      target:self
+                                                    selector:@selector(idleTimerFired)
+                                                    userInfo:nil
+                                                     repeats:NO];
+}
+
+- (void)idleTimerFired {
+    self.idleTimer = nil;
+    [self dim];
+}
+
+#pragma mark - Touch handling
+
+- (void)userDidInteract {
+    if (self.sleeping) {
+        [self wake];
+    } else {
+        [self scheduleIdleTimer];
+    }
+}
+
+#pragma mark - Dim / wake
+
+- (void)dim {
+    if (self.sleeping) return;
+    self.sleeping = YES;
+
+    UIWindow *window = self.window;
+    if (!window) return;
+
+    self.savedBrightness = [UIScreen mainScreen].brightness;
+
+    UIView *overlay = [[UIView alloc] initWithFrame:window.bounds];
+    overlay.backgroundColor = [UIColor blackColor];
+    overlay.alpha = 0.0;
+    overlay.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    // userInteractionEnabled YES so it absorbs touches (sendEvent: still fires for wake)
+    overlay.userInteractionEnabled = YES;
+    self.sleepOverlay = overlay;
+    [window addSubview:overlay];
+
+    [UIView animateWithDuration:kDimDuration delay:0
+                        options:UIViewAnimationOptionCurveEaseIn
+                     animations:^{
+        overlay.alpha = 1.0;
+        [UIScreen mainScreen].brightness = 0.0;
+    } completion:nil];
+}
+
+- (void)wake {
+    if (!self.sleeping) return;
+    self.sleeping = NO;
+
+    // Restore brightness immediately so the first thing the user sees is the
+    // screen coming back on, not a black frame while the overlay fades.
+    [UIScreen mainScreen].brightness = self.savedBrightness;
+
+    UIView *overlay = self.sleepOverlay;
+    self.sleepOverlay = nil;
+
+    [overlay.layer removeAllAnimations]; // cancel any in-progress dim
+    [UIView animateWithDuration:kWakeDuration animations:^{
+        overlay.alpha = 0.0;
+    } completion:^(BOOL finished) {
+        [overlay removeFromSuperview];
+    }];
+
+    [self scheduleIdleTimer];
+}
+
+/// Instant restore with no animation, used when the feature is disabled.
+- (void)wakeImmediately {
+    if (!self.sleeping) return;
+    self.sleeping = NO;
+    [UIScreen mainScreen].brightness = self.savedBrightness;
+    [self.sleepOverlay.layer removeAllAnimations];
+    [self.sleepOverlay removeFromSuperview];
+    self.sleepOverlay = nil;
+}
+
+#pragma mark - App lifecycle
+
+- (void)appWillResignActive {
+    // Pause idle timer when app is not active (control center, incoming call, etc.)
+    // Don't dim — the OS will dim/lock on its own.
+    [self.idleTimer invalidate];
+    self.idleTimer = nil;
+}
+
+- (void)appDidBecomeActive {
+    if (!self.sleeping) {
+        [self scheduleIdleTimer];
+    }
+    // If we were sleeping when resigned, stay sleeping — user will touch to wake.
+}
+
+@end

--- a/HADashboard/Controllers/HASettingsViewController.m
+++ b/HADashboard/Controllers/HASettingsViewController.m
@@ -50,6 +50,10 @@ static NSString *const kDeviceNameOverride    = @"ha_device_name_override";
 @property (nonatomic, strong) UIView *kioskSection;
 @property (nonatomic, strong) UISwitch *kioskSwitch;
 
+// Wake on touch (sub-setting of kiosk mode)
+@property (nonatomic, strong) UIView *proximityWakeSection;
+@property (nonatomic, strong) UISwitch *proximityWakeSwitch;
+
 // Demo mode
 @property (nonatomic, strong) UIView *demoSection;
 @property (nonatomic, strong) UISwitch *demoSwitch;
@@ -293,6 +297,19 @@ static NSString *const kDeviceNameOverride    = @"ha_device_name_override";
     self.kioskSwitch = kioskSw;
     [container addSubview:self.kioskSection];
 
+    // Wake on touch — sub-setting shown below kiosk, disabled when kiosk is off
+    BOOL kioskOn = [[HAAuthManager sharedManager] isKioskMode];
+    UISwitch *proxWakeSw = nil;
+    self.proximityWakeSection = [self createToggleSection:@"Wake on Touch"
+        helpText:@"Dims the screen after 60 seconds of inactivity. Touch anywhere to wake."
+        isOn:[[HAAuthManager sharedManager] proximityWakeEnabled]
+        target:self action:@selector(proximityWakeSwitchToggled:)
+        switchOut:&proxWakeSw];
+    proxWakeSw.enabled = kioskOn;
+    self.proximityWakeSection.alpha = kioskOn ? 1.0 : 0.4;
+    self.proximityWakeSwitch = proxWakeSw;
+    [container addSubview:self.proximityWakeSection];
+
     // Demo mode
     UISwitch *demoSw = nil;
     self.demoSection = [self createToggleSection:@"Demo Mode"
@@ -429,6 +446,7 @@ static NSString *const kDeviceNameOverride    = @"ha_device_name_override";
         @"themeStack":self.themeStack,
         @"dispHdr":   self.displaySectionHeader,
         @"kiosk":     self.kioskSection,
+        @"proxWake":  self.proximityWakeSection,
         @"demo":      self.demoSection,
         @"autoReload":self.autoReloadSection,
         @"camMute":   self.cameraMuteSection,
@@ -444,7 +462,7 @@ static NSString *const kDeviceNameOverride    = @"ha_device_name_override";
     NSDictionary *metrics = @{@"p": @16, @"sh": @32, @"hg": @10, @"fh": @44};
 
     [container addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:
-        @"V:|[connHdr]-hg-[connRow]-sh-[appHdr]-hg-[themeStack]-sh-[dispHdr]-hg-[kiosk]-p-[demo]-p-[autoReload]-p-[camMute]-p-[clrCache(fh)]-sh-[intHdr]-hg-[intSec]-sh-[aboutHdr]-hg-[about]-sh-[devHdr]-hg-[dev]-sh-[logout(fh)]|"
+        @"V:|[connHdr]-hg-[connRow]-sh-[appHdr]-hg-[themeStack]-sh-[dispHdr]-hg-[kiosk]-p-[proxWake]-p-[demo]-p-[autoReload]-p-[camMute]-p-[clrCache(fh)]-sh-[intHdr]-hg-[intSec]-sh-[aboutHdr]-hg-[about]-sh-[devHdr]-hg-[dev]-sh-[logout(fh)]|"
         options:0 metrics:metrics views:views]];
 
     for (NSString *name in views) {
@@ -853,6 +871,20 @@ static NSString *const kDeviceNameOverride    = @"ha_device_name_override";
 
 - (void)kioskSwitchToggled:(UISwitch *)sender {
     [[HAAuthManager sharedManager] setKioskMode:sender.isOn];
+    // Enable/disable the dependent wake-on-touch sub-setting
+    self.proximityWakeSwitch.enabled = sender.isOn;
+    [UIView animateWithDuration:0.2 animations:^{
+        self.proximityWakeSection.alpha = sender.isOn ? 1.0 : 0.4;
+    }];
+    if (!sender.isOn && self.proximityWakeSwitch.isOn) {
+        // Turn off wake-on-touch when kiosk is disabled
+        [self.proximityWakeSwitch setOn:NO animated:YES];
+        [[HAAuthManager sharedManager] setProximityWakeEnabled:NO];
+    }
+}
+
+- (void)proximityWakeSwitchToggled:(UISwitch *)sender {
+    [[HAAuthManager sharedManager] setProximityWakeEnabled:sender.isOn];
 }
 
 - (void)autoReloadSwitchToggled:(UISwitch *)sender {

--- a/HADashboard/HAAppDelegate.m
+++ b/HADashboard/HAAppDelegate.m
@@ -1,5 +1,6 @@
 #import "HAAppDelegate.h"
 #import "HAAuthManager.h"
+#import "HAProximityWakeController.h"
 #import "HAPerfMonitor.h"
 #import "HAConnectionManager.h"
 #import "HADashboardViewController.h"
@@ -21,6 +22,23 @@
 @end
 
 @implementation HAThemeAwareWindow
+
+- (void)sendEvent:(UIEvent *)event {
+    [super sendEvent:event];
+    // Notify HAProximityWakeController of user interaction so it can reset
+    // the idle timer or wake the screen. We only care about touch-began so
+    // rapid move/end events don't flood the notification center.
+    if (event.type == UIEventTypeTouches) {
+        for (UITouch *touch in [event allTouches]) {
+            if (touch.phase == UITouchPhaseBegan) {
+                [[NSNotificationCenter defaultCenter]
+                    postNotificationName:HAWindowUserDidInteractNotification object:nil];
+                break;
+            }
+        }
+    }
+}
+
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
     [super traitCollectionDidChange:previousTraitCollection];
     if (@available(iOS 13.0, *)) {


### PR DESCRIPTION
## Summary

Adds a **Wake on Touch** sub-setting under Kiosk Mode. When enabled, the screen dims to black after 60 seconds of inactivity and wakes instantly on any touch.

- Idle timer (60 s) resets on every touch via `sendEvent:` in `HAThemeAwareWindow`
- Dim: animates `UIScreen.brightness` → 0 and fades in a full-screen black overlay over 4 s
- Wake: restores brightness immediately to its pre-dim value, fades out the overlay in 0.35 s
- The overlay absorbs touches during wake to prevent accidental taps on cells beneath it
- App resign-active pauses the timer; become-active resumes it
- Disabling Kiosk Mode also disables Wake on Touch

Partially closes #6 — this addresses the "screen off when idle" half of the request using simulated sleep (brightness + overlay) since iOS does not expose true sleep/wake APIs to sandboxed apps. Proximity/presence detection to wake automatically can be layered on top in a follow-up.

## Test plan

- [ ] Enable Kiosk Mode → Wake on Touch toggle becomes active
- [ ] Leave screen idle for 60 s → dims smoothly to black
- [ ] Touch screen while dim → brightness restores instantly, overlay fades out
- [ ] Disable Kiosk Mode → Wake on Touch turns off, screen stays on
- [ ] Background the app mid-dim → timer pauses; foreground → resumes correctly
- [ ] Verify no regression on single-mode thermostat, camera, and other cells