### PR TITLE
feat: add protected local camera streaming and v1.2.6 release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,14 @@ ASC_KEY_ID=              # App Store Connect API Key ID
 ASC_ISSUER_ID=           # App Store Connect Issuer ID
 ASC_KEY_PATH=            # Path to .p8 key file, e.g. ~/private_keys/AuthKey_XXXX.p8
 
+# ── Toolchains (optional overrides) ─────────────────────────────────
+XCODE_PATH=              # Modern Xcode 26/27 app path; default /Applications/Xcode.app
+XCODE13_PATH=            # Full Xcode 13.2.1 app path, if installed
+XCODE13_SDK_PATH=        # Extracted Xcode 13 iPhoneOS.sdk; can replace full Xcode 13
+HADASHBOARD_SIGNING_STYLE=manual    # manual or automatic
+HADASHBOARD_SIGNING_DEVICE_ID=      # CoreDevice/UDID used for automatic registration
+CATALYST_IPHONEOS_DEPLOYMENT_TARGET=15.0
+
 # ── Home Assistant ───────────────────────────────────────────────────
 HA_SERVER=               # e.g. http://192.168.1.100:8123
 HA_TOKEN=                # Long-lived access token from HA
@@ -22,8 +30,9 @@ IPHONE_DEVICECTL_ID=
 IPAD_MINI5_UDID=
 IPAD_MINI5_DEVICECTL_ID=
 IPAD_MINI4_UDID=
-IPAD_UDID=
 IPAD2_UDID=
+IPAD3_UDID=
+IPAD4_UDID=
 
 # ── Simulator (optional — auto-detected by name if not set) ────────
 # SIM_IPAD_UDID=           # Override iPad simulator UDID
@@ -31,11 +40,15 @@ IPAD2_UDID=
 # SIM_IPAD_NAME=iPad (10th generation)    # Simulator name for auto-lookup
 # SIM_IPHONE_NAME=iPhone 15 Pro           # Simulator name for auto-lookup
 
-# ── iPad 2 WiFi SSH (jailbroken) ────────────────────────────────────
+# ── Legacy WiFi SSH targets (jailbroken) ───────────────────────────
 IPAD2_IP=                # iPad 2 local IP address
 IPAD2_SSH_PASS=alpine    # SSH password (default: alpine)
+IPAD3_IP=                # iPad 3 local IP address
+IPAD3_SSH_PASS=alpine
+IPAD4_IP=                # iPad 4 local IP address
+IPAD4_SSH_PASS=alpine
 
-# ── Unraid Server (for iPad 2 USB deploy) ───────────────────────────
+# ── Unraid Server (for iPad 2/iPad 4 USB deploy) ───────────────────
 UNRAID_HOST=             # Unraid server IP
 UNRAID_USER=root
 UNRAID_PASS=

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,7 @@ on:
 env:
   SCHEME: HADashboard
   TEAM_ID: ${{ vars.TEAM_ID }}
-  # Immutable Xcode 13.2.1 iPhoneOS SDK stubs (21MB) for armv7 linking.
-  # Kept as a repository release asset so legacy builds never need an Apple
-  # login or an evictable Actions cache to recover the old SDK.
+  # Immutable Xcode 13.2.1 iPhoneOS SDK stubs for iOS 9 armv7/arm64 linking.
   XCODE13_SDK_STUBS_RELEASE: xcode13-sdk-stubs-v1
   XCODE13_SDK_STUBS_SHA256: 7b89a8882d60246b0ba53ed4a61363a0cbcad648e5b36874940bf4ee400c2dfc
 
@@ -34,10 +32,10 @@ jobs:
       - name: Select Xcode
         run: |
           # Find the latest Xcode 26.x (year-based naming from WWDC 2025)
-          XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
+          XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1 || true)
           if [ -z "$XCODE" ]; then
             # Fall back to default Xcode
-            XCODE=$(ls -d /Applications/Xcode.app /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
+            XCODE=$(ls -d /Applications/Xcode.app /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1 || true)
           fi
           echo "Using: $XCODE ($(${XCODE}/Contents/Developer/usr/bin/xcodebuild -version | head -1))"
           sudo xcode-select -s "$XCODE"
@@ -70,23 +68,54 @@ jobs:
             -destination "generic/platform=iOS Simulator" \
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO \
+            IPHONEOS_DEPLOYMENT_TARGET=15.0 \
             MARKETING_VERSION=${{ steps.version.outputs.version }} \
             CURRENT_PROJECT_VERSION=${{ steps.version.outputs.build_number }}
           # Snapshot tests are skipped in CI — reference images are recorded
           # on iOS 17.4 and differ across iOS versions. Run locally with:
           #   scripts/test-snapshots.sh
 
-  # ── Verify immutable Xcode 13 SDK stubs on main pushes ───────────────
-  # The armv7 link step needs TBD stubs from Xcode 13's iOS SDK. Downloading
-  # this repository-owned release asset is deterministic and avoids Apple-ID
-  # authentication entirely.
-  verify-sdk-stubs:
+      - name: Test streaming and device integration behavior
+        run: |
+          xcodebuild test \
+            -scheme $SCHEME \
+            -destination 'platform=macOS,variant=Mac Catalyst' \
+            -configuration Debug \
+            CODE_SIGNING_ALLOWED=NO \
+            IPHONEOS_DEPLOYMENT_TARGET=15.0 \
+            MARKETING_VERSION=${{ steps.version.outputs.version }} \
+            CURRENT_PROJECT_VERSION=${{ steps.version.outputs.build_number }} \
+            -only-testing:HADashboardTests/HAStreamingTests \
+            -only-testing:HADashboardTests/HARTSPCredentialManagerTests \
+            -only-testing:HADashboardTests/HADeviceRegistrationTests \
+            -only-testing:HADashboardTests/HASensorReporterTests \
+            -only-testing:HADashboardTests/HAProximityWakeControllerTests \
+            -only-testing:HADashboardTests/HARemoteCommandHandlerTests \
+            -only-testing:HADashboardTests/HADeviceIntegrationManagerTests \
+            -only-testing:HADashboardTests/HANotificationPresenterTests
+
+  # ── Verify immutable stubs and compile both iOS 9 release slices ─────
+  verify-ios9-slices:
     runs-on: macos-latest
-    timeout-minutes: 10
-    if: github.ref == 'refs/heads/main'
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Select Xcode
+        run: |
+          XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1 || true)
+          if [ -z "$XCODE" ]; then
+            XCODE=$(ls -d /Applications/Xcode.app /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1 || true)
+          fi
+          test -d "$XCODE"
+          echo "Using: $XCODE ($(${XCODE}/Contents/Developer/usr/bin/xcodebuild -version | head -1))"
+          sudo xcode-select -s "$XCODE"
+          echo "XCODE_PATH=$XCODE" >> "$GITHUB_ENV"
+
       - name: Download and verify Xcode 13 SDK stubs
         env:
           GH_TOKEN: ${{ github.token }}
@@ -102,11 +131,18 @@ jobs:
           echo "$XCODE13_SDK_STUBS_SHA256  $STUBS_ARCHIVE" | shasum -a 256 -c -
           tar tzf "$STUBS_ARCHIVE" | grep -Fx 'iPhoneOS.sdk/SDKSettings.plist'
           tar tzf "$STUBS_ARCHIVE" | grep -Fx 'iPhoneOS.sdk/System/Library/Frameworks/UIKit.framework/UIKit.tbd'
+          tar xzf "$STUBS_ARCHIVE" -C "$STUBS_DIR"
+          echo "XCODE13_SDK_PATH=$STUBS_DIR/iPhoneOS.sdk" >> "$GITHUB_ENV"
+
+      - name: Compile and verify iOS 9 slices
+        env:
+          HADASHBOARD_SLICES_ONLY: YES
+        run: scripts/build.sh device
 
   # ── Universal armv7+arm64 release ────────────────────────────────────
   archive-release:
-    needs: build-and-test
-    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.release_version != '')
+    needs: [build-and-test, verify-ios9-slices]
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.release_version != '')
     runs-on: macos-latest
     timeout-minutes: 45
     permissions:
@@ -118,9 +154,9 @@ jobs:
 
       - name: Select Xcode
         run: |
-          XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
+          XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1 || true)
           if [ -z "$XCODE" ]; then
-            XCODE=$(ls -d /Applications/Xcode.app /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
+            XCODE=$(ls -d /Applications/Xcode.app /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1 || true)
           fi
           echo "Using: $XCODE ($(${XCODE}/Contents/Developer/usr/bin/xcodebuild -version | head -1))"
           sudo xcode-select -s "$XCODE"
@@ -140,6 +176,17 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
           echo "Version: $VERSION (build $BUILD_NUMBER)"
+
+      - name: Validate curated release notes
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          NOTES="docs/releases/v${VERSION}.md"
+          PUBLIC_NOTES="docs/releases/v${VERSION}-github.md"
+          test -f "$NOTES"
+          test -f "$PUBLIC_NOTES"
+          ! grep -Fq 'Status: **Draft' "$NOTES"
+          ! grep -Fq 'Status: **Draft' "$PUBLIC_NOTES"
+          ! grep -Fq -- '- [ ]' "$NOTES"
 
       - name: Decode ASC API key
         env:
@@ -216,8 +263,8 @@ jobs:
           plutil -replace teamID -string "$TEAM_ID" ExportOptions-AppStore.plist
           plutil -replace teamID -string "$TEAM_ID" ExportOptions-AdHoc.plist
 
-      # ── Step 1: Build armv7 slice with clang direct ──────────────────
-      - name: Build armv7 slice (clang direct, sdk=26.2)
+      # ── Step 1: Build both iOS 9 slices with clang direct ────────────
+      - name: Build armv7 and arm64 iOS 9 slices
         run: |
           VERSION=${{ steps.version.outputs.version }}
           BUILD_NUMBER=${{ steps.version.outputs.build_number }}
@@ -225,7 +272,7 @@ jobs:
           XCODE26_SDK="$(xcrun --sdk iphoneos --show-sdk-path)"
           SDK_VER=$(plutil -extract Version raw "$XCODE26_SDK/SDKSettings.plist")
 
-          echo "Compiling armv7 with Xcode 26 clang (sdk=$SDK_VER)..."
+          echo "Compiling iOS 9 slices with modern Xcode clang (sdk=$SDK_VER)..."
 
           # Collect include directories
           INCLUDE_FLAGS=()
@@ -245,60 +292,83 @@ jobs:
               -not -path '*/iOSSnapshotTestCase/*' \
               -not -path '*/MDI/*')
 
-          # Compile all .m files
-          mkdir -p build/armv7-obj
-          ERRORS=0
-          COMPILED=0
-          for src in "${SOURCES[@]}"; do
-            OBJ_NAME=$(echo "$src" | sed 's|/|_|g; s|\.m$|.o|')
-            if "$CLANG" \
-                --target=armv7-apple-ios9.0 \
-                -isysroot "$XCODE26_SDK" \
-                -x objective-c -fobjc-arc -fmodules -Os -DNDEBUG -g -w \
-                "${INCLUDE_FLAGS[@]}" \
-                -c "$src" -o "build/armv7-obj/$OBJ_NAME" 2>/dev/null; then
-              COMPILED=$((COMPILED + 1))
-            else
-              ERRORS=$((ERRORS + 1))
-              if [ $ERRORS -le 3 ]; then
-                echo "FAIL: $src"
-                "$CLANG" --target=armv7-apple-ios9.0 -isysroot "$XCODE26_SDK" \
-                    -x objective-c -fobjc-arc -fmodules -Os -DNDEBUG \
-                    "${INCLUDE_FLAGS[@]}" -c "$src" -o /dev/null 2>&1 | grep 'error:' | head -3
+          # Compile and link both shipped slices directly. Xcode 27 no longer
+          # permits xcodebuild to target pre-iOS 15, but clang still produces
+          # valid iOS 9 Mach-O slices when linked against the Xcode 13 stubs.
+          for ARCH in armv7 arm64; do
+            TARGET="$ARCH-apple-ios9.0"
+            OBJECT_DIR="build/$ARCH-obj"
+            ARCH_FLAGS=()
+            if [[ "$ARCH" == "armv7" ]]; then
+              # Xcode 27 ld can lose Thumb mode bits for LC_MAIN and Obj-C IMPs.
+              ARCH_FLAGS=(-marm)
+            fi
+            mkdir -p "$OBJECT_DIR"
+            ERRORS=0
+            COMPILED=0
+            for src in "${SOURCES[@]}"; do
+              OBJ_NAME=$(echo "$src" | sed 's|/|_|g; s|\.m$|.o|')
+              if "$CLANG" \
+                  --target="$TARGET" \
+                  -isysroot "$XCODE26_SDK" \
+                  -x objective-c -fobjc-arc -fmodules -Os -DNDEBUG -g \
+                  -Werror=unguarded-availability \
+                  ${ARCH_FLAGS[@]+"${ARCH_FLAGS[@]}"} \
+                  "${INCLUDE_FLAGS[@]}" \
+                  -c "$src" -o "$OBJECT_DIR/$OBJ_NAME" 2>/dev/null; then
+                COMPILED=$((COMPILED + 1))
+              else
+                ERRORS=$((ERRORS + 1))
+                if [ $ERRORS -le 3 ]; then
+                  echo "FAIL ($ARCH): $src"
+                  "$CLANG" --target="$TARGET" -isysroot "$XCODE26_SDK" \
+                      -x objective-c -fobjc-arc -fmodules -Os -DNDEBUG \
+                      -Werror=unguarded-availability \
+                      "${INCLUDE_FLAGS[@]}" -c "$src" -o /dev/null 2>&1 | grep 'error:' | head -3
+                fi
+              fi
+            done
+
+            if [ $ERRORS -gt 0 ]; then
+              echo "❌ $ARCH compile failed: $COMPILED/$((COMPILED + ERRORS)) files"
+              exit 1
+            fi
+
+            "$CLANG" \
+                --target="$TARGET" \
+                -isysroot "$XCODE13_SDK" \
+                -framework Foundation -framework UIKit -framework CoreFoundation \
+                -framework CoreGraphics -framework CoreText -framework QuartzCore \
+                -framework Security -framework CFNetwork -framework AVFoundation \
+                -framework AudioToolbox -framework CoreMedia -framework CoreVideo \
+                -framework VideoToolbox \
+                -fobjc-arc -dead_strip \
+                ${ARCH_FLAGS[@]+"${ARCH_FLAGS[@]}"} \
+                -Xlinker -platform_version -Xlinker ios -Xlinker 9.0 -Xlinker "$SDK_VER" \
+                "$OBJECT_DIR"/*.o \
+                -o "build/$ARCH-thin"
+
+            if [[ "$ARCH" == "armv7" ]]; then
+              ENTRYOFF=$(otool -l "build/$ARCH-thin" | awk '
+                $1 == "cmd" && $2 == "LC_MAIN" { wanted = 1; next }
+                wanted && $1 == "entryoff" { print $2; exit }
+              ')
+              if [[ -z "$ENTRYOFF" || $((ENTRYOFF % 2)) -ne 0 ]]; then
+                echo "❌ armv7 ARM-mode LC_MAIN entryoff is unexpectedly odd: ${ENTRYOFF:-missing}"
+                exit 1
+              fi
+              if nm -arch armv7 -m "build/$ARCH-thin" | grep ' _main$' | grep -q '\[Thumb\]'; then
+                echo "❌ armv7 main is unexpectedly marked as Thumb"
+                exit 1
               fi
             fi
+
+            echo "✓ $ARCH slice: $(du -h "build/$ARCH-thin" | cut -f1)"
+            otool -l "build/$ARCH-thin" | grep -A5 'LC_VERSION_MIN_IPHONEOS\|LC_BUILD_VERSION'
           done
 
-          if [ $ERRORS -gt 0 ]; then
-            echo "❌ armv7 compile failed: $COMPILED/$((COMPILED + ERRORS)) files"
-            exit 1
-          fi
-          echo "✓ Compiled $COMPILED files"
-
-          # Link against Xcode 13 TBD stubs with platform_version override
-          "$CLANG" \
-              --target=armv7-apple-ios9.0 \
-              -isysroot "$XCODE13_SDK" \
-              -framework Foundation -framework UIKit -framework CoreFoundation \
-              -framework CoreGraphics -framework CoreText -framework QuartzCore \
-              -framework Security -framework CFNetwork \
-              -fobjc-arc -dead_strip \
-              -Xlinker -platform_version -Xlinker ios -Xlinker 9.0 -Xlinker "$SDK_VER" \
-              build/armv7-obj/*.o \
-              -o build/armv7-thin
-
-          # Generate dSYM
-          DSYMUTIL="$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/bin/dsymutil"
-          "$DSYMUTIL" build/armv7-thin -o build/armv7.dSYM
-          # Rename DWARF to match app executable name
-          mv "build/armv7.dSYM/Contents/Resources/DWARF/armv7-thin" \
-             "build/armv7.dSYM/Contents/Resources/DWARF/HA Dashboard" 2>/dev/null || true
-
-          echo "✓ armv7 slice: $(du -h build/armv7-thin | cut -f1)"
-          otool -l build/armv7-thin | grep -A5 'LC_VERSION_MIN_IPHONEOS'
-
-      # ── Step 2: Archive arm64 with Xcode 26 ─────────────────────────
-      - name: Archive arm64
+      # ── Step 2: Archive signed bundle/resource template ──────────────
+      - name: Archive signed bundle template
         run: |
           xcodebuild archive \
             -scheme $SCHEME \
@@ -306,6 +376,7 @@ jobs:
             -configuration Release \
             -archivePath build/HADashboard.xcarchive \
             ARCHS=arm64 VALID_ARCHS=arm64 \
+            IPHONEOS_DEPLOYMENT_TARGET=15.0 \
             MARKETING_VERSION=${{ steps.version.outputs.version }} \
             CURRENT_PROJECT_VERSION=${{ steps.version.outputs.build_number }} \
             DEVELOPMENT_TEAM=$TEAM_ID \
@@ -321,9 +392,11 @@ jobs:
           BUILD_NUMBER=${{ steps.version.outputs.build_number }}
           APP="build/HADashboard.xcarchive/Products/Applications/HA Dashboard.app"
           SRC_ICON="HADashboard/Assets.xcassets/AppIcon.appiconset/icon-1024.png"
+          ENTITLEMENTS="build/final-entitlements.plist"
+          codesign -d --entitlements :- "$APP" > "$ENTITLEMENTS" 2>/dev/null
 
           echo "=== Swap in universal binary ==="
-          lipo -create build/armv7-thin "$APP/HA Dashboard" \
+          lipo -create build/armv7-thin build/arm64-thin \
               -output "$APP/HA Dashboard.tmp"
           mv "$APP/HA Dashboard.tmp" "$APP/HA Dashboard"
           echo "Archs: $(lipo -archs "$APP/HA Dashboard")"
@@ -357,42 +430,40 @@ jobs:
           sips -z 120 120 "$SRC_ICON" --out "$APP/AppIcon60x60@2x.png" 2>/dev/null
           sips -z 180 180 "$SRC_ICON" --out "$APP/AppIcon60x60@3x.png" 2>/dev/null
 
-          echo "=== Merge dSYMs ==="
+          echo "=== Generate universal dSYM ==="
           DSYM="build/HADashboard.xcarchive/dSYMs/HA Dashboard.app.dSYM"
-          ARM64_DWARF="$DSYM/Contents/Resources/DWARF/HA Dashboard"
-          ARMV7_DWARF="build/armv7.dSYM/Contents/Resources/DWARF/HA Dashboard"
-          if [ -f "$ARM64_DWARF" ] && [ -f "$ARMV7_DWARF" ]; then
-            lipo -create "$ARMV7_DWARF" "$ARM64_DWARF" -output "${ARM64_DWARF}.universal"
-            mv "${ARM64_DWARF}.universal" "$ARM64_DWARF"
-            echo "dSYM UUIDs:"
-            dwarfdump --uuid "$DSYM"
-          fi
+          rm -rf "$DSYM"
+          "$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/bin/dsymutil" \
+              "$APP/HA Dashboard" -o "$DSYM"
+          echo "dSYM UUIDs:"
+          dwarfdump --uuid "$DSYM"
 
           echo "=== Re-sign ==="
           IDENTITY=$(security find-identity -v -p codesigning 2>/dev/null | grep "Apple" | head -1 | sed 's/.*"\(.*\)"/\1/')
-          codesign --force --sign "$IDENTITY" --timestamp=none "$APP"
+          codesign --force --sign "$IDENTITY" --entitlements "$ENTITLEMENTS" --timestamp=none "$APP"
 
           echo "=== Verify ==="
-          echo "Binary:    $(lipo -archs "$APP/HA Dashboard")"
-          echo "MinOS:     $(plutil -extract MinimumOSVersion raw "$PLIST")"
+          ARCHS=$(lipo -archs "$APP/HA Dashboard")
+          test "$ARCHS" = "armv7 arm64"
+          test "$(plutil -extract MinimumOSVersion raw "$PLIST")" = "9.0"
+          for ARCH in armv7 arm64; do
+            MINIMUM=$(otool -l -arch "$ARCH" "$APP/HA Dashboard" | awk '
+              $1 == "cmd" && $2 == "LC_VERSION_MIN_IPHONEOS" { wanted = 1; next }
+              wanted && $1 == "version" { print $2; wanted = 0 }
+            ')
+            test "$MINIMUM" = "9.0"
+          done
+          BINARY_UUIDS=$(dwarfdump --uuid "$APP/HA Dashboard" | awk '{print $2, $3}' | sort)
+          DSYM_UUIDS=$(dwarfdump --uuid "$DSYM" | awk '{print $2, $3}' | sort)
+          test "$BINARY_UUIDS" = "$DSYM_UUIDS"
+          echo "Binary:    $ARCHS"
+          echo "MinOS:     9.0 (armv7, arm64, bundle)"
           echo "Bundle ID: $(plutil -extract CFBundleIdentifier raw "$PLIST")"
+          test -f "$APP/PrivacyInfo.xcprivacy"
+          plutil -lint "$APP/PrivacyInfo.xcprivacy"
+          codesign --verify --deep --strict --verbose=2 "$APP"
 
-      # ── Step 4: Export for App Store ─────────────────────────────────
-      - name: Export App Store IPA (uploads to TestFlight)
-        env:
-          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
-        run: |
-          xcodebuild -exportArchive \
-            -archivePath build/HADashboard.xcarchive \
-            -exportPath build/appstore \
-            -exportOptionsPlist ExportOptions-AppStore.plist \
-            -authenticationKeyPath "$RUNNER_TEMP/private_keys/AuthKey.p8" \
-            -authenticationKeyID "$ASC_KEY_ID" \
-            -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
-            -allowProvisioningUpdates
-
-      # ── Step 5: Export Ad Hoc IPA ────────────────────────────────────
+      # ── Step 4: Export and verify Ad Hoc IPA before any upload ───────
       - name: Export Ad Hoc IPA
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
@@ -416,6 +487,45 @@ jobs:
             mv "$ADHOC_IPA" "build/HADashboard-${VERSION}-universal-armv7-arm64.ipa"
           fi
 
+      - name: Verify exported Ad Hoc IPA
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          IPA="build/HADashboard-${VERSION}-universal-armv7-arm64.ipa"
+          VERIFY_DIR="$RUNNER_TEMP/verify-adhoc"
+          mkdir -p "$VERIFY_DIR"
+          ditto -x -k "$IPA" "$VERIFY_DIR"
+          APP=$(find "$VERIFY_DIR/Payload" -maxdepth 1 -name '*.app' -type d | head -1)
+          test -d "$APP"
+          BINARY="$APP/HA Dashboard"
+          test "$(lipo -archs "$BINARY")" = "armv7 arm64"
+          test "$(plutil -extract MinimumOSVersion raw "$APP/Info.plist")" = "9.0"
+          test "$(plutil -extract CFBundleIdentifier raw "$APP/Info.plist")" = "com.hadashboard.app"
+          test -f "$APP/PrivacyInfo.xcprivacy"
+          plutil -lint "$APP/PrivacyInfo.xcprivacy"
+          for ARCH in armv7 arm64; do
+            MINIMUM=$(otool -l -arch "$ARCH" "$BINARY" | awk '
+              $1 == "cmd" && $2 == "LC_VERSION_MIN_IPHONEOS" { wanted = 1; next }
+              wanted && $1 == "version" { print $2; wanted = 0 }
+            ')
+            test "$MINIMUM" = "9.0"
+          done
+          codesign --verify --deep --strict --verbose=2 "$APP"
+
+      # ── Step 5: Upload the verified archive to TestFlight ────────────
+      - name: Export App Store IPA (uploads to TestFlight)
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath build/HADashboard.xcarchive \
+            -exportPath build/appstore \
+            -exportOptionsPlist ExportOptions-AppStore.plist \
+            -authenticationKeyPath "$RUNNER_TEMP/private_keys/AuthKey.p8" \
+            -authenticationKeyID "$ASC_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
+            -allowProvisioningUpdates
+
       - name: Upload IPA artifact
         uses: actions/upload-artifact@v4
         with:
@@ -429,7 +539,8 @@ jobs:
         with:
           files: |
             build/HADashboard-*-universal-armv7-arm64.ipa
-          generate_release_notes: true
+          body_path: docs/releases/${{ github.ref_name }}-github.md
+          generate_release_notes: false
           draft: false
 
       # ── Cleanup ─────────────────────────────────────────────────────

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,10 @@ docs/*
 !docs/privacy.html
 !docs/support.html
 !docs/rosettasim-deployment.md
+!docs/live-camera-streaming-v1.md
+!docs/releases/
+docs/releases/*
+!docs/releases/*.md
 !docs/screenshots
 docs/screenshots/*
 !docs/screenshots/*.png

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # HA Dashboard
 
-Native iOS Home Assistant dashboard app. Renders HA Lovelace dashboards natively across iOS 9.3.5 (iPad 2, armv7) through iOS 18+ (iPhone 16 Pro Max, arm64), providing a kiosk-friendly wall-mounted display experience on old iPads while also working as a mobile dashboard on modern devices.
+Native Home Assistant dashboard app. The scripted universal product carries armv7 and arm64 slices with an iOS 9.0 minimum, covering iOS 9.3.3 legacy devices through iOS 27, plus a Mac Catalyst developer build. Local Camera Stream is separately gated to iOS 10.3.3+.
 
 ## Published Links
 
@@ -19,20 +19,21 @@ Native iOS Home Assistant dashboard app. Renders HA Lovelace dashboards natively
 
 ## Build Setup
 
-Two Xcode versions are required:
+The modern toolchain plus legacy iPhoneOS link stubs are required for the full universal product:
 
 | Xcode | Path | Purpose |
 |-------|------|---------|
-| **13.2.1** | `/Applications/Xcode-13.2.1.app` | Provides armv7 SDK stubs for linking the universal device build (iPad 2). |
-| **26** | `/Applications/Xcode.app` | Builds all targets: arm64 sim, x86_64 legacy sim (RosettaSim), and device. |
+| **13.2.1 SDK** | Full Xcode app or `XCODE13_SDK_PATH` | Link stubs for both iOS 9 armv7 and arm64 device slices. |
+| **26 or 27** | `/Applications/Xcode.app`, beta fallback, or `XCODE_PATH` | Modern compiler, current simulator, signed bundle template, physical-device tooling, and Catalyst. |
 
 ### Build Targets
 
 | Target | Command | Arch | iOS Min | SDK | Notes |
 |--------|---------|------|---------|-----|-------|
 | Simulator | `scripts/build.sh sim` | arm64 | 15.0 | Xcode 26 | Native arm64 sim for iOS 16+ |
-| RosettaSim | `scripts/build.sh rosettasim` | x86_64 | 9.0 | Xcode 26 | Legacy sim for iOS 9–14 via RosettaSim. Uses `MERGED_BINARY_TYPE=none` to disable mergeable libraries — the default Debug stub+dylib pattern crashes on legacy runtimes' libdispatch. |
-| Device | `scripts/build.sh device` | armv7+arm64 | 9.0 | Xcode 26 clang + Xcode 13 link stubs | Universal binary. armv7 compiled with Xcode 26 clang, linked against Xcode 13 SDK. arm64 via xcodebuild. |
+| RosettaSim | `scripts/build.sh rosettasim` | x86_64 | 9.0 | macOS 26 + Xcode 26 only | Legacy sim for iOS 9–14. Xcode/macOS 27 fail closed because they cannot build/boot the x86-only runtimes. |
+| Device | `scripts/build.sh device` | armv7+arm64 | 9.0 in both slices | Xcode 26/27 clang + Xcode 13 link stubs | Both executables compile/link directly; armv7 is forced to ARM mode to avoid Xcode 27 Thumb-relocation loss, while xcodebuild supplies only the signed bundle/resources before replacement and re-signing. |
+| Mac Catalyst | `scripts/build.sh mac` | arm64 | iOS 15 Catalyst mapping | Xcode 26/27 | Sandboxed developer build with camera, microphone, client, server, and app-private Keychain access-group entitlements. |
 
 - **XcodeGen** generates `HADashboard.xcodeproj` from `project.yml` — run `scripts/regen.sh` after changing project.yml
 - `regen.sh` sources `.env` to inject your Team ID and Bundle ID into the project before generation
@@ -62,12 +63,13 @@ Key variables:
 |--------|------|-----|---------------|
 | iPad 2 | armv7 | 9.3.5 | WiFi SSH (jailbroken) or Unraid USB |
 | iPad 3 | armv7 | 9.3.5 | WiFi SSH (jailbroken) |
-| iPad Mini 4 | arm64 | 15.x | WiFi via ios-deploy + pymobiledevice3 |
-| iPad Mini 5 | arm64 | 26.x | WiFi via devicectl |
-| iPhone 16 Pro Max | arm64 | 18.x | WiFi via devicectl |
+| iPad 4 | armv7 | 10.3.x | Wi-Fi SSH (jailbroken) or validated Unraid USB |
+| iPad Mini 4 | arm64 | 15.x | MobileDevice Wi-Fi via `ideviceinstaller` |
+| iPad Mini 5 | arm64 | 26.x | CoreDevice, with validated MobileDevice Wi-Fi fallback |
+| iPhone 16 | arm64 | 26.x | CoreDevice/devicectl |
 | iPad Simulator | arm64 | 16.4+ | `xcrun simctl install/launch` |
 | iPhone Simulator | arm64 | 16.4+ | `xcrun simctl install/launch` |
-| Legacy Simulator | x86_64 | 9.3–14.x | `rosettasim-ctl install/launch` (via RosettaSim) |
+| Legacy Simulator | x86_64 | 9.3–14.x | `rosettasim-ctl` on macOS 26 + Xcode 26 only |
 
 ## Versioning & Release
 
@@ -80,28 +82,19 @@ Version is derived from **git tags** — no files to edit for a version bump.
 
 ### Release Workflow
 
-To cut a release:
+Release only from a clean, current `main` after the exact candidate has passed
+the acceptance checklist. Curated notes are required because the historical
+`v1.2.5` tag predates source already shipped as App Store build 158.
 
 ```bash
-# 1. Tag HEAD (annotated tag)
-git tag -a v1.2.1 -m "v1.2.1: summary of changes"
-git push origin main --tags
-
-# 2. Create GitHub release with notes
-gh release create v1.2.1 --title "v1.2.1" --latest --notes "..."
+cp docs/releases/v1.2.6.md docs/releases/vX.Y.Z.md
+# Edit and verify the notes, merge to main, then:
+scripts/release.sh X.Y.Z
 ```
 
-To **retag** (move an existing tag to current HEAD):
-
-```bash
-git tag -d v1.2.1                    # Delete local tag
-git push origin :refs/tags/v1.2.1    # Delete remote tag
-git tag -a v1.2.1 -m "..."           # Recreate at HEAD
-git push origin v1.2.1               # Push new tag
-# Then delete old GitHub release and create a new one
-gh release delete v1.2.1 --yes
-gh release create v1.2.1 --title "v1.2.1" --latest --notes "..."
-```
+`release.sh` refuses detached HEAD, a dirty tree, a non-main branch, an
+out-of-date `origin/main`, a missing notes file, or an existing tag. It creates
+and pushes an annotated tag. Never move a published release tag.
 
 ### CI Pipeline (`.github/workflows/build.yml`)
 
@@ -110,17 +103,18 @@ Triggered on pushes to `main` and `v*` tags:
 | Job | Trigger | What it does |
 |-----|---------|-------------|
 | `build-and-test` | All pushes | Builds simulator target, verifies compilation |
-| `seed-sdk-cache` | Main push only | Extracts Xcode 13 armv7 SDK stubs from cached .xip (one-time) |
-| `archive-release` | Tag push only | Full release: armv7 clang compile → arm64 archive → lipo merge → sign → **export App Store IPA (uploads to TestFlight)** → export Ad Hoc IPA → upload to GitHub Release |
+| `verify-ios9-slices` | Every CI run | Downloads/checks the immutable Xcode 13 SDK stubs, then compiles and verifies unsigned armv7+arm64 iOS 9 slices. |
+| `archive-release` | Tag push only | Direct armv7+arm64 iOS 9 compile/link → signed bundle template → universal replacement/dSYM → export App Store/TestFlight + Ad Hoc IPA → GitHub Release. |
 
 The `archive-release` job handles **everything** for App Store submission:
-- Builds universal armv7+arm64 binary
+- Builds a universal armv7+arm64 binary whose two Mach-O slices both target iOS 9.0
 - Signs with dev certificate + provisioning profile (from GitHub secrets)
 - Exports App Store IPA via `xcodebuild -exportArchive` with ASC API key auth
 - **Automatically uploads to TestFlight** (the App Store export triggers upload)
 - Exports Ad Hoc IPA and attaches to GitHub Release
 
-**After CI completes**, go to [App Store Connect](https://appstoreconnect.apple.com) → TestFlight to:
+The tag workflow creates the GitHub release automatically using the matching
+`docs/releases/vX.Y.Z.md` file. After CI completes, go to [App Store Connect](https://appstoreconnect.apple.com) → TestFlight to:
 1. Add release notes for the TestFlight build
 2. Submit for external testing or App Review
 
@@ -146,19 +140,22 @@ Local builds use `ASC_KEY_PATH` to point to the `.p8` file on disk. CI decodes `
 scripts/deploy.sh sim              # iPad simulator (arm64, iOS 16+)
 scripts/deploy.sh sim iphone       # iPhone simulator (arm64, iOS 16+)
 scripts/deploy.sh iphone           # Physical iPhone via devicectl
-scripts/deploy.sh mini5            # iPad Mini 5 via devicectl (WiFi)
-scripts/deploy.sh mini4            # iPad Mini 4 via ios-deploy (WiFi)
+scripts/deploy.sh mini5            # iPad Mini 5 via CoreDevice/MobileDevice Wi-Fi
+scripts/deploy.sh mini4            # iPad Mini 4 via ideviceinstaller (Wi-Fi)
 scripts/deploy.sh ipad2            # iPad 2 via WiFi SSH (jailbroken)
 scripts/deploy.sh ipad3            # iPad 3 via WiFi SSH (jailbroken)
+scripts/deploy.sh ipad4            # iPad 4 via WiFi SSH (jailbroken)
+scripts/deploy.sh ipad4-usb        # iPad 4 via validated Unraid USB
+scripts/deploy.sh mac              # Mac Catalyst
 scripts/deploy.sh all              # Deploy to all targets
 scripts/deploy.sh all --kiosk      # Deploy to all targets in kiosk mode
 ```
 
-Options: `--no-build`, `--dashboard X`, `--default`, `--server URL`, `--kiosk`, `--no-kiosk`
+Options: `--no-build`, `--dashboard X`, `--default`, `--server URL`, `--token`, `--kiosk`, `--no-kiosk`, `--reset`, `--demo`
 
 ### RosettaSim (Legacy Simulators — iOS 9.3–14.x)
 
-Legacy iOS simulators run x86_64 under RosettaSim. Standard `xcrun simctl install/launch` **hangs** on these runtimes — use `rosettasim-ctl` instead.
+Legacy iOS simulators run x86_64 under RosettaSim on **macOS 26 with Xcode 26**. Standard `xcrun simctl install/launch` hangs on these runtimes, so use `rosettasim-ctl`. Xcode 27 rejects the legacy deployment target and macOS 27 cannot construct an x86 launch host; `build.sh rosettasim` therefore fails closed there. This does not affect the physical iOS 9 universal device build.
 
 **Binary**: `/Users/ashhopkins/Projects/rosetta/src/build/rosettasim-ctl`
 
@@ -208,7 +205,7 @@ For native runtimes (iOS 16+), all commands transparently pass through to `xcrun
 
 **Rebuild rosettasim-ctl**: `cd ~/Projects/rosetta/src && make ctl`
 
-**Known legacy simulator UDIDs:**
+**Example saved simulator UDIDs (verify locally; simulator recreation changes them):**
 
 | Device | iOS | UDID |
 |--------|-----|------|
@@ -220,7 +217,7 @@ For native runtimes (iOS 16+), all commands transparently pass through to `xcrun
 ## Architecture
 
 ### Language & Frameworks
-- Pure **Objective-C**, no Swift, no storyboards, no XIBs
+- Pure **Objective-C**, no Swift and no application UI storyboards/XIBs; `LaunchScreen.storyboard` is the sole storyboard
 - All UI built programmatically with `NSLayoutConstraint` anchors (iOS 9+)
 - **SocketRocket** (`Vendor/SRWebSocket`) for WebSocket
 - **NSURLSession** for REST API calls
@@ -236,6 +233,10 @@ For native runtimes (iOS 16+), all commands transparently pass through to `xcrun
 | `HAWebSocketClient` | SocketRocket wrapper. Auth, state subscriptions, service calls, Lovelace fetch. |
 | `HAAPIClient` | REST client with Bearer auth. Auto-retries 401 with refresh in OAuth mode. |
 | `HADiscoveryService` | Bonjour/mDNS browser for `_home-assistant._tcp`. |
+| `HAStreamingManager` | Opt-in foreground RTSP listeners plus authenticated-media-client-gated H.264/AAC capture and encoding. |
+| `HARTSPCredentialManager` | Generates and rotates the per-device RTSP password stored in the device-only Keychain; username is fixed as `hadashboard`. |
+| `HARTSPServer` | Digest-authenticated RTSP/RTP-over-TCP server bound to one selected local address; media remains plaintext. |
+| `HACameraRegistrationManager` | Asynchronous, admin-authenticated Generic Camera reconciliation for app-owned entry IDs, with RTSP Digest credentials, 75/120-second camera-only timeouts, and context-bound retry delays capped at 60 seconds. |
 | `HALovelaceParser` | Converts HA Lovelace JSON into `HADashboardConfig` (sections + items). |
 | `HAEntityDisplayHelper` | Centralized entity display: name, state, icon glyph, icon color, toggle detection. |
 | `HAEntityCellFactory` | Maps entity domains + card types to cell reuse identifiers. |
@@ -269,9 +270,9 @@ For native runtimes (iOS 16+), all commands transparently pass through to `xcrun
 
 ## Testing
 
-### Snapshot Regression Tests (96 tests)
+### Snapshot Regression Tests
 
-Pixel-perfect visual regression tests covering all 32 cell types in multiple states across gradient + light themes.
+Pixel-perfect visual regression coverage across card types and multiple states in gradient and light themes. Avoid hard-coded suite counts here; query the current test bundle and reference directory when reporting coverage.
 
 ```bash
 scripts/test-snapshots.sh
@@ -331,8 +332,10 @@ Replace `IPAD3` with `IPAD2` or `IPAD4` for other devices. Credentials are in `.
 HADashboard/
 ├── Auth/           # HAAuthManager, HAKeychainHelper, HAOAuthClient
 ├── Controllers/    # HADashboardViewController, HASettingsViewController
+├── Integration/    # Home Assistant sensors and remote commands
 ├── Models/         # HADashboardConfig, HAEntity, HALovelaceParser
 ├── Networking/     # HAAPIClient, HAConnectionManager, HAWebSocketClient, HADiscoveryService
+├── Streaming/      # Digest-protected RTSP, device credential, capture, and H.264/AAC encoders
 ├── Theme/          # HATheme, HAIconMapper, HAHaptics
 ├── Views/
 │   ├── Cells/      # 25+ entity cells (HABaseEntityCell subclasses) + composite cards
@@ -340,6 +343,7 @@ HADashboard/
 │   ├── HAEntityRowView, HAGraphView, HASectionHeaderView
 │   └── HAThermostatGaugeView
 ├── Info.plist
+├── PrivacyInfo.xcprivacy
 └── main.m
 Vendor/             # SocketRocket (SRWebSocket), MDI icon font, iOSSnapshotTestCase
 HADashboardTests/   # 96 snapshot regression tests + reference images
@@ -348,10 +352,22 @@ screenshots/        # HA web + app screenshot captures (git-ignored)
 project.yml         # XcodeGen project definition (placeholders — .env fills real values)
 .env.example        # Template for required environment variables
 PRIVACY.md          # Privacy policy
+docs/releases/      # Curated GitHub, App Store, TestFlight, and release-gate notes
 ```
 
 ## Known Issues
 
 - Constraint warning on iPad 2 settings screen (UISegmentedControl vertical position) — cosmetic only
 - Developer disk image must be remounted after iPad 2 reboot (deploy script handles this automatically)
-- iPad Mini 4 deploy requires ios-deploy + pymobiledevice3 installed via Homebrew/pip
+- Mini 4/Mini 5 MobileDevice fallback requires `libimobiledevice` and `ideviceinstaller`; automatic launch additionally needs a matching Developer Disk Image
+- The 32-bit iOS 10.3.3 h3lix jailbreak needs a compatible Dropbear service; OpenSSH can accept port 22 but hang before sending its banner
+- RosettaSim iOS 9–14 validation requires macOS 26 + Xcode 26 and is unavailable on macOS/Xcode 27
+- Local Camera Stream requires per-device RTSP Digest credentials, but media remains plaintext and unencrypted; use only on a trusted LAN, never forward 8554/8555, and prefer a DHCP reservation
+- Leaving Both camera mode does not delete the saved rear Generic Camera entry from Home Assistant
+
+## Privacy and Release Metadata
+
+- `HADashboard/PrivacyInfo.xcprivacy` declares app-only defaults, elapsed-time logging, and local user-approved storage display required-reason APIs.
+- Keep `HADashboard/Info.plist` and `project.yml` camera, microphone, and local-network purpose strings identical.
+- Public privacy wording lives in `PRIVACY.md` and `docs/privacy.html`; camera support guidance is in `docs/support.html` and `docs/live-camera-streaming-v1.md`.
+- `docs/releases/vX.Y.Z.md` is the internal App Store/TestFlight/acceptance dossier; `vX.Y.Z-github.md` is the bounded public GitHub release body.

--- a/HADashboard.xcodeproj/project.pbxproj
+++ b/HADashboard.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		095EBF448090516D25E704CF /* testCounterSc__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 781894A58BE0E95BCF5E4B75 /* testCounterSc__dark_gradient@2x.png */; };
 		098AF2B1120A48F2618F2D6E /* testUnavailableLight__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 19CCB667C400122E1BEBB6FF /* testUnavailableLight__dark_gradient@2x.png */; };
 		09D8C7808AC508BBE02555A0 /* testGraphSingle__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 552D266316B4B0FBE8E39BF6 /* testGraphSingle__light@2x.png */; };
+		0A03A4280BF4E3CB85A7B808 /* HAStreamingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 395E6D29E1144404119445B5 /* HAStreamingTests.m */; };
 		0A4C81F2E37EB6639DFA0EEF /* testEntitiesCard5Rows__gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D1226B8BE48CEBB4B01DFEA6 /* testEntitiesCard5Rows__gradient@2x.png */; };
 		0A545760E10B96EDA3871C0A /* HAEntity+Humidifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CE1309D6715AA7185FF825E /* HAEntity+Humidifier.m */; };
 		0ABD799AC8AFA8C64D8F29E4 /* HACacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A4ADBBFFA9D4D28AD62F59F /* HACacheTests.m */; };
@@ -179,9 +180,11 @@
 		203F4BB0D7EFDB85043BDEA0 /* testVacuumTile_commands__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 42638F033E642723A2EFEBE8 /* testVacuumTile_commands__light@2x.png */; };
 		2096FED6D5D54E5653A1055B /* HASunBasedThemeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 78B20879C1CE0CB4DC78D874 /* HASunBasedThemeTests.m */; };
 		20A81DE8D9AA7147B2A94861 /* LOTShapePath.m in Sources */ = {isa = PBXBuildFile; fileRef = 716E325D4BEB6C64357244B6 /* LOTShapePath.m */; };
+		20A8CF2053A27427F694844C /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78E45E8D320DD66648A8BFC0 /* CoreMedia.framework */; };
 		20BF60FFFE96AF0029F92E53 /* testSensorScIlluminance__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F4B0A507784B58EA8ECC3300 /* testSensorScIlluminance__dark_gradient@2x.png */; };
 		20CBC99BB1017A7BCBD93E7E /* LOTLayerContainer.h in Sources */ = {isa = PBXBuildFile; fileRef = 4D3F0E89E0336F9D57BFEAD6 /* LOTLayerContainer.h */; };
 		20F655C89EBC7C444D875489 /* testBinarySensorScPlug__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = CE4633EEFF1D308879E2D4C6 /* testBinarySensorScPlug__light@2x.png */; };
+		20F75B4E5D3986B7E465CB9F /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0AD82FDF0E4C16C983C3440E /* VideoToolbox.framework */; };
 		210F271C8FDEADFADD63023B /* testClimateCool__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = C5212B65EC0B01BC90E3423C /* testClimateCool__light@2x.png */; };
 		2132E14D064611645FBCCBF9 /* testButtonPressed__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 9FFF476A09F3B9B3B720417E /* testButtonPressed__dark_gradient@2x.png */; };
 		2146839F8148C64C7EA86C6E /* testSensorEnergy__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8646913B04315EE7C57CCF37 /* testSensorEnergy__light@2x.png */; };
@@ -277,6 +280,7 @@
 		32AA3ADAB463EB5457435ABB /* testHeadingNoIcon__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F2CC37281454F9612529EA52 /* testHeadingNoIcon__dark_gradient@2x.png */; };
 		32B23D480688113330CC558A /* LOTShapeGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = D61E75BE77416517D352F761 /* LOTShapeGroup.m */; };
 		333584F44414AB03372A649F /* UIColor+Expanded.m in Sources */ = {isa = PBXBuildFile; fileRef = 60096532829E8887FBBD4146 /* UIColor+Expanded.m */; };
+		3372F0186F2BAAF3BEC13CF6 /* HAURLSessionRedirectGuard.m in Sources */ = {isa = PBXBuildFile; fileRef = 86A85250D349B93E74648930 /* HAURLSessionRedirectGuard.m */; };
 		338196E570780D7A9BEFD128 /* LOTShapeCircle.h in Sources */ = {isa = PBXBuildFile; fileRef = E3B5D118C52BD3EBD9D7668E /* LOTShapeCircle.h */; };
 		34227DDA8F1B6F241A036C23 /* testClimateTile_presetModes__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = B1714E7F1696D1A481954A17 /* testClimateTile_presetModes__dark_gradient@2x.png */; };
 		344232B346A971F81A46EA56 /* testSwitchOff__gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = DEBF7E1F01F3451EC583547D /* testSwitchOff__gradient@2x.png */; };
@@ -304,6 +308,7 @@
 		39D64F86B941B5080B43C1B5 /* testDetailViewTimer_detailViewTimer_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 0BE48790F76DB46FC2667283 /* testDetailViewTimer_detailViewTimer_gradient@2x.png */; };
 		39DFB1DA83E5B9BEC51475EF /* testPersonHome_personHome_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 33BD521E13C47B1AEA755C4B /* testPersonHome_personHome_gradient@2x.png */; };
 		39F77690671E7BE5BCC5BC99 /* testAlarmScAway__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 4605B552B2A70061C44DC14E /* testAlarmScAway__light@2x.png */; };
+		3A0E289CBCCCC3A9C563AC70 /* HAAppSceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CFC6D599899DD15B4FC4430 /* HAAppSceneDelegate.m */; };
 		3A30B5DB31468F2130D6E180 /* HADiscoveredServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 407A8F062B0D329670BA8079 /* HADiscoveredServer.m */; };
 		3A5B784CC1B44C4CC3F49DB9 /* testMediaPlayerTile_showNameFalse__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 0133F67C77E9E0C77E6FF92C /* testMediaPlayerTile_showNameFalse__light@2x.png */; };
 		3ACAC8BBA1F875D42E67EBD5 /* testLockTile_iconOverride__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 77B02AE122037A153F5B71D5 /* testLockTile_iconOverride__dark_gradient@2x.png */; };
@@ -443,6 +448,7 @@
 		52DD304F4782C2C2CB0D5D51 /* testLightScAllModes__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F33262B35A9DC55AB46504C9 /* testLightScAllModes__light@2x.png */; };
 		5313E843E54AC0D61143E149 /* testInputNumberSlider__gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F4120E3CF4CA2EB723056F74 /* testInputNumberSlider__gradient@2x.png */; };
 		53242E873E26DAE7FEC3C498 /* testMediaPlayerScIdle__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = C3962398E30BF42016B77422 /* testMediaPlayerScIdle__dark_gradient@2x.png */; };
+		53B668B913D8E8BA5A65C748 /* HARTSPCredentialManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 622182878CD56801C140B5A4 /* HARTSPCredentialManager.m */; };
 		53C3F40D463FFF553AC9BB66 /* LOTRenderGroup.h in Sources */ = {isa = PBXBuildFile; fileRef = 0E017D5C2F18B52BA37CC9DD /* LOTRenderGroup.h */; };
 		53CAB53F20E1516B162CBC67 /* testMediaPlayerScOff__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 320406F33EEB1E97507A0BED /* testMediaPlayerScOff__dark_gradient@2x.png */; };
 		53CACCFB86BEBA366D4947DC /* testClimateTile_showNameFalse__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 99546DF24111BA06ED8D3B85 /* testClimateTile_showNameFalse__dark_gradient@2x.png */; };
@@ -795,6 +801,8 @@
 		9746E231F40E88A4C3D583EC /* testDetailViewMediaPlayer_detailViewMediaPlayer_dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = AECF6023D946C73E1A07AE82 /* testDetailViewMediaPlayer_detailViewMediaPlayer_dark_gradient@2x.png */; };
 		977BE89993E1FC7CF02265AF /* testSensorButton_showStateTrue__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 60A354DE6AD13E9152489111 /* testSensorButton_showStateTrue__light@2x.png */; };
 		978DD2C57D1B0B5ACDCD1FB5 /* HASensorSnapshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C432ACD4D867243A79F62F3D /* HASensorSnapshotTests.m */; };
+		97F5CDF85A43EAC765975DCD /* HAAACEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 53591114789889D6657F3060 /* HAAACEncoder.m */; };
+		9832382D33C4145E3F843D8C /* HAStreamingManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CCD20AE0FC5BAA13F701BA4F /* HAStreamingManager.m */; };
 		98744B2535A6B39519F86CF8 /* testScriptSc__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F25792AB3B1CD2BB50130DF3 /* testScriptSc__dark_gradient@2x.png */; };
 		98D03C1230A2C4C015DB5F30 /* HAColorWheelView.m in Sources */ = {isa = PBXBuildFile; fileRef = C75FF3B38F1E910FD66E73CD /* HAColorWheelView.m */; };
 		98E961419C5E61FF61A36834 /* UIImage+Diff.m in Sources */ = {isa = PBXBuildFile; fileRef = 7186A0CC8A263178C4D19883 /* UIImage+Diff.m */; };
@@ -843,6 +851,7 @@
 		A1418771ED2FE7DB664324CE /* testLockJammed_lockJammed_light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 2C9D8CD8B90918398C64B11C /* testLockJammed_lockJammed_light@2x.png */; };
 		A15893A59E6C12D7EBF13854 /* testButtonEntityTile_default__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 82176B202BD792E2150E88DB /* testButtonEntityTile_default__dark_gradient@2x.png */; };
 		A1B599F6956510965DBCD7FD /* HAGlanceCardTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B10613BD6A68BD6B118F6CEE /* HAGlanceCardTests.m */; };
+		A1C12B8E98D184C38BE573A4 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2B2653048FACE4BABE15EE2B /* PrivacyInfo.xcprivacy */; };
 		A1C49C7DDB5B90DD76E84C1D /* HADemoDataProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = F660D78813F980622507314B /* HADemoDataProvider.m */; };
 		A1E09F5C44AC0CB17DAE12DB /* testFanOnFull__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 86769F6BE55AAED58CFB4494 /* testFanOnFull__light@2x.png */; };
 		A1F788D9A65790D5FF04D310 /* testLawnMowerTile_default__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6F58C0D70220BEE7C81AC6AF /* testLawnMowerTile_default__light@2x.png */; };
@@ -894,6 +903,7 @@
 		AA47E7299C4AB64F4F76F7F1 /* testDefaultSectionUnknownDomain_defaultSection_dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 47FCE00CFB7D48DB8F868C03 /* testDefaultSectionUnknownDomain_defaultSection_dark_gradient@2x.png */; };
 		AA529AC52F9A774EC1125A48 /* HAThermostatGaugeCell.m in Sources */ = {isa = PBXBuildFile; fileRef = D9C41285654C5319851716E0 /* HAThermostatGaugeCell.m */; };
 		AA87BA236133213780AF1C15 /* testCoverButton_default__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D4DED12886082FFB28CCA5AA /* testCoverButton_default__light@2x.png */; };
+		AA882AEDC0D0DF831B8D70E9 /* HARTSPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 46FF72C3A285CDAD68438579 /* HARTSPServer.m */; };
 		AAA03063331A727638DC0778 /* HADashboardRaceConditionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 52E2153FB4F52AFA0E654A77 /* HADashboardRaceConditionTests.m */; };
 		AAAD9370AFC7F915618A5BCE /* testVacuumScReturning__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = C5992A8956A874A6C013CE4D /* testVacuumScReturning__dark_gradient@2x.png */; };
 		AB69FA11AF49B1E85CF67DCB /* testGauge50Percent__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 4C49EF2079BC625DB4591DB4 /* testGauge50Percent__light@2x.png */; };
@@ -929,6 +939,7 @@
 		AF69548291B2D7313422FBFE /* testBinarySensorScPlug__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = C8EEB43753B7C9D457451CEE /* testBinarySensorScPlug__dark_gradient@2x.png */; };
 		AF9139FC8BE5FDFE5B9995FB /* testLockJammed_lockJammed_dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D6374E7433994F9C46FC8B09 /* testLockJammed_lockJammed_dark_gradient@2x.png */; };
 		AFAB9EA86E4781A32E2D24FD /* HASettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AD88657773756D0FB73EABF /* HASettingsViewController.m */; };
+		B03BD5963B4D46494AFC7205 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 739E3AAFEE723F558E6E8BE0 /* AudioToolbox.framework */; };
 		B074C316D310DAF3079814AF /* testButtonPressed__gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 960CAE33D55B60457B5BA859 /* testButtonPressed__gradient@2x.png */; };
 		B0854A636571D237782CA29A /* testLockScLocked__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 13B3CC13A156009B60750032 /* testLockScLocked__light@2x.png */; };
 		B0A6D7563577CD4F6FC6FC97 /* testFanScReverse__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 17B0B3AB22CAC0466BC456D8 /* testFanScReverse__dark_gradient@2x.png */; };
@@ -985,6 +996,7 @@
 		BAA21C5492111A391FE27A66 /* testSideBySide_9plus3_Thermostat_Vacuum_9plus3_thermostat_vacuum_light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 382BF077E2DCABE92A508E63 /* testSideBySide_9plus3_Thermostat_Vacuum_9plus3_thermostat_vacuum_light@2x.png */; };
 		BAEB0AA9EFB7B070B09CA13B /* testClimateSectionOff_climateSectionOff_light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 28524009248187A49963F706 /* testClimateSectionOff_climateSectionOff_light@2x.png */; };
 		BB6D090C768CE598EFF8D231 /* hail.json in Resources */ = {isa = PBXBuildFile; fileRef = A144C78E8FF90795B9BBF80B /* hail.json */; };
+		BB77898BA8ADC0C19075BC21 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 192DEF3966D8287040B8820B /* CoreVideo.framework */; };
 		BB9F11849E3E5EDE95CB9824 /* testModeHvacIcons_modeHvacIcons_dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 729E436805BAD458F423E201 /* testModeHvacIcons_modeHvacIcons_dark_gradient@2x.png */; };
 		BBB86B24FB7AF6C047C2EBFA /* HACameraEntityCell.m in Sources */ = {isa = PBXBuildFile; fileRef = B5537DFCAB4A2DC1E69870E3 /* HACameraEntityCell.m */; };
 		BBD1DB70D3E71A29358F5384 /* testLightScMaxBright__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 2FE5E5D008C1F9D9B7815D14 /* testLightScMaxBright__light@2x.png */; };
@@ -1007,10 +1019,12 @@
 		BE557DEE531FD11926159FAA /* LOTKeypath.m in Sources */ = {isa = PBXBuildFile; fileRef = 18FA4895E095464791FB69E4 /* LOTKeypath.m */; };
 		BE6E8571BDF2A1DB3F18ED69 /* testGaugeNarrowTextScaling__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = C14ECD35A40E91B24C5D0FDA /* testGaugeNarrowTextScaling__dark_gradient@2x.png */; };
 		BF0F069C4B20B26DC418C325 /* LOTAnimatedControl.h in Sources */ = {isa = PBXBuildFile; fileRef = 75AABE76DB6949A4C0C187D1 /* LOTAnimatedControl.h */; };
+		BF6309C368BAC8DDB71F43E7 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33568683800A7076EFF2235B /* AVFoundation.framework */; };
 		BFC93FB56E4ABE11442980A0 /* testCoverSectionClosed_coverSectionClosed_light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = A29D81C5B8FE103951E4F59F /* testCoverSectionClosed_coverSectionClosed_light@2x.png */; };
 		C026954F229FC3104D8109EB /* testWeatherRainy__gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F044090C4D69280B90D5B8D8 /* testWeatherRainy__gradient@2x.png */; };
 		C068AA61B791DF4B6E151BD2 /* testLawnMowerScDocked__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 7D22879B19844A2173AD7A46 /* testLawnMowerScDocked__light@2x.png */; };
 		C079014762633478A740F30D /* testClimateTile_iconOverride__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = DCAFEAA923B4685075DB63EC /* testClimateTile_iconOverride__dark_gradient@2x.png */; };
+		C092F7F18948B1D893F54D1B /* HARTSPCredentialManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A6391A33D6AC3257EF4FEAD7 /* HARTSPCredentialManagerTests.m */; };
 		C0A9774D25688A4D25F1BC80 /* LOTMask.h in Sources */ = {isa = PBXBuildFile; fileRef = C80BF4AF9AE8F59905FC0513 /* LOTMask.h */; };
 		C0B4B91B5AC0ABACBCE3096F /* LOTRenderNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 735DD3DA28F8D096BBE9172E /* LOTRenderNode.m */; };
 		C0FE11DACD4511E4540D54B3 /* testSensorScMonetary__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D408C43209500B01FF5D74EE /* testSensorScMonetary__light@2x.png */; };
@@ -1320,6 +1334,7 @@
 		F7A888A5952D06E6A2DF525B /* testClimateTile_hvacModes__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E2AABED5345E64FCE3E6CD5E /* testClimateTile_hvacModes__dark_gradient@2x.png */; };
 		F828BE534F8016DE6E975801 /* testVacuumSectionDocked_vacuumSectionDocked_dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 2B3E97450683143C6BCAE6FA /* testVacuumSectionDocked_vacuumSectionDocked_dark_gradient@2x.png */; };
 		F8A3E1EE39BD809E079669BB /* HASensorEntityCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B8B99431EB6E311A5275015 /* HASensorEntityCell.m */; };
+		F941AFAA09A469A72FBA04F6 /* HACameraRegistrationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5753921C664BF976733932B2 /* HACameraRegistrationManager.m */; };
 		F95576675E17EDFE7F53F28C /* testTimerScPaused__light@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = A0F1DBA74E58B2DB3F8CDADF /* testTimerScPaused__light@2x.png */; };
 		F9CE95057FDA73A77B662F5F /* testVacuumScCleaning__dark_gradient@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D79C2BF2E4CCAD70EB098092 /* testVacuumScCleaning__dark_gradient@2x.png */; };
 		FA0C237F75B417A3E37BBBC1 /* HATileFeatureSnapshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89C3AEC2DEBB17550A98AECB /* HATileFeatureSnapshotTests.m */; };
@@ -1419,6 +1434,7 @@
 		0A2B1B8B531681F9B9BE5DD1 /* testMinimalLight__gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testMinimalLight__gradient@2x.png"; sourceTree = "<group>"; };
 		0A3B80A3F5358F12FBE37CAD /* testTileLight__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testTileLight__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		0A496416F16A6F8B4787A3C2 /* HALayoutSnapshotTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HALayoutSnapshotTests.m; sourceTree = "<group>"; };
+		0AD82FDF0E4C16C983C3440E /* VideoToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VideoToolbox.framework; path = System/Library/Frameworks/VideoToolbox.framework; sourceTree = SDKROOT; };
 		0AD8792C80A4C1DE556BBD67 /* testLightGlance_showNameFalse__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testLightGlance_showNameFalse__light@2x.png"; sourceTree = "<group>"; };
 		0B3D1167314B6091EC4C0907 /* HADashboardTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HADashboardTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0B3DE0F4B9518869D0895D79 /* testGraphSingleWithAxisLabels__gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testGraphSingleWithAxisLabels__gradient@2x.png"; sourceTree = "<group>"; };
@@ -1512,6 +1528,7 @@
 		1912900C0FEAEC9AD8ABC2B5 /* LOTMaskContainer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LOTMaskContainer.m; sourceTree = "<group>"; };
 		19164C15EA41D923054CA6A6 /* testClimateScSwing__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testClimateScSwing__light@2x.png"; sourceTree = "<group>"; };
 		191AFC01879312924CA918B3 /* testVacuumButton_default__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testVacuumButton_default__light@2x.png"; sourceTree = "<group>"; };
+		192DEF3966D8287040B8820B /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
 		193E89C81868749B34410B71 /* testFanSectionOnFull_fanSectionOnFull_dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testFanSectionOnFull_fanSectionOnFull_dark_gradient@2x.png"; sourceTree = "<group>"; };
 		19B8789033BBEBFD3C5C7CC5 /* testLockButton_default__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testLockButton_default__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		19CCB667C400122E1BEBB6FF /* testUnavailableLight__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testUnavailableLight__dark_gradient@2x.png"; sourceTree = "<group>"; };
@@ -1557,6 +1574,7 @@
 		22A4B18DACA244624CF8F1F5 /* testCounterLow__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testCounterLow__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		22C347AC57C4E616FE4D1E5F /* testDetailViewCover_detailViewCover_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testDetailViewCover_detailViewCover_gradient@2x.png"; sourceTree = "<group>"; };
 		233B95AC17779B1A64AADAAF /* HAEntityDetailViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HAEntityDetailViewController.h; sourceTree = "<group>"; };
+		23B7767D3D3A5FB692DB3197 /* HAStreamingManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HAStreamingManager.h; sourceTree = "<group>"; };
 		23B798AFE4CB29E8BFB35D9B /* testAlarmArmedAway_alarmArmedAway_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testAlarmArmedAway_alarmArmedAway_gradient@2x.png"; sourceTree = "<group>"; };
 		23FF44DA8FD126898C2D8ECA /* testInputTextScPassword__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testInputTextScPassword__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		244EFE8FBF54D4705C3CB130 /* testFanSectionOnHalf_fanSectionOnHalf_dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testFanSectionOnHalf_fanSectionOnHalf_dark_gradient@2x.png"; sourceTree = "<group>"; };
@@ -1570,6 +1588,7 @@
 		258F79C5609D3A6EB2835092 /* testSceneDefault_sceneDefault_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSceneDefault_sceneDefault_gradient@2x.png"; sourceTree = "<group>"; };
 		25A23BBB01EFF935B0E6A107 /* HATileFeatureTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HATileFeatureTests.m; sourceTree = "<group>"; };
 		2602194C06F6E6194C465DCC /* LOTRoundedRectAnimator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LOTRoundedRectAnimator.m; sourceTree = "<group>"; };
+		2614DAAA805D8414CDCE0210 /* HARTSPCredentialManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HARTSPCredentialManager.h; sourceTree = "<group>"; };
 		2614F9A296644EA0F0AF16D4 /* testCounterTile_showStateFalse__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testCounterTile_showStateFalse__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		265653D943AF6CB5A11C5F78 /* testInputSelectFiveOptions__gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testInputSelectFiveOptions__gradient@2x.png"; sourceTree = "<group>"; };
 		26814E1E406DAF04BA78C899 /* testMediaPlayerTile_volume__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testMediaPlayerTile_volume__dark_gradient@2x.png"; sourceTree = "<group>"; };
@@ -1601,6 +1620,7 @@
 		2AD77E742D7A927E33B079EC /* testValveScClosed__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testValveScClosed__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		2AD88657773756D0FB73EABF /* HASettingsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HASettingsViewController.m; sourceTree = "<group>"; };
 		2B0B4D40FD4366B1043E01AE /* testClimateScHeatCool__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testClimateScHeatCool__dark_gradient@2x.png"; sourceTree = "<group>"; };
+		2B2653048FACE4BABE15EE2B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		2B32F99678A8E119396D05AD /* testSensorTile_showNameFalse__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSensorTile_showNameFalse__light@2x.png"; sourceTree = "<group>"; };
 		2B3E97450683143C6BCAE6FA /* testVacuumSectionDocked_vacuumSectionDocked_dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testVacuumSectionDocked_vacuumSectionDocked_dark_gradient@2x.png"; sourceTree = "<group>"; };
 		2B92D735BA19E223E67CA825 /* testDetailViewLock_detailViewLock_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testDetailViewLock_detailViewLock_gradient@2x.png"; sourceTree = "<group>"; };
@@ -1636,9 +1656,12 @@
 		320406F33EEB1E97507A0BED /* testMediaPlayerScOff__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testMediaPlayerScOff__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		32477A7DDC4B53C476782967 /* testTileSwitch__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testTileSwitch__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		328789DB337D0797BCDCDD9D /* HABaseSnapshotTestCase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HABaseSnapshotTestCase.h; sourceTree = "<group>"; };
+		32ABC923A9651E8D1C78B90E /* HARTSPServer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HARTSPServer.h; sourceTree = "<group>"; };
 		32B507A2E1E41E7F19525055 /* HADisplayConfigSnapshotTests_Batch3.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HADisplayConfigSnapshotTests_Batch3.m; sourceTree = "<group>"; };
+		332FA399EDD007F85EF751EA /* HAAACEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HAAACEncoder.h; sourceTree = "<group>"; };
 		333F6F4FD297CE380E67BE95 /* testCoverTile_iconOverride__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testCoverTile_iconOverride__light@2x.png"; sourceTree = "<group>"; };
 		33496D5F822F319FB7AB297A /* HAWeatherEntityCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HAWeatherEntityCell.h; sourceTree = "<group>"; };
+		33568683800A7076EFF2235B /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		339C778C6D0EC21C44715FCE /* testInputDateTimeScDate__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testInputDateTimeScDate__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		33A3AE6EE74FF884AA4B075D /* HAAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HAAppDelegate.h; sourceTree = "<group>"; };
 		33B46ABA70DA1957D2CA6C94 /* HAColorWheelView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HAColorWheelView.h; sourceTree = "<group>"; };
@@ -1670,6 +1693,7 @@
 		3874F216CF8574854509B9F8 /* testGaugeNarrowTextScaling__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testGaugeNarrowTextScaling__light@2x.png"; sourceTree = "<group>"; };
 		388FF9D2AF9B7E8CF53EC105 /* HABadgeRowCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HABadgeRowCell.m; sourceTree = "<group>"; };
 		3917103E2349188F308EE7F2 /* testDetailViewDefault_detailViewDefault_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testDetailViewDefault_detailViewDefault_gradient@2x.png"; sourceTree = "<group>"; };
+		395E6D29E1144404119445B5 /* HAStreamingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HAStreamingTests.m; sourceTree = "<group>"; };
 		3972080E7FD170B7D51B6B28 /* testDeviceTrackerTile_showStateFalse__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testDeviceTrackerTile_showStateFalse__light@2x.png"; sourceTree = "<group>"; };
 		397B549E6DBFA47DCECC5CCE /* testLightGlance_default__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testLightGlance_default__light@2x.png"; sourceTree = "<group>"; };
 		398362558D5BC7787F14736C /* cloudy.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = cloudy.json; sourceTree = "<group>"; };
@@ -1756,6 +1780,7 @@
 		461DB841C7599C21FFBEDFBD /* testSceneTile_default__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSceneTile_default__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		4698406BC89AE90C270FA70C /* testRemoteTile_default__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testRemoteTile_default__light@2x.png"; sourceTree = "<group>"; };
 		46ED8207B44116C0751D20BD /* LOTAnimatedControl.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LOTAnimatedControl.m; sourceTree = "<group>"; };
+		46FF72C3A285CDAD68438579 /* HARTSPServer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HARTSPServer.m; sourceTree = "<group>"; };
 		47032E131604D5DD1E33F441 /* testDefaultSectionUnknownDomain_defaultSection_light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testDefaultSectionUnknownDomain_defaultSection_light@2x.png"; sourceTree = "<group>"; };
 		4703B07623EEA65F960FBF03 /* testSideBySide_6plus6_TwoLights_6plus6_two_lights_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSideBySide_6plus6_TwoLights_6plus6_two_lights_gradient@2x.png"; sourceTree = "<group>"; };
 		4739DFF5A910091285FDD93B /* testPersonTile_showNameFalse__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testPersonTile_showNameFalse__light@2x.png"; sourceTree = "<group>"; };
@@ -1833,6 +1858,7 @@
 		52E2153FB4F52AFA0E654A77 /* HADashboardRaceConditionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HADashboardRaceConditionTests.m; sourceTree = "<group>"; };
 		5327015D129A6B72FD59F69C /* testTileSwitch__gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testTileSwitch__gradient@2x.png"; sourceTree = "<group>"; };
 		5346CFF487536F31530DA119 /* testLightTile_colorTemp__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testLightTile_colorTemp__dark_gradient@2x.png"; sourceTree = "<group>"; };
+		53591114789889D6657F3060 /* HAAACEncoder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HAAACEncoder.m; sourceTree = "<group>"; };
 		536DC1A09834B541D2766E26 /* testAutomationTile_iconOverride__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testAutomationTile_iconOverride__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		53AA8B3ECEAC1E8D118A8FCB /* testBadgeRow2Items__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testBadgeRow2Items__light@2x.png"; sourceTree = "<group>"; };
 		5497B6B63E5B7A7A73A666BD /* fog-night.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "fog-night.json"; sourceTree = "<group>"; };
@@ -1842,6 +1868,7 @@
 		552746C79FEF0EC3E6F37564 /* LOTShapePath.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LOTShapePath.h; sourceTree = "<group>"; };
 		552D266316B4B0FBE8E39BF6 /* testGraphSingle__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testGraphSingle__light@2x.png"; sourceTree = "<group>"; };
 		553C46FBBCA93B8EE0E1E87F /* testVacuumTile_default__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testVacuumTile_default__dark_gradient@2x.png"; sourceTree = "<group>"; };
+		5568DB6B77EA62BE4D65CD2F /* HAURLSessionRedirectGuard.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HAURLSessionRedirectGuard.h; sourceTree = "<group>"; };
 		55A663AB7C65725C76FF1C30 /* HAInputTextEntityCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HAInputTextEntityCell.m; sourceTree = "<group>"; };
 		55AF769DA3EB8112C914900E /* HAAPIClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HAAPIClient.h; sourceTree = "<group>"; };
 		55C81C548C0C6BA9B67D53F7 /* testUnavailableSwitch__gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testUnavailableSwitch__gradient@2x.png"; sourceTree = "<group>"; };
@@ -1858,6 +1885,7 @@
 		5720673574AD9675490F3610 /* testInputNumberScSlider__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testInputNumberScSlider__light@2x.png"; sourceTree = "<group>"; };
 		574DA19196093151397E9DF3 /* testSensorScMonetary__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSensorScMonetary__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		574E93F2C4AB3FFCE6C40E4A /* testLockTile_default__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testLockTile_default__light@2x.png"; sourceTree = "<group>"; };
+		5753921C664BF976733932B2 /* HACameraRegistrationManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HACameraRegistrationManager.m; sourceTree = "<group>"; };
 		5789D5538B129E1E66CB022A /* HAPanelLayout.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HAPanelLayout.m; sourceTree = "<group>"; };
 		5835F2575879530E7C40E91E /* testTimerTile_showNameFalse__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testTimerTile_showNameFalse__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		584CFB3FB088459D25966215 /* HAWebSocketClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HAWebSocketClient.m; sourceTree = "<group>"; };
@@ -1916,6 +1944,7 @@
 		6154D815E2C78BB32E1BA079 /* testSensorHumidity__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSensorHumidity__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		61C75F3F5218A92A67A6D0A8 /* testCoverOpenShutter_coverOpenShutter_light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testCoverOpenShutter_coverOpenShutter_light@2x.png"; sourceTree = "<group>"; };
 		62097223905B8A8D4511137C /* testSwitchButton_showStateTrue__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSwitchButton_showStateTrue__dark_gradient@2x.png"; sourceTree = "<group>"; };
+		622182878CD56801C140B5A4 /* HARTSPCredentialManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HARTSPCredentialManager.m; sourceTree = "<group>"; };
 		6224452D320DB7DA0618248C /* testVacuumTile_showStateFalse__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testVacuumTile_showStateFalse__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		62488D34D2B42217087DC5C2 /* testDetailViewSensor_detailViewSensor_dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testDetailViewSensor_detailViewSensor_dark_gradient@2x.png"; sourceTree = "<group>"; };
 		629BBEEAC8332E638ABF8DF5 /* testCoverScTilt__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testCoverScTilt__light@2x.png"; sourceTree = "<group>"; };
@@ -2024,6 +2053,7 @@
 		7341C58F46BCA6AC06D483C4 /* testVacuumSectionReturning_vacuumSectionReturning_light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testVacuumSectionReturning_vacuumSectionReturning_light@2x.png"; sourceTree = "<group>"; };
 		735DD3DA28F8D096BBE9172E /* LOTRenderNode.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LOTRenderNode.m; sourceTree = "<group>"; };
 		7376E6E3086B763C5C48BE5A /* HAConnectionManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HAConnectionManager.h; sourceTree = "<group>"; };
+		739E3AAFEE723F558E6E8BE0 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		739E98FECCD070466888C7CA /* testClimateScAll__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testClimateScAll__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		73A193D9B709DC1B8EE1B3DE /* testMediaPlayerGlance_default__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testMediaPlayerGlance_default__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		73B069A22C4D8128C1DB7094 /* HAAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HAAction.m; sourceTree = "<group>"; };
@@ -2058,6 +2088,7 @@
 		781894A58BE0E95BCF5E4B75 /* testCounterSc__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testCounterSc__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		78AA8580713328EB148E38CC /* testInputDateTimeScTime__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testInputDateTimeScTime__light@2x.png"; sourceTree = "<group>"; };
 		78B20879C1CE0CB4DC78D874 /* HASunBasedThemeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HASunBasedThemeTests.m; sourceTree = "<group>"; };
+		78E45E8D320DD66648A8BFC0 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		790C44CADFFF8AC00332767C /* LOTCircleAnimator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LOTCircleAnimator.h; sourceTree = "<group>"; };
 		792F52F0948594D04FCF8030 /* testScriptSc__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testScriptSc__light@2x.png"; sourceTree = "<group>"; };
 		7991C088C3CF9E6A59B5D09C /* testSideBySide_9plus3_Thermostat_Vacuum_9plus3_thermostat_vacuum_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSideBySide_9plus3_Thermostat_Vacuum_9plus3_thermostat_vacuum_gradient@2x.png"; sourceTree = "<group>"; };
@@ -2084,6 +2115,7 @@
 		7C9A00A46EDFFC52771A1FAD /* testInputBooleanTile_default__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testInputBooleanTile_default__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		7CC417D5771DE8C1B629889F /* testCoverTile_default__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testCoverTile_default__light@2x.png"; sourceTree = "<group>"; };
 		7CD5BB8143EAFFBF96EB3F1F /* wind.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = wind.json; sourceTree = "<group>"; };
+		7CFC6D599899DD15B4FC4430 /* HAAppSceneDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HAAppSceneDelegate.m; sourceTree = "<group>"; };
 		7D22879B19844A2173AD7A46 /* testLawnMowerScDocked__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testLawnMowerScDocked__light@2x.png"; sourceTree = "<group>"; };
 		7D3ECA7E341704C06E3D4C8F /* testToggleSectionOn_toggleSectionOn_dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testToggleSectionOn_toggleSectionOn_dark_gradient@2x.png"; sourceTree = "<group>"; };
 		7D5ECE6CAF53E100C3FB25B1 /* testWeatherCloudy__gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testWeatherCloudy__gradient@2x.png"; sourceTree = "<group>"; };
@@ -2140,6 +2172,7 @@
 		8646913B04315EE7C57CCF37 /* testSensorEnergy__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSensorEnergy__light@2x.png"; sourceTree = "<group>"; };
 		86769F6BE55AAED58CFB4494 /* testFanOnFull__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testFanOnFull__light@2x.png"; sourceTree = "<group>"; };
 		86821EF1EA2830D58D9D7495 /* HAHistoryManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HAHistoryManager.h; sourceTree = "<group>"; };
+		86A85250D349B93E74648930 /* HAURLSessionRedirectGuard.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HAURLSessionRedirectGuard.m; sourceTree = "<group>"; };
 		86A9163B7A7E6540610BBCC1 /* testAlarmScVacation__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testAlarmScVacation__light@2x.png"; sourceTree = "<group>"; };
 		86B02E27609090619C6890B6 /* HAEntityDisplayHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HAEntityDisplayHelper.h; sourceTree = "<group>"; };
 		86B850684166965F87FDF0AE /* LOTShapeTrimPath.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LOTShapeTrimPath.m; sourceTree = "<group>"; };
@@ -2237,6 +2270,7 @@
 		95047298B6D5C721140A8A96 /* testClimateSectionOff_climateSectionOff_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testClimateSectionOff_climateSectionOff_gradient@2x.png"; sourceTree = "<group>"; };
 		950B526B74E72C7A5B197EB1 /* testMinimalSection_2Entities_minimal_2entities_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testMinimalSection_2Entities_minimal_2entities_gradient@2x.png"; sourceTree = "<group>"; };
 		9553175D08E8AD3C34BE297F /* testSensorGlance_default__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSensorGlance_default__light@2x.png"; sourceTree = "<group>"; };
+		956A8AB5540190E9DE3A8F81 /* HAAppSceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HAAppSceneDelegate.h; sourceTree = "<group>"; };
 		9576360E7399A22107C98F6A /* testCoverTile_showStateFalse__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testCoverTile_showStateFalse__light@2x.png"; sourceTree = "<group>"; };
 		95C01A8F1882C61C4B55B467 /* HAEntity+Update.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "HAEntity+Update.m"; sourceTree = "<group>"; };
 		95C0F6E8BB240435A75E8AD1 /* testVacuumSectionReturning_vacuumSectionReturning_dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testVacuumSectionReturning_vacuumSectionReturning_dark_gradient@2x.png"; sourceTree = "<group>"; };
@@ -2278,6 +2312,7 @@
 		9B8B99431EB6E311A5275015 /* HASensorEntityCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HASensorEntityCell.m; sourceTree = "<group>"; };
 		9BB581EA0744F168650242C9 /* testMediaPlayerSectionPlaying_mediaPlayerSectionPlaying_light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testMediaPlayerSectionPlaying_mediaPlayerSectionPlaying_light@2x.png"; sourceTree = "<group>"; };
 		9BB60A23CAF412606C814506 /* testToggleSectionOn_toggleSectionOn_light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testToggleSectionOn_toggleSectionOn_light@2x.png"; sourceTree = "<group>"; };
+		9BDB9594E361B05EAB3D458C /* HADashboard-Catalyst.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "HADashboard-Catalyst.entitlements"; sourceTree = "<group>"; };
 		9C011E8CE2ED039570658616 /* testUnavailableClimate__gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testUnavailableClimate__gradient@2x.png"; sourceTree = "<group>"; };
 		9CD3CEE209D08615B35F52CB /* HAHistoryManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HAHistoryManager.m; sourceTree = "<group>"; };
 		9D10A1A9A3CDCE0F4EB3037F /* testHeadingNoIcon__gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testHeadingNoIcon__gradient@2x.png"; sourceTree = "<group>"; };
@@ -2332,6 +2367,7 @@
 		A557DB1393BD4876B131C987 /* testLightOff__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testLightOff__light@2x.png"; sourceTree = "<group>"; };
 		A5D57010AA276E7162648A88 /* testSceneTile_iconOverride__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSceneTile_iconOverride__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		A622B3FC65485F8EE3B7A34E /* testHumidifierScOff__light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testHumidifierScOff__light@2x.png"; sourceTree = "<group>"; };
+		A6391A33D6AC3257EF4FEAD7 /* HARTSPCredentialManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HARTSPCredentialManagerTests.m; sourceTree = "<group>"; };
 		A63C3ADEE0F64145A5E932B7 /* testSceneButton_default__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSceneButton_default__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		A65280B4D6B7C6A53BA79150 /* HANotificationPresenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HANotificationPresenter.h; sourceTree = "<group>"; };
 		A6A4DABE0D2DE5C81A577195 /* LOTTrimPathNode.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LOTTrimPathNode.m; sourceTree = "<group>"; };
@@ -2530,6 +2566,7 @@
 		CC1E56E9F5A336BB58D43680 /* testClimateSectionCool_climateSectionCool_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testClimateSectionCool_climateSectionCool_gradient@2x.png"; sourceTree = "<group>"; };
 		CC5FEA2AA1A8C32A1249A2D0 /* HAEntityStateCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HAEntityStateCache.h; sourceTree = "<group>"; };
 		CC7048E617278DB393BEE895 /* HAActionDispatcherTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HAActionDispatcherTests.m; sourceTree = "<group>"; };
+		CCD20AE0FC5BAA13F701BA4F /* HAStreamingManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HAStreamingManager.m; sourceTree = "<group>"; };
 		CCD4EA84802932229A2C404C /* testTimerActive__gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testTimerActive__gradient@2x.png"; sourceTree = "<group>"; };
 		CCE97E2C76ABB84E19B50374 /* testDetailViewDefault_detailViewDefault_light@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testDetailViewDefault_detailViewDefault_light@2x.png"; sourceTree = "<group>"; };
 		CD1282CD1FA1F67DBC768521 /* testSideBySide_6plus6_TwoLights_6plus6_two_lights_dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testSideBySide_6plus6_TwoLights_6plus6_two_lights_dark_gradient@2x.png"; sourceTree = "<group>"; };
@@ -2811,6 +2848,7 @@
 		FA6BADF264F08492B1EC7B57 /* partly-cloudy-night.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "partly-cloudy-night.json"; sourceTree = "<group>"; };
 		FA8562AC70FF28676AB84367 /* testAlarmScTriggered__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testAlarmScTriggered__dark_gradient@2x.png"; sourceTree = "<group>"; };
 		FA9E549296F0364233A02A50 /* UIImage+Compare.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Compare.m"; sourceTree = "<group>"; };
+		FAA406AF27A5D734A9B2DA62 /* HACameraRegistrationManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HACameraRegistrationManager.h; sourceTree = "<group>"; };
 		FB213C4E67BAB59D56020667 /* testAlarmArmedHome_alarmArmedHome_dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testAlarmArmedHome_alarmArmedHome_dark_gradient@2x.png"; sourceTree = "<group>"; };
 		FB361C9D351DE13A97400B57 /* HASensorReporter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HASensorReporter.m; sourceTree = "<group>"; };
 		FB5AC39CFCF609EAA1F2883B /* HAEntity.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HAEntity.h; sourceTree = "<group>"; };
@@ -2836,6 +2874,21 @@
 		FFD7ED639C9321DBA82DDA27 /* HAAuthManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HAAuthManager.m; sourceTree = "<group>"; };
 		FFDC0480E43A7A66F9DAE4FD /* testMinimalSwitch__dark_gradient@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testMinimalSwitch__dark_gradient@2x.png"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		AEF3556BA3517A3E6ECC31A4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF6309C368BAC8DDB71F43E7 /* AVFoundation.framework in Frameworks */,
+				B03BD5963B4D46494AFC7205 /* AudioToolbox.framework in Frameworks */,
+				20A8CF2053A27427F694844C /* CoreMedia.framework in Frameworks */,
+				BB77898BA8ADC0C19075BC21 /* CoreVideo.framework in Frameworks */,
+				20F75B4E5D3986B7E465CB9F /* VideoToolbox.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		00821B4C0BF62D42FC7694E2 /* Cells */ = {
@@ -2933,6 +2986,18 @@
 				ECB0063E3DA5B6A5380226EC /* HAWeatherEntityCell.m */,
 			);
 			path = Cells;
+			sourceTree = "<group>";
+		};
+		0236BCA667C4D207CE2C3066 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				739E3AAFEE723F558E6E8BE0 /* AudioToolbox.framework */,
+				33568683800A7076EFF2235B /* AVFoundation.framework */,
+				78E45E8D320DD66648A8BFC0 /* CoreMedia.framework */,
+				192DEF3966D8287040B8820B /* CoreVideo.framework */,
+				0AD82FDF0E4C16C983C3440E /* VideoToolbox.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		0DA5A7C3E0F0A1BE18AA1CC4 /* Resources */ = {
@@ -3219,14 +3284,19 @@
 				E1D57968CA6A9F084ED526A7 /* Models */,
 				A556514053D652530987DEB3 /* Networking */,
 				46887388C1A18E9AC7CF7300 /* Resources */,
+				58217558B04895AFFFEDDDEE /* Streaming */,
 				D60FD6EF2513D7679795D7FD /* Theme */,
 				2FA6142685F5700A27FA10F0 /* Views */,
 				5F3977C0C20957C49DC162F6 /* Assets.xcassets */,
 				33A3AE6EE74FF884AA4B075D /* HAAppDelegate.h */,
 				A813193370856C9C1CCEAD9E /* HAAppDelegate.m */,
+				956A8AB5540190E9DE3A8F81 /* HAAppSceneDelegate.h */,
+				7CFC6D599899DD15B4FC4430 /* HAAppSceneDelegate.m */,
+				9BDB9594E361B05EAB3D458C /* HADashboard-Catalyst.entitlements */,
 				F51D788749A749C34A4EF8FE /* Info.plist */,
 				40B14EFB95D338A8FAABC4B7 /* LaunchScreen.storyboard */,
 				8B7330389B39D40E70CDC883 /* main.m */,
+				2B2653048FACE4BABE15EE2B /* PrivacyInfo.xcprivacy */,
 			);
 			path = HADashboard;
 			sourceTree = "<group>";
@@ -3439,6 +3509,21 @@
 				68B5C673682A8D7E2BBE1360 /* testVacuumReturning_vacuumReturning_light@2x.png */,
 			);
 			path = HAControlSnapshotTests;
+			sourceTree = "<group>";
+		};
+		58217558B04895AFFFEDDDEE /* Streaming */ = {
+			isa = PBXGroup;
+			children = (
+				332FA399EDD007F85EF751EA /* HAAACEncoder.h */,
+				53591114789889D6657F3060 /* HAAACEncoder.m */,
+				2614DAAA805D8414CDCE0210 /* HARTSPCredentialManager.h */,
+				622182878CD56801C140B5A4 /* HARTSPCredentialManager.m */,
+				32ABC923A9651E8D1C78B90E /* HARTSPServer.h */,
+				46FF72C3A285CDAD68438579 /* HARTSPServer.m */,
+				23B7767D3D3A5FB692DB3197 /* HAStreamingManager.h */,
+				CCD20AE0FC5BAA13F701BA4F /* HAStreamingManager.m */,
+			);
+			path = Streaming;
 			sourceTree = "<group>";
 		};
 		5C357860077C7FF2EBABF386 /* AnimatableLayers */ = {
@@ -3913,6 +3998,7 @@
 				8771F55C00356DD461DB6AC5 /* iOSSnapshotTestCase */,
 				6ED5CB047DDA3DEC3DC50BE5 /* MDI */,
 				606A30DA26A0CFADF37D8082 /* Vendor */,
+				0236BCA667C4D207CE2C3066 /* Frameworks */,
 				EB1E6FFC9E4AD1CBD44AC043 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -4174,6 +4260,8 @@
 			children = (
 				55AF769DA3EB8112C914900E /* HAAPIClient.h */,
 				425C0ABCCCC9ACB1A5264B16 /* HAAPIClient.m */,
+				FAA406AF27A5D734A9B2DA62 /* HACameraRegistrationManager.h */,
+				5753921C664BF976733932B2 /* HACameraRegistrationManager.m */,
 				7376E6E3086B763C5C48BE5A /* HAConnectionManager.h */,
 				D923F28F7F9CA85F2AE6DC64 /* HAConnectionManager.m */,
 				E1BDF17A04D61972A6A72B12 /* HADateUtils.h */,
@@ -4190,6 +4278,8 @@
 				B9FB1828282C6F9D290DE809 /* HALogbookManager.m */,
 				FFBD14F6E7AA4728D3998AEC /* HAMJPEGStreamParser.h */,
 				7808378C0D1A893DF410B526 /* HAMJPEGStreamParser.m */,
+				5568DB6B77EA62BE4D65CD2F /* HAURLSessionRedirectGuard.h */,
+				86A85250D349B93E74648930 /* HAURLSessionRedirectGuard.m */,
 				8DE59ACF50060861213F5DDF /* HAWebSocketClient.h */,
 				584CFB3FB088459D25966215 /* HAWebSocketClient.m */,
 				FF2FACEA35EB6A250C2AD53F /* NSMutableURLRequest+HAHelpers.h */,
@@ -4460,10 +4550,12 @@
 				B515DAD59397BD82D51BE42F /* HALightingSnapshotTests.m */,
 				72FFAE7B08DD2FF900440D81 /* HAMJPEGStreamTests.m */,
 				BF3BB81D6358A1EFC0A7F6C4 /* HAOAuthClientTests.m */,
+				A6391A33D6AC3257EF4FEAD7 /* HARTSPCredentialManagerTests.m */,
 				5EC033606331DA18E5D52CE4 /* HASafeDictTests.m */,
 				C432ACD4D867243A79F62F3D /* HASensorSnapshotTests.m */,
 				96430275DA9C1A3D906305F4 /* HASnapshotTestHelpers.h */,
 				EE9C4C72189AA85B5EC9ED55 /* HASnapshotTestHelpers.m */,
+				395E6D29E1144404119445B5 /* HAStreamingTests.m */,
 				78B20879C1CE0CB4DC78D874 /* HASunBasedThemeTests.m */,
 				89C3AEC2DEBB17550A98AECB /* HATileFeatureSnapshotTests.m */,
 				25A23BBB01EFF935B0E6A107 /* HATileFeatureTests.m */,
@@ -4770,6 +4862,7 @@
 			buildPhases = (
 				F1F49CBA556115E44B6C83E5 /* Sources */,
 				03FFD5458CCCB2953F392FE0 /* Resources */,
+				AEF3556BA3517A3E6ECC31A4 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -4843,6 +4936,7 @@
 			files = (
 				03ADFFB7B8D96DD4D8F97BD6 /* Assets.xcassets in Resources */,
 				2881B660189B8CE69CB29C2E /* LaunchScreen.storyboard in Resources */,
+				A1C12B8E98D184C38BE573A4 /* PrivacyInfo.xcprivacy in Resources */,
 				9D654F59705D8BA87D556140 /* clear-day.json in Resources */,
 				459C9635019F7A6AA2BBBAB7 /* clear-night.json in Resources */,
 				D6A561D7E2EE7EA799AE8208 /* cloudy.json in Resources */,
@@ -5931,9 +6025,11 @@
 				EFF2D03A1A5B6318EECB0750 /* HALightingSnapshotTests.m in Sources */,
 				48421F38085456F0C84F5DC3 /* HAMJPEGStreamTests.m in Sources */,
 				F022C139DA5CD97CAD9B39FF /* HAOAuthClientTests.m in Sources */,
+				C092F7F18948B1D893F54D1B /* HARTSPCredentialManagerTests.m in Sources */,
 				2C4275DCD5D60B53C580C634 /* HASafeDictTests.m in Sources */,
 				978DD2C57D1B0B5ACDCD1FB5 /* HASensorSnapshotTests.m in Sources */,
 				8001FCCF9601F206DFB000EC /* HASnapshotTestHelpers.m in Sources */,
+				0A03A4280BF4E3CB85A7B808 /* HAStreamingTests.m in Sources */,
 				2096FED6D5D54E5653A1055B /* HASunBasedThemeTests.m in Sources */,
 				FA0C237F75B417A3E37BBBC1 /* HATileFeatureSnapshotTests.m in Sources */,
 				739078C313CA9F70B458A2D5 /* HATileFeatureTests.m in Sources */,
@@ -5954,11 +6050,13 @@
 			files = (
 				EFFC88B6EB6843E13D00B690 /* CGGeometry+LOTAdditions.h in Sources */,
 				03934F21756ACEBE4FD6B5C6 /* CGGeometry+LOTAdditions.m in Sources */,
+				97F5CDF85A43EAC765975DCD /* HAAACEncoder.m in Sources */,
 				C2BD3F6B693CDD013FB84FC0 /* HAAPIClient.m in Sources */,
 				2BE5D6E9645C0264C99BA803 /* HAAction.m in Sources */,
 				2E1691C280F96B4383EB0D17 /* HAActionDispatcher.m in Sources */,
 				C2D5CD3B5FF6B8A69246FBE9 /* HAAlarmEntityCell.m in Sources */,
 				FACB0B4D6D96457B2AD1E2A1 /* HAAppDelegate.m in Sources */,
+				3A0E289CBCCCC3A9C563AC70 /* HAAppSceneDelegate.m in Sources */,
 				8636500D1A13D2C764910FED /* HAAreaCardCell.m in Sources */,
 				49B3E5131DE6588A49678200 /* HAAttributeRowView.m in Sources */,
 				0E0112A7B1E4575C46A1985F /* HAAuthManager.m in Sources */,
@@ -5971,6 +6069,7 @@
 				3DCA54BBEA4A6DB5397BA572 /* HACacheManager.m in Sources */,
 				06F39326AFAE0FEEADD37511 /* HACalendarCardCell.m in Sources */,
 				BBB86B24FB7AF6C047C2EBFA /* HACameraEntityCell.m in Sources */,
+				F941AFAA09A469A72FBA04F6 /* HACameraRegistrationManager.m in Sources */,
 				ED1125408B8C1B6A44EA69E9 /* HAClimateEntityCell.m in Sources */,
 				DDEA7123AF56287E575DCF7C /* HAClockWeatherCell.m in Sources */,
 				98D03C1230A2C4C015DB5F30 /* HAColorWheelView.m in Sources */,
@@ -6049,6 +6148,8 @@
 				38F8169FFA64FFA9635128A2 /* HAPersonEntityCell.m in Sources */,
 				75714986505624EA918DDACA /* HAPictureGlanceCardCell.m in Sources */,
 				8F8364A87419BED13E8974F6 /* HAProximityWakeController.m in Sources */,
+				53B668B913D8E8BA5A65C748 /* HARTSPCredentialManager.m in Sources */,
+				AA882AEDC0D0DF831B8D70E9 /* HARTSPServer.m in Sources */,
 				22D12E429523F54D75C9801C /* HARemoteCommandHandler.m in Sources */,
 				1B67362D07BD8992BBA9EF37 /* HARemoteEntityCell.m in Sources */,
 				82BFD7ACD06BDDC9A662B2EE /* HASceneEntityCell.m in Sources */,
@@ -6062,6 +6163,7 @@
 				8FB612C832CEF14BE5B48EA0 /* HASoftwareBlur.m in Sources */,
 				FFE638BE994AC20EC8D6EE6A /* HAStatisticCardCell.m in Sources */,
 				453227D0A2E07614B5548333 /* HAStrategyResolver.m in Sources */,
+				9832382D33C4145E3F843D8C /* HAStreamingManager.m in Sources */,
 				EA9753E5BD391B150C4EC4B8 /* HASunBasedTheme.m in Sources */,
 				9486AB278A90B913E81CDBAE /* HASwitch.m in Sources */,
 				CA152CB0C67CEBC6E0D702FD /* HASwitchEntityCell.m in Sources */,
@@ -6074,6 +6176,7 @@
 				512C6BF05CB95C1193E1527C /* HAToastView.m in Sources */,
 				FA25B21C0013EFD2EB99BFB1 /* HATodoEntityCell.m in Sources */,
 				79F19FA2019298026D5BB1F6 /* HATopAlignedFlowLayout.m in Sources */,
+				3372F0186F2BAAF3BEC13CF6 /* HAURLSessionRedirectGuard.m in Sources */,
 				74399345097DC68EA6B243A0 /* HAUpdateEntityCell.m in Sources */,
 				780CF7C4B83AC1CC8EF2CA02 /* HAVacuumEntityCell.m in Sources */,
 				509E37389F2B3A36C64A5BBA /* HAWaterHeaterEntityCell.m in Sources */,
@@ -6340,6 +6443,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = NO;
+				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "HADashboard/HADashboard-Catalyst.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0;
@@ -6437,6 +6541,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = NO;
+				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "HADashboard/HADashboard-Catalyst.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0;

--- a/HADashboard/Auth/HAAuthManager.h
+++ b/HADashboard/Auth/HAAuthManager.h
@@ -19,6 +19,10 @@ typedef NS_ENUM(NSInteger, HAAuthMode) {
 @property (nonatomic, copy, readonly) NSString *refreshToken;
 @property (nonatomic, copy, readonly) NSDate *tokenExpiresAt;
 
+/// Non-secret generation that changes whenever the configured server/account
+/// credentials are replaced or cleared. Access-token refreshes keep it stable.
+@property (nonatomic, readonly) NSUInteger authenticationRevision;
+
 /// Selected dashboard URL path (nil = default dashboard)
 @property (nonatomic, copy, readonly) NSString *selectedDashboardPath;
 

--- a/HADashboard/Auth/HAAuthManager.m
+++ b/HADashboard/Auth/HAAuthManager.m
@@ -2,6 +2,10 @@
 #import "HAKeychainHelper.h"
 #import "HAOAuthClient.h"
 #import "HALog.h"
+#import "HAStreamingManager.h"
+#import "HADeviceIntegrationManager.h"
+#import "HADeviceRegistration.h"
+#import "HACameraRegistrationManager.h"
 
 NSString *const HAAuthManagerDidUpdateNotification = @"HAAuthManagerDidUpdateNotification";
 
@@ -30,6 +34,7 @@ static NSString *const kCameraGlobalMuteKey = @"HACameraGlobalMute";
 @property (nonatomic, assign, readwrite) BOOL cameraGlobalMute;
 @property (nonatomic, strong) NSTimer *refreshTimer;
 @property (nonatomic, strong) NSMutableArray<void (^)(BOOL, NSError *)> *pendingRefreshCompletions;
+@property (nonatomic, assign) NSUInteger credentialGeneration;
 @end
 
 @implementation HAAuthManager
@@ -97,6 +102,12 @@ static NSString *const kCameraGlobalMuteKey = @"HACameraGlobalMute";
     return self.serverURL.length > 0 && self.accessToken.length > 0;
 }
 
+- (NSUInteger)authenticationRevision {
+    @synchronized(self) {
+        return self.credentialGeneration;
+    }
+}
+
 #pragma mark - Save Credentials
 
 + (NSString *)normalizedURL:(NSString *)url {
@@ -108,6 +119,7 @@ static NSString *const kCameraGlobalMuteKey = @"HACameraGlobalMute";
 }
 
 - (void)saveServerURL:(NSString *)url token:(NSString *)token {
+    [self invalidatePendingTokenRefreshes];
     NSString *normalizedURL = [HAAuthManager normalizedURL:url];
 
     [HAKeychainHelper setString:normalizedURL forKey:kServerURLKey];
@@ -134,6 +146,7 @@ static NSString *const kCameraGlobalMuteKey = @"HACameraGlobalMute";
                  accessToken:(NSString *)accessToken
                 refreshToken:(NSString *)refreshToken
                    expiresIn:(NSTimeInterval)expiresIn {
+    [self invalidatePendingTokenRefreshes];
     NSString *normalizedURL = [HAAuthManager normalizedURL:serverURL];
     NSDate *expiry = [NSDate dateWithTimeIntervalSinceNow:expiresIn];
 
@@ -230,6 +243,7 @@ static NSString *const kCameraGlobalMuteKey = @"HACameraGlobalMute";
         return;
     }
 
+    __block NSUInteger refreshGeneration = 0;
     @synchronized(self) {
         if (self.pendingRefreshCompletions) {
             // Already refreshing — queue this caller so it gets the result
@@ -238,10 +252,14 @@ static NSString *const kCameraGlobalMuteKey = @"HACameraGlobalMute";
         }
         self.pendingRefreshCompletions = [NSMutableArray array];
         if (completion) [self.pendingRefreshCompletions addObject:[completion copy]];
+        refreshGeneration = self.credentialGeneration;
     }
 
     HAOAuthClient *oauth = [[HAOAuthClient alloc] initWithServerURL:self.serverURL];
     [oauth refreshWithToken:self.refreshToken completion:^(NSDictionary *tokenResponse, NSError *error) {
+        @synchronized(self) {
+            if (refreshGeneration != self.credentialGeneration) return;
+        }
         BOOL success = NO;
         if (error || !tokenResponse[@"access_token"]) {
             HALogE(@"auth", @"Token refresh failed: %@", error.localizedDescription);
@@ -264,6 +282,23 @@ static NSString *const kCameraGlobalMuteKey = @"HACameraGlobalMute";
             cb(success, error);
         }
     }];
+}
+
+- (void)invalidatePendingTokenRefreshes {
+    NSArray<void (^)(BOOL, NSError *)> *completions = nil;
+    @synchronized(self) {
+        self.credentialGeneration++;
+        completions = [self.pendingRefreshCompletions copy];
+        self.pendingRefreshCompletions = nil;
+    }
+    if (completions.count == 0) return;
+    NSError *cancelled = [NSError errorWithDomain:NSURLErrorDomain
+                                              code:NSURLErrorCancelled
+                                          userInfo:@{NSLocalizedDescriptionKey:
+                                              @"The authentication refresh was cancelled because credentials changed."}];
+    for (void (^callback)(BOOL, NSError *) in completions) {
+        callback(NO, cancelled);
+    }
 }
 
 #pragma mark - Other Settings
@@ -313,16 +348,25 @@ static NSString *const kCameraGlobalMuteKey = @"HACameraGlobalMute";
 }
 
 - (void)clearCredentials {
+    // Stop all opt-in services before removing their persisted state.
+    [HADeviceIntegrationManager sharedManager].enabled = NO;
+    [[HADeviceRegistration sharedManager] resetLocalRegistration];
+    [[HAStreamingManager sharedManager] clearLocalStreamConfiguration];
+    [[HACameraRegistrationManager sharedManager] resetLocalRegistrationState];
+    [self invalidatePendingTokenRefreshes];
+
     [HAKeychainHelper removeItemForKey:kServerURLKey];
     [HAKeychainHelper removeItemForKey:kAccessTokenKey];
     [HAKeychainHelper removeItemForKey:kAuthModeKey];
     [HAKeychainHelper removeItemForKey:kRefreshTokenKey];
     [HAKeychainHelper removeItemForKey:kTokenExpiryKey];
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kSelectedDashboardKey];
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kKioskModeKey];
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kDemoModeKey];
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kAutoReloadDashboardKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
+
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSString *bundleIdentifier = [NSBundle mainBundle].bundleIdentifier;
+    if (bundleIdentifier.length) {
+        [defaults removePersistentDomainForName:bundleIdentifier];
+    }
+    [defaults synchronize];
 
     self.serverURL = nil;
     self.accessToken = nil;
@@ -331,8 +375,10 @@ static NSString *const kCameraGlobalMuteKey = @"HACameraGlobalMute";
     self.tokenExpiresAt = nil;
     self.selectedDashboardPath = nil;
     self.kioskMode = NO;
+    self.proximityWakeEnabled = NO;
     self.demoMode = NO;
     self.autoReloadDashboard = YES;
+    self.cameraGlobalMute = YES;
 
     [self.refreshTimer invalidate];
     self.refreshTimer = nil;

--- a/HADashboard/Auth/HAOAuthClient.m
+++ b/HADashboard/Auth/HAOAuthClient.m
@@ -1,6 +1,7 @@
 #import "HAOAuthClient.h"
 #import "HAAuthManager.h"
 #import "NSMutableURLRequest+HAHelpers.h"
+#import "HAURLSessionRedirectGuard.h"
 
 static NSString *const kClientId = @"https://hadashboard.local/";
 static NSString *const kRedirectURI = @"https://hadashboard.local/";
@@ -17,7 +18,9 @@ static NSString *const kRedirectURI = @"https://hadashboard.local/";
     if (self) {
         _serverURL = [[HAAuthManager normalizedURL:serverURL] copy];
 
-        _session = [NSURLSession sessionWithConfiguration:[NSMutableURLRequest ha_defaultSessionConfiguration]];
+        _session = [NSURLSession sessionWithConfiguration:[NSMutableURLRequest ha_defaultSessionConfiguration]
+                                                  delegate:[HAURLSessionRedirectGuard sharedGuard]
+                                             delegateQueue:nil];
     }
     return self;
 }

--- a/HADashboard/Cache/HACacheManager.h
+++ b/HADashboard/Cache/HACacheManager.h
@@ -29,6 +29,9 @@
 /// Delete all cache files for the current server.
 - (void)clearAllCaches;
 
+/// Delete cache directories for every server previously used by this app.
+- (void)clearAllServerCaches;
+
 #pragma mark - Paths
 
 /// Returns the Application Support cache directory for the current server.

--- a/HADashboard/Cache/HACacheManager.m
+++ b/HADashboard/Cache/HACacheManager.m
@@ -144,4 +144,23 @@
     if (expendDir) [fm removeItemAtPath:expendDir error:nil];
 }
 
+- (void)clearAllServerCaches {
+    NSString *appSupport = [NSSearchPathForDirectoriesInDomains(
+        NSApplicationSupportDirectory, NSUserDomainMask, YES) firstObject];
+    NSString *caches = [NSSearchPathForDirectoriesInDomains(
+        NSCachesDirectory, NSUserDomainMask, YES) firstObject];
+    // Drain queued writes first so an older dashboard snapshot cannot recreate
+    // the cache immediately after Log Out & Reset removes it.
+    dispatch_sync(self.writeQueue, ^{
+        NSFileManager *fm = [NSFileManager defaultManager];
+        if (appSupport.length) {
+            [fm removeItemAtPath:[appSupport stringByAppendingPathComponent:@"HACache"] error:nil];
+        }
+        if (caches.length) {
+            [fm removeItemAtPath:[caches stringByAppendingPathComponent:@"HACache"] error:nil];
+        }
+    });
+    self.serverURL = nil;
+}
+
 @end

--- a/HADashboard/Cache/HADashboardConfigCache.m
+++ b/HADashboard/Cache/HADashboardConfigCache.m
@@ -67,8 +67,12 @@
 
     // Compute hash of new config
     NSError *error = nil;
+    NSJSONWritingOptions writingOptions = 0;
+    if (@available(iOS 11.0, *)) {
+        writingOptions = NSJSONWritingSortedKeys;
+    }
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:config
-                                                      options:NSJSONWritingSortedKeys
+                                                      options:writingOptions
                                                         error:&error];
     if (!jsonData) {
         HALogE(@"cache", @"Failed to serialize dashboard config: %@", error.localizedDescription);

--- a/HADashboard/Cache/HAEntityStateCache.h
+++ b/HADashboard/Cache/HAEntityStateCache.h
@@ -22,6 +22,9 @@
 /// Call this on applicationWillResignActive:.
 - (void)flushToDisk;
 
+/// Drop any debounced in-memory snapshot so a reset cannot recreate a cache.
+- (void)discardPendingWrites;
+
 /// Whether there is a cached state file on disk for the current server.
 - (BOOL)hasCachedStates;
 

--- a/HADashboard/Cache/HAEntityStateCache.m
+++ b/HADashboard/Cache/HAEntityStateCache.m
@@ -69,6 +69,11 @@ static const NSTimeInterval kDebounceInterval = 5.0;
     [self writePendingToDiskSync];
 }
 
+- (void)discardPendingWrites {
+    self.writeScheduled = NO;
+    self.pendingEntities = nil;
+}
+
 #pragma mark - Private
 
 - (void)writePendingToDisk {

--- a/HADashboard/Controllers/HASettingsViewController.m
+++ b/HADashboard/Controllers/HASettingsViewController.m
@@ -14,6 +14,9 @@
 #import "HACacheManager.h"
 #import "HAEntityStateCache.h"
 #import "HAHistoryManager.h"
+#import "HAStreamingManager.h"
+#import "HACameraRegistrationManager.h"
+#import "HARTSPCredentialManager.h"
 
 
 // NSUserDefaults keys for device integration
@@ -66,6 +69,18 @@ static NSString *const kDeviceNameOverride    = @"ha_device_name_override";
 @property (nonatomic, strong) UIView *cameraMuteSection;
 @property (nonatomic, strong) UISwitch *cameraMuteSwitch;
 
+// Local live camera/audio publisher (opt-in, foreground-only)
+@property (nonatomic, strong) UIView *liveStreamingSection;
+@property (nonatomic, strong) UILabel *liveStreamingStatusLabel;
+@property (nonatomic, strong) UISwitch *liveStreamingSwitch;
+@property (nonatomic, strong) UISegmentedControl *liveStreamingCameraSegment;
+@property (nonatomic, strong) UISlider *liveStreamingQualitySlider;
+@property (nonatomic, strong) UILabel *liveStreamingQualityLabel;
+@property (nonatomic, strong) UIButton *liveStreamingAccessButton;
+@property (nonatomic, strong) NSTimer *liveStreamingQualityDebounceTimer;
+@property (nonatomic, assign) NSInteger sensitiveStreamPasteboardChangeCount;
+@property (nonatomic, strong) NSDate *sensitiveStreamPasteboardExpiry;
+
 // Clear cache
 @property (nonatomic, strong) UIButton *clearCacheButton;
 
@@ -98,11 +113,29 @@ static NSString *const kDeviceNameOverride    = @"ha_device_name_override";
     self.view.backgroundColor = [HATheme backgroundColor];
 
     [self setupUI];
+    NSNotificationCenter *notifications = [NSNotificationCenter defaultCenter];
+    [notifications addObserver:self selector:@selector(liveStreamingStateChanged:)
+                          name:HAStreamingManagerStateDidChangeNotification object:nil];
+    [notifications addObserver:self selector:@selector(liveStreamingStateChanged:)
+                          name:HACameraRegistrationDidChangeNotification object:nil];
+    [notifications addObserver:self selector:@selector(deviceRegistrationStateChanged:)
+                          name:HADeviceRegistrationDidCompleteNotification object:nil];
+    [notifications addObserver:self selector:@selector(deviceRegistrationStateChanged:)
+                          name:HADeviceRegistrationDidInvalidateNotification object:nil];
+    [notifications addObserver:self selector:@selector(clearExpiredSensitiveStreamPasteboardAfterActivation:)
+                          name:UIApplicationDidBecomeActiveNotification object:nil];
+}
+
+- (void)dealloc {
+    [self clearSensitiveStreamPasteboardIfExpired];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [self.liveStreamingQualityDebounceTimer invalidate];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     [self updateConnectionSummary];
+    [self updateLiveStreamingStatus];
 }
 
 - (void)setupUI {
@@ -333,12 +366,15 @@ static NSString *const kDeviceNameOverride    = @"ha_device_name_override";
     // Camera audio mute default
     UISwitch *camMuteSw = nil;
     self.cameraMuteSection = [self createToggleSection:@"Mute Camera Audio"
-        helpText:@"Camera streams are muted by default. Turn this off to hear audio when opening fullscreen camera views (HLS streams only)."
+        helpText:@"Controls audio playback for Home Assistant camera cards only. Local Camera Stream always includes microphone audio while a client is viewing it; turn that stream off to stop publishing audio."
         isOn:[[HAAuthManager sharedManager] cameraGlobalMute]
         target:self action:@selector(cameraMuteSwitchToggled:)
         switchOut:&camMuteSw];
     self.cameraMuteSwitch = camMuteSw;
     [container addSubview:self.cameraMuteSection];
+
+    self.liveStreamingSection = [self createLiveStreamingSection];
+    [container addSubview:self.liveStreamingSection];
 
     // Clear cache button
     self.clearCacheButton = [UIButton buttonWithType:UIButtonTypeSystem];
@@ -450,6 +486,7 @@ static NSString *const kDeviceNameOverride    = @"ha_device_name_override";
         @"demo":      self.demoSection,
         @"autoReload":self.autoReloadSection,
         @"camMute":   self.cameraMuteSection,
+        @"liveStream":self.liveStreamingSection,
         @"clrCache":  self.clearCacheButton,
         @"intHdr":    self.integrationSectionHeader,
         @"intSec":    self.integrationSection,
@@ -462,7 +499,7 @@ static NSString *const kDeviceNameOverride    = @"ha_device_name_override";
     NSDictionary *metrics = @{@"p": @16, @"sh": @32, @"hg": @10, @"fh": @44};
 
     [container addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:
-        @"V:|[connHdr]-hg-[connRow]-sh-[appHdr]-hg-[themeStack]-sh-[dispHdr]-hg-[kiosk]-p-[proxWake]-p-[demo]-p-[autoReload]-p-[camMute]-p-[clrCache(fh)]-sh-[intHdr]-hg-[intSec]-sh-[aboutHdr]-hg-[about]-sh-[devHdr]-hg-[dev]-sh-[logout(fh)]|"
+        @"V:|[connHdr]-hg-[connRow]-sh-[appHdr]-hg-[themeStack]-sh-[dispHdr]-hg-[kiosk]-p-[proxWake]-p-[demo]-p-[autoReload]-p-[camMute]-p-[liveStream]-p-[clrCache(fh)]-sh-[intHdr]-hg-[intSec]-sh-[aboutHdr]-hg-[about]-sh-[devHdr]-hg-[dev]-sh-[logout(fh)]|"
         options:0 metrics:metrics views:views]];
 
     for (NSString *name in views) {
@@ -488,6 +525,355 @@ static NSString *const kDeviceNameOverride    = @"ha_device_name_override";
         relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeCenterX multiplier:1 constant:0]];
     [container addConstraint:[NSLayoutConstraint constraintWithItem:container attribute:NSLayoutAttributeWidth
         relatedBy:NSLayoutRelationLessThanOrEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1 constant:maxWidth]];
+}
+
+- (UIView *)createLiveStreamingSection {
+    HAStreamingManager *manager = [HAStreamingManager sharedManager];
+    UIView *section = [[UIView alloc] init];
+    section.translatesAutoresizingMaskIntoConstraints = NO;
+
+    UILabel *title = [[UILabel alloc] init];
+    title.text = @"Local Camera Stream";
+    title.font = [UIFont systemFontOfSize:16];
+    title.textColor = [HATheme primaryTextColor];
+    title.translatesAutoresizingMaskIntoConstraints = NO;
+    [section addSubview:title];
+
+    self.liveStreamingSwitch = [[HASwitch alloc] init];
+    self.liveStreamingSwitch.onTintColor = [HATheme switchTintColor];
+    self.liveStreamingSwitch.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.liveStreamingSwitch addTarget:self action:@selector(liveStreamingToggled:) forControlEvents:UIControlEventValueChanged];
+    [section addSubview:self.liveStreamingSwitch];
+
+    self.liveStreamingCameraSegment = [[UISegmentedControl alloc] initWithItems:@[@"Front", @"Rear", @"Both"]];
+    self.liveStreamingCameraSegment.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.liveStreamingCameraSegment setEnabled:manager.frontCameraAvailable forSegmentAtIndex:HAStreamingCameraModeFront];
+    [self.liveStreamingCameraSegment setEnabled:manager.rearCameraAvailable forSegmentAtIndex:HAStreamingCameraModeRear];
+    [self.liveStreamingCameraSegment setEnabled:manager.multiCamSupported forSegmentAtIndex:HAStreamingCameraModeBoth];
+    self.liveStreamingCameraSegment.selectedSegmentIndex = manager.cameraMode;
+    self.liveStreamingCameraSegment.hidden = !(manager.frontCameraAvailable && manager.rearCameraAvailable);
+    [self.liveStreamingCameraSegment addTarget:self action:@selector(liveStreamingCameraChanged:) forControlEvents:UIControlEventValueChanged];
+    [section addSubview:self.liveStreamingCameraSegment];
+
+    self.liveStreamingQualityLabel = [[UILabel alloc] init];
+    self.liveStreamingQualityLabel.font = [UIFont systemFontOfSize:12];
+    self.liveStreamingQualityLabel.textColor = [HATheme secondaryTextColor];
+    self.liveStreamingQualityLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    [section addSubview:self.liveStreamingQualityLabel];
+
+    self.liveStreamingQualitySlider = [[UISlider alloc] init];
+    self.liveStreamingQualitySlider.minimumValue = 0.0f;
+    self.liveStreamingQualitySlider.maximumValue = 1.0f;
+    self.liveStreamingQualitySlider.value = manager.qualityScale;
+    self.liveStreamingQualitySlider.continuous = YES;
+    self.liveStreamingQualitySlider.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.liveStreamingQualitySlider addTarget:self action:@selector(liveStreamingQualityPreviewChanged:) forControlEvents:UIControlEventValueChanged];
+    [self.liveStreamingQualitySlider addTarget:self action:@selector(liveStreamingQualityCommitted:) forControlEvents:(UIControlEventTouchUpInside | UIControlEventTouchUpOutside | UIControlEventTouchCancel)];
+    [section addSubview:self.liveStreamingQualitySlider];
+
+    self.liveStreamingStatusLabel = [[UILabel alloc] init];
+    self.liveStreamingStatusLabel.font = [UIFont systemFontOfSize:12];
+    self.liveStreamingStatusLabel.textColor = [HATheme secondaryTextColor];
+    self.liveStreamingStatusLabel.numberOfLines = 0;
+    self.liveStreamingStatusLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    self.liveStreamingStatusLabel.userInteractionEnabled = YES;
+    [self.liveStreamingStatusLabel addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(copyLiveStreamURL:)]];
+    [section addSubview:self.liveStreamingStatusLabel];
+
+    self.liveStreamingAccessButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.liveStreamingAccessButton setTitle:@"Protected access · Manage" forState:UIControlStateNormal];
+    self.liveStreamingAccessButton.titleLabel.font = [UIFont systemFontOfSize:12 weight:UIFontWeightMedium];
+    self.liveStreamingAccessButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
+    self.liveStreamingAccessButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.liveStreamingAccessButton addTarget:self action:@selector(liveStreamingAccessTapped:)
+        forControlEvents:UIControlEventTouchUpInside];
+    [section addSubview:self.liveStreamingAccessButton];
+
+    CGFloat segmentHeight = self.liveStreamingCameraSegment.hidden ? 0 : 32;
+    [NSLayoutConstraint activateConstraints:@[
+        [title.topAnchor constraintEqualToAnchor:section.topAnchor],
+        [title.leadingAnchor constraintEqualToAnchor:section.leadingAnchor],
+        [self.liveStreamingSwitch.trailingAnchor constraintEqualToAnchor:section.trailingAnchor],
+        [self.liveStreamingSwitch.centerYAnchor constraintEqualToAnchor:title.centerYAnchor],
+        [self.liveStreamingCameraSegment.topAnchor constraintEqualToAnchor:title.bottomAnchor constant:self.liveStreamingCameraSegment.hidden ? 0 : 8],
+        [self.liveStreamingCameraSegment.leadingAnchor constraintEqualToAnchor:section.leadingAnchor],
+        [self.liveStreamingCameraSegment.trailingAnchor constraintEqualToAnchor:section.trailingAnchor],
+        [self.liveStreamingCameraSegment.heightAnchor constraintEqualToConstant:segmentHeight],
+        [self.liveStreamingQualityLabel.topAnchor constraintEqualToAnchor:self.liveStreamingCameraSegment.bottomAnchor constant:8],
+        [self.liveStreamingQualityLabel.leadingAnchor constraintEqualToAnchor:section.leadingAnchor],
+        [self.liveStreamingQualityLabel.trailingAnchor constraintEqualToAnchor:section.trailingAnchor],
+        [self.liveStreamingQualitySlider.topAnchor constraintEqualToAnchor:self.liveStreamingQualityLabel.bottomAnchor constant:2],
+        [self.liveStreamingQualitySlider.leadingAnchor constraintEqualToAnchor:section.leadingAnchor],
+        [self.liveStreamingQualitySlider.trailingAnchor constraintEqualToAnchor:section.trailingAnchor],
+        [self.liveStreamingQualitySlider.heightAnchor constraintEqualToConstant:30],
+        [self.liveStreamingStatusLabel.topAnchor constraintEqualToAnchor:self.liveStreamingQualitySlider.bottomAnchor constant:6],
+        [self.liveStreamingStatusLabel.leadingAnchor constraintEqualToAnchor:section.leadingAnchor],
+        [self.liveStreamingStatusLabel.trailingAnchor constraintEqualToAnchor:section.trailingAnchor],
+        [self.liveStreamingAccessButton.topAnchor constraintEqualToAnchor:self.liveStreamingStatusLabel.bottomAnchor constant:4],
+        [self.liveStreamingAccessButton.leadingAnchor constraintEqualToAnchor:section.leadingAnchor],
+        [self.liveStreamingAccessButton.trailingAnchor constraintEqualToAnchor:section.trailingAnchor],
+        [self.liveStreamingAccessButton.heightAnchor constraintEqualToConstant:30],
+        [self.liveStreamingAccessButton.bottomAnchor constraintEqualToAnchor:section.bottomAnchor],
+    ]];
+    [self updateLiveStreamingStatus];
+    return section;
+}
+
+- (void)liveStreamingToggled:(UISwitch *)sender {
+    HAStreamingManager *manager = [HAStreamingManager sharedManager];
+    if (!sender.isOn) {
+        [manager stopWithTrigger:HAStreamingStopTriggerUser error:nil];
+        [manager setFeatureEnabled:NO error:nil];
+        [self updateLiveStreamingStatus];
+        return;
+    }
+
+    NSError *error = nil;
+    if (![manager setFeatureEnabled:YES error:&error]) {
+        sender.on = NO;
+        [self showLiveStreamingError:error];
+        return;
+    }
+    sender.enabled = NO;
+    [manager armLocalStreamWithCompletion:^(BOOL success, NSError *startError) {
+        sender.enabled = YES;
+        if (!success) {
+            BOOL temporarilyAway = manager.featureEnabled &&
+                [UIApplication sharedApplication].applicationState != UIApplicationStateActive;
+            if (!temporarilyAway) {
+                sender.on = NO;
+                [manager setFeatureEnabled:NO error:nil];
+                [self showLiveStreamingError:startError];
+            }
+        }
+        [self updateLiveStreamingStatus];
+    }];
+}
+
+- (void)liveStreamingCameraChanged:(UISegmentedControl *)sender {
+    HAStreamingManager *manager = [HAStreamingManager sharedManager];
+    NSError *error = nil;
+    if (![manager setCameraMode:(HAStreamingCameraMode)sender.selectedSegmentIndex error:&error]) {
+        sender.selectedSegmentIndex = manager.cameraMode;
+        [self showLiveStreamingError:error];
+    }
+    [self updateLiveStreamingStatus];
+}
+
+- (void)liveStreamingQualityPreviewChanged:(UISlider *)sender {
+    self.liveStreamingQualityLabel.text = [[HAStreamingManager sharedManager] qualityDescriptionForScale:sender.value];
+    [self.liveStreamingQualityDebounceTimer invalidate];
+    self.liveStreamingQualityDebounceTimer = [NSTimer scheduledTimerWithTimeInterval:0.35
+        target:self selector:@selector(commitDebouncedStreamingQuality:) userInfo:nil repeats:NO];
+}
+
+- (void)commitDebouncedStreamingQuality:(NSTimer *)timer {
+    (void)timer;
+    [self liveStreamingQualityCommitted:self.liveStreamingQualitySlider];
+}
+
+- (void)liveStreamingQualityCommitted:(UISlider *)sender {
+    [self.liveStreamingQualityDebounceTimer invalidate];
+    self.liveStreamingQualityDebounceTimer = nil;
+    HAStreamingManager *manager = [HAStreamingManager sharedManager];
+    NSError *error = nil;
+    if (![manager setQualityScale:sender.value error:&error]) {
+        sender.value = manager.qualityScale;
+        [self showLiveStreamingError:error];
+    }
+    [self updateLiveStreamingStatus];
+}
+
+- (void)copyLiveStreamURL:(UITapGestureRecognizer *)gesture {
+    (void)gesture;
+    NSArray<NSString *> *urls = [HAStreamingManager sharedManager].streamURLs;
+    if (urls.count == 0) return;
+    [UIPasteboard generalPasteboard].string = [urls componentsJoinedByString:@"\n"];
+    [HAToastView showInView:self.view message:urls.count > 1 ? @"RTSP URLs copied" : @"RTSP URL copied" subtitle:nil duration:1.5 tapAction:nil];
+}
+
+- (void)liveStreamingAccessTapped:(UIButton *)sender {
+    NSError *credentialError = nil;
+    HARTSPCredentials *credentials = [[HARTSPCredentialManager sharedManager]
+        credentialsWithError:&credentialError];
+    if (!credentials) {
+        [self showLiveStreamingError:credentialError];
+        return;
+    }
+    HAStreamingManager *stream = [HAStreamingManager sharedManager];
+    UIAlertController *menu = [UIAlertController alertControllerWithTitle:@"Protected Stream Access"
+        message:@"Each device has its own strong password. When Register with Home Assistant is enabled, Home Assistant receives it over HTTPS or automatically over a local-network HTTP connection. On HTTP, that password is sent without transport encryption. RTSP media also remains plaintext on your trusted local network."
+        preferredStyle:UIAlertControllerStyleActionSheet];
+    if (stream.streamURLs.count > 0) {
+        [menu addAction:[UIAlertAction actionWithTitle:@"Copy URL with Password"
+            style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+                (void)action;
+                NSMutableArray<NSString *> *protectedURLs = [NSMutableArray array];
+                for (NSString *URL in stream.streamURLs) {
+                    if ([URL hasPrefix:@"rtsp://"]) {
+                        [protectedURLs addObject:[NSString stringWithFormat:@"rtsp://%@:%@@%@",
+                            credentials.username, credentials.password, [URL substringFromIndex:7]]];
+                    }
+                }
+                NSString *sensitiveValue = [protectedURLs componentsJoinedByString:@"\n"];
+                UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
+                NSDate *expiration = [NSDate dateWithTimeIntervalSinceNow:60.0];
+                if (@available(iOS 10.0, *)) {
+                    // System-managed expiration continues while this process is
+                    // suspended, and local-only prevents Universal Clipboard
+                    // from propagating the stream password to another device.
+                    [pasteboard setItems:@[@{@"public.utf8-plain-text": sensitiveValue}]
+                                 options:@{
+                                     UIPasteboardOptionExpirationDate: expiration,
+                                     UIPasteboardOptionLocalOnly: @YES,
+                                 }];
+                } else {
+                    // Local Camera Stream is unavailable before iOS 10.3.3;
+                    // retain a defensive fallback for compile-time portability.
+                    pasteboard.string = sensitiveValue;
+                }
+                self.sensitiveStreamPasteboardChangeCount = pasteboard.changeCount;
+                self.sensitiveStreamPasteboardExpiry = expiration;
+                [HAToastView showInView:self.view message:@"Sensitive connection URL copied"
+                    subtitle:@"Local clipboard item expires in 60 seconds" duration:2.5 tapAction:nil];
+                __weak typeof(self) weakSelf = self;
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(60 * NSEC_PER_SEC)),
+                    dispatch_get_main_queue(), ^{
+                        [weakSelf clearSensitiveStreamPasteboardIfExpired];
+                    });
+            }]];
+    }
+    [menu addAction:[UIAlertAction actionWithTitle:@"Rotate Stream Password"
+        style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
+            (void)action;
+            [self confirmStreamCredentialRotation];
+        }]];
+    [menu addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    menu.popoverPresentationController.sourceView = sender;
+    menu.popoverPresentationController.sourceRect = sender.bounds;
+    [self presentViewController:menu animated:YES completion:nil];
+}
+
+- (void)clearSensitiveStreamPasteboardIfExpired {
+    if (!self.sensitiveStreamPasteboardExpiry ||
+        [self.sensitiveStreamPasteboardExpiry timeIntervalSinceNow] > 0) return;
+    [self clearSensitiveStreamPasteboardIfUnchanged];
+}
+
+- (void)clearExpiredSensitiveStreamPasteboardAfterActivation:(NSNotification *)notification {
+    (void)notification;
+    [self clearSensitiveStreamPasteboardIfExpired];
+}
+
+- (void)clearSensitiveStreamPasteboardIfUnchanged {
+    if (!self.sensitiveStreamPasteboardExpiry) return;
+    UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
+    if (pasteboard.changeCount == self.sensitiveStreamPasteboardChangeCount) {
+        pasteboard.string = @"";
+    }
+    self.sensitiveStreamPasteboardExpiry = nil;
+    self.sensitiveStreamPasteboardChangeCount = 0;
+}
+
+- (void)confirmStreamCredentialRotation {
+    UIAlertController *confirmation = [UIAlertController alertControllerWithTitle:@"Rotate Stream Password?"
+        message:@"Current clients will disconnect immediately. The protected listener re-arms with the new password first. The app then attempts to update app-owned Home Assistant camera entries asynchronously and retries transient failures while the same stream, registration setting, account, and server remain active. Manual clients will need the new URL."
+        preferredStyle:UIAlertControllerStyleAlert];
+    [confirmation addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    [confirmation addAction:[UIAlertAction actionWithTitle:@"Rotate" style:UIAlertActionStyleDestructive
+        handler:^(UIAlertAction *action) {
+            (void)action;
+            self.liveStreamingAccessButton.enabled = NO;
+            [[HAStreamingManager sharedManager] rotateStreamCredentialWithCompletion:^(BOOL success, NSError *error) {
+                self.liveStreamingAccessButton.enabled = YES;
+                if (!success) [self showLiveStreamingError:error];
+                else {
+                    BOOL registrationCanUpdate = [HADeviceIntegrationManager sharedManager].enabled &&
+                        [HACameraRegistrationManager sharedManager].automaticRegistrationTransportAllowed;
+                    NSString *subtitle = registrationCanUpdate
+                        ? @"Home Assistant update follows; Settings shows progress"
+                        : @"Manual clients need the new protected URL";
+                    [HAToastView showInView:self.view message:@"Stream password rotated"
+                        subtitle:subtitle duration:2.5 tapAction:nil];
+                }
+                [self updateLiveStreamingStatus];
+            }];
+        }]];
+    [self presentViewController:confirmation animated:YES completion:nil];
+}
+
+- (void)showLiveStreamingError:(NSError *)error { UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Local Camera Stream" message:error.localizedDescription preferredStyle:UIAlertControllerStyleAlert]; [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]]; [self presentViewController:alert animated:YES completion:nil]; }
+
+- (void)liveStreamingStateChanged:(NSNotification *)notification {
+    (void)notification;
+    dispatch_async(dispatch_get_main_queue(), ^{ [self updateLiveStreamingStatus]; });
+}
+
+- (void)updateLiveStreamingStatus {
+    HAStreamingManager *manager = [HAStreamingManager sharedManager];
+    self.liveStreamingSwitch.on = manager.featureEnabled;
+    self.liveStreamingSwitch.enabled = manager.supported;
+    self.liveStreamingCameraSegment.selectedSegmentIndex = manager.cameraMode;
+    self.liveStreamingQualitySlider.value = manager.qualityScale;
+    self.liveStreamingQualityLabel.text = manager.qualityDescription;
+    // Keep recovery available if the persistent toggle is on but listener
+    // arming failed because a stale or damaged credential could not be read.
+    self.liveStreamingAccessButton.enabled = manager.supported && manager.featureEnabled;
+    if (!manager.supported) {
+        self.liveStreamingStatusLabel.text = @"Requires iOS 10.3.3 or newer.";
+    } else if (manager.streaming && manager.secondaryStreamURL.length) {
+        NSString *state = manager.isCapturing
+            ? [NSString stringWithFormat:@"CAMERA + MIC LIVE · %lu authenticated %@",
+                (unsigned long)manager.streamClientCount, manager.streamClientCount == 1 ? @"client" : @"clients"]
+            : @"PROTECTED · Camera off · Waiting for authenticated viewer";
+        self.liveStreamingStatusLabel.text = [NSString stringWithFormat:@"%@\nFRONT %@\nREAR %@\nTap an address to copy it without credentials.",
+            state, manager.streamURL ?: @"", manager.secondaryStreamURL];
+    } else if (manager.streaming) {
+        NSString *camera = manager.cameraMode == HAStreamingCameraModeRear ? @"REAR" : @"FRONT";
+        NSString *state = manager.isCapturing
+            ? [NSString stringWithFormat:@"CAMERA + MIC LIVE · %lu authenticated %@",
+                (unsigned long)manager.streamClientCount, manager.streamClientCount == 1 ? @"client" : @"clients"]
+            : @"PROTECTED · Camera off · Waiting for authenticated viewer";
+        self.liveStreamingStatusLabel.text = [NSString stringWithFormat:@"%@\n%@ %@\nTap the address to copy it without credentials.",
+            state, camera, manager.streamURL ?: @""];
+    } else if (manager.featureEnabled) {
+        self.liveStreamingStatusLabel.text = @"Protected stream is re-arming.";
+    } else {
+        self.liveStreamingStatusLabel.text = @"Off · A unique device password is retained for the next use.";
+    }
+    HACameraRegistrationManager *registration = [HACameraRegistrationManager sharedManager];
+    if ([HADeviceIntegrationManager sharedManager].enabled && manager.streaming) {
+        if (registration.isRetryScheduled) {
+            NSString *retryStatus = [NSString stringWithFormat:
+                @"\nHome Assistant: retry %lu in %.0f s.",
+                (unsigned long)registration.retryAttempt,
+                registration.scheduledRetryDelay];
+            if (registration.lastError.localizedDescription.length) {
+                retryStatus = [retryStatus stringByAppendingFormat:@"\nLast error: %@",
+                    registration.lastError.localizedDescription];
+            }
+            self.liveStreamingStatusLabel.text = [self.liveStreamingStatusLabel.text
+                stringByAppendingString:retryStatus];
+        } else if (registration.isRegistering) {
+            NSString *registeringStatus = registration.retryAttempt > 0
+                ? [NSString stringWithFormat:@"\nHome Assistant: registering camera (retry %lu)…",
+                    (unsigned long)registration.retryAttempt]
+                : @"\nHome Assistant: registering camera…";
+            if (registration.retryAttempt > 0 && registration.lastError.localizedDescription.length) {
+                registeringStatus = [registeringStatus stringByAppendingFormat:@"\nLast error: %@",
+                    registration.lastError.localizedDescription];
+            }
+            self.liveStreamingStatusLabel.text = [self.liveStreamingStatusLabel.text
+                stringByAppendingString:registeringStatus];
+        } else if (registration.lastError) {
+            self.liveStreamingStatusLabel.text = [self.liveStreamingStatusLabel.text
+                stringByAppendingFormat:@"\nHome Assistant: %@", registration.lastError.localizedDescription];
+        }
+    }
+    if (manager.supported) {
+        self.liveStreamingStatusLabel.text = [self.liveStreamingStatusLabel.text
+            stringByAppendingString:@"\nSecurity: RTSP media and camera-password registration to a local HTTP Home Assistant server are plaintext on your LAN."];
+    }
 }
 
 #pragma mark - Section Helpers
@@ -562,7 +948,10 @@ static NSString *const kDeviceNameOverride    = @"ha_device_name_override";
     [regRow addSubview:regLabel];
 
     self.registrationSwitch = [[HASwitch alloc] init];
-    self.registrationSwitch.on = [HADeviceRegistration sharedManager].isRegistered;
+    // Reflect the persisted user intent, not only whether the latest webhook
+    // registration has completed. This prevents the toggle appearing to turn
+    // itself off while Home Assistant is temporarily unreachable.
+    self.registrationSwitch.on = [HADeviceIntegrationManager sharedManager].enabled;
     self.registrationSwitch.onTintColor = [HATheme switchTintColor];
     [self.registrationSwitch addTarget:self action:@selector(registrationSwitchToggled:) forControlEvents:UIControlEventValueChanged];
     self.registrationSwitch.translatesAutoresizingMaskIntoConstraints = NO;
@@ -611,15 +1000,23 @@ static NSString *const kDeviceNameOverride    = @"ha_device_name_override";
 
 - (void)updateRegistrationStatus {
     HADeviceRegistration *reg = [HADeviceRegistration sharedManager];
-    if (reg.isRegistered) {
-        NSString *truncatedId = reg.webhookId;
-        if (truncatedId.length > 12) {
-            truncatedId = [NSString stringWithFormat:@"%@\u2026", [truncatedId substringToIndex:12]];
-        }
-        self.registrationStatusLabel.text = [NSString stringWithFormat:@"Registered \u2014 Webhook: %@", truncatedId];
+    BOOL enabled = [HADeviceIntegrationManager sharedManager].enabled;
+    self.registrationSwitch.on = enabled;
+    if (!enabled) {
+        self.registrationStatusLabel.text = @"Off. Enable to send diagnostics to your Home Assistant, including battery, brightness, app/dashboard state, Wi-Fi identifiers when available, camera-stream status, and available storage only over a local webhook route.";
+    } else if (reg.isRegistered) {
+        self.registrationStatusLabel.text = @"Registered — device diagnostics and commands enabled.";
     } else {
-        self.registrationStatusLabel.text = @"Not registered. Enable to send device sensors to Home Assistant.";
+        self.registrationStatusLabel.text = @"Registration is enabled but not complete. HA Dashboard will retry when it reconnects to Home Assistant.";
     }
+}
+
+- (void)deviceRegistrationStateChanged:(NSNotification *)notification {
+    (void)notification;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self updateRegistrationStatus];
+        [self updateLiveStreamingStatus];
+    });
 }
 
 #pragma mark - Device Integration Actions
@@ -634,6 +1031,35 @@ static NSString *const kDeviceNameOverride    = @"ha_device_name_override";
                 // Enable integration manager so sensors start reporting
                 [HADeviceIntegrationManager sharedManager].enabled = YES;
                 [self updateRegistrationStatus];
+                HAStreamingManager *stream = [HAStreamingManager sharedManager];
+                if (stream.streaming && stream.streamURLs.count > 0) {
+                    NSError *credentialError = nil;
+                    HARTSPCredentials *credentials = [[HARTSPCredentialManager sharedManager]
+                        credentialsWithError:&credentialError];
+                    if (!credentials) {
+                        self.registrationStatusLabel.text = [NSString stringWithFormat:
+                            @"Registered — protected camera credentials failed: %@",
+                            credentialError.localizedDescription ?: @"Unknown error"];
+                        return;
+                    }
+                    self.registrationStatusLabel.text = @"Registered — adding camera entries…";
+                    [[HACameraRegistrationManager sharedManager]
+                        ensureCameraEntriesForStreamURLs:stream.streamURLs
+                        deviceName:[HADeviceRegistration sharedManager].deviceName
+                        username:credentials.username
+                        password:credentials.password
+                        credentialRevision:credentials.revision
+                        framesPerSecond:stream.targetFrameRate
+                        completion:^(BOOL cameraSuccess, NSError *cameraError) {
+                            if (cameraSuccess) {
+                                [self updateRegistrationStatus];
+                            } else {
+                                self.registrationStatusLabel.text = [NSString stringWithFormat:
+                                    @"Registered — camera entry failed: %@",
+                                    cameraError.localizedDescription ?: @"Unknown error"];
+                            }
+                        }];
+                }
             } else {
                 sender.on = NO;
                 self.registrationStatusLabel.text = [NSString stringWithFormat:@"Registration failed: %@",
@@ -658,11 +1084,8 @@ static NSString *const kDeviceNameOverride    = @"ha_device_name_override";
 
     // Push name change to HA if registered
     if ([HADeviceRegistration sharedManager].isRegistered) {
-        NSDictionary *update = @{
-            @"device_name": [HADeviceRegistration sharedManager].deviceName,
-            @"app_version": [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"] ?: @"0.0.0",
-        };
-        [[HADeviceRegistration sharedManager] sendWebhookWithType:@"update_registration" data:update completion:nil];
+        [[HADeviceRegistration sharedManager]
+            updateRegistrationMetadataWithCompletion:nil];
     }
 }
 
@@ -987,12 +1410,18 @@ static NSString *const kDeviceNameOverride    = @"ha_device_name_override";
 
 - (void)logoutTapped {
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Log Out & Reset"
-        message:@"This will remove all saved credentials, settings, and return the app to its initial state."
+        message:@"This removes locally saved credentials, registration data, settings, cached dashboard data, and logs, then returns the app to its initial state. Home Assistant devices and camera entries remain on your server until you remove them there."
         preferredStyle:UIAlertControllerStyleAlert];
     [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
     [alert addAction:[UIAlertAction actionWithTitle:@"Log Out" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
-        [[HAConnectionManager sharedManager] disconnect];
+        HAConnectionManager *connection = [HAConnectionManager sharedManager];
+        [connection disconnect];
+        [connection clearEntityStore];
+        [[HAEntityStateCache sharedCache] discardPendingWrites];
+        [[HAHistoryManager sharedManager] clearCache];
+        [[HACacheManager sharedManager] clearAllServerCaches];
         [[HAAuthManager sharedManager] clearCredentials];
+        [HALog clearLogs];
 
         // Navigate to login screen
         HALoginViewController *loginVC = [[HALoginViewController alloc] init];

--- a/HADashboard/HAAppDelegate.h
+++ b/HADashboard/HAAppDelegate.h
@@ -4,4 +4,13 @@
 
 @property (strong, nonatomic) UIWindow *window;
 
+/// Used by the iOS 13+/Catalyst scene delegate. iOS 9–12 continue to create
+/// the same window directly from application:didFinishLaunchingWithOptions:.
+- (void)configureInitialInterfaceInWindow:(UIWindow *)window;
+
+/// Scene-based apps do not deliver their foreground transition through the
+/// application delegate. Both lifecycle entry points use this shared method.
+- (void)resumeForegroundServices;
+- (void)suspendForegroundServices;
+
 @end

--- a/HADashboard/HAAppDelegate.m
+++ b/HADashboard/HAAppDelegate.m
@@ -13,6 +13,7 @@
 #import "HAEntityStateCache.h"
 #import "HADeviceIntegrationManager.h"
 #import "HADeviceRegistration.h"
+#import "HAStreamingManager.h"
 
 /// Window subclass that detects system appearance changes (iOS 13+) and posts
 /// HAThemeDidChangeNotification so every view/VC refreshes — not just the
@@ -67,6 +68,7 @@
 @end
 
 @interface HAAppDelegate ()
+@property (nonatomic, strong) UIButton *streamPrivacyIndicator;
 @end
 
 @implementation HAAppDelegate
@@ -91,11 +93,6 @@
     [HALog logStartup:@"warmFonts BEGIN"];
     [HAIconMapper warmFonts];
     [HALog logStartup:@"warmFonts END"];
-
-    [HALog logStartup:@"UIWindow alloc BEGIN"];
-    self.window = [[HAThemeAwareWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-    self.window.backgroundColor = [UIColor whiteColor];
-    [HALog logStartup:@"UIWindow alloc END"];
 
     // Bootstrap credentials from launch arguments (for simulator/testing):
     //   -HAServerURL http://... -HAAccessToken eyJ... -HADashboard office
@@ -157,6 +154,44 @@
         }
     }
 
+    // Legacy SSH deployment writes launch overrides into the app preference
+    // plist because it cannot pass process arguments. Consume those values
+    // once, after their durable equivalents have been saved, so an access
+    // token or reset flag is never left in NSUserDefaults across launches.
+    NSArray<NSString *> *bootstrapKeys = @[
+        @"HAClearCredentials", @"HAServerURL", @"HAAccessToken", @"HADashboard",
+        @"HAKioskMode", @"HAThemeMode", @"HAGradientEnabled", @"HADemoMode",
+        @"HAAutoRegister",
+    ];
+    for (NSString *key in bootstrapKeys) [defaults removeObjectForKey:key];
+    [defaults synchronize];
+
+    if (@available(iOS 13.0, *)) {
+        // A scene delegate will create the window. Deferring this prevents the
+        // app-delegate window from being detached from Catalyst's scene.
+        [HALog logStartup:@"Waiting for scene delegate window"];
+    } else {
+        [HALog logStartup:@"UIWindow alloc BEGIN"];
+        HAThemeAwareWindow *window = [[HAThemeAwareWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+        [HALog logStartup:@"UIWindow alloc END"];
+        [self configureInitialInterfaceInWindow:window];
+    }
+
+    [[HAPerfMonitor sharedMonitor] start];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+        selector:@selector(streamingStateDidChange:)
+        name:HAStreamingManagerStateDidChangeNotification object:nil];
+
+    [HALog logStartup:@"didFinishLaunching END"];
+    return YES;
+}
+
+- (void)configureInitialInterfaceInWindow:(UIWindow *)window {
+    if (!window || self.window.rootViewController) return;
+    self.window = window;
+    self.window.backgroundColor = [UIColor whiteColor];
+
     [HALog logStartup:@"isConfigured check BEGIN"];
     BOOL configured = [[HAAuthManager sharedManager] isConfigured];
     HALogI(@"startup", @"isConfigured=%@", configured ? @"YES" : @"NO");
@@ -177,21 +212,78 @@
     [HALog logStartup:@"makeKeyAndVisible BEGIN"];
     [self.window makeKeyAndVisible];
     [HALog logStartup:@"makeKeyAndVisible END"];
+    [self installStreamPrivacyIndicator];
 
     // Apply the saved theme's interface style to the window so the nav bar,
     // status bar, and all dynamic colors match the selected theme from launch.
     [HATheme applyInterfaceStyle];
+}
 
-    [[HAPerfMonitor sharedMonitor] start];
+- (void)installStreamPrivacyIndicator {
+    [self.streamPrivacyIndicator removeFromSuperview];
+    UIButton *indicator = [UIButton buttonWithType:UIButtonTypeCustom];
+    indicator.translatesAutoresizingMaskIntoConstraints = NO;
+    indicator.backgroundColor = [UIColor colorWithRed:0.78 green:0.08 blue:0.10 alpha:0.96];
+    indicator.layer.cornerRadius = 15.0;
+    indicator.titleLabel.font = [UIFont boldSystemFontOfSize:12.0];
+    indicator.contentEdgeInsets = UIEdgeInsetsMake(6, 12, 6, 12);
+    indicator.accessibilityLabel = @"Camera and microphone are live. Tap to stop streaming.";
+    [indicator addTarget:self action:@selector(streamPrivacyIndicatorTapped:)
+        forControlEvents:UIControlEventTouchUpInside];
+    [self.window addSubview:indicator];
+    NSLayoutYAxisAnchor *topAnchor;
+    if (@available(iOS 11.0, *)) topAnchor = self.window.safeAreaLayoutGuide.topAnchor;
+    else topAnchor = self.window.topAnchor;
+    [NSLayoutConstraint activateConstraints:@[
+        [indicator.centerXAnchor constraintEqualToAnchor:self.window.centerXAnchor],
+        [indicator.topAnchor constraintEqualToAnchor:topAnchor constant:8.0],
+        [indicator.heightAnchor constraintGreaterThanOrEqualToConstant:30.0],
+    ]];
+    self.streamPrivacyIndicator = indicator;
+    [self updateStreamPrivacyIndicator];
+}
 
-    [HALog logStartup:@"didFinishLaunching END"];
-    return YES;
+- (void)streamingStateDidChange:(NSNotification *)notification {
+    (void)notification;
+    dispatch_async(dispatch_get_main_queue(), ^{ [self updateStreamPrivacyIndicator]; });
+}
+
+- (void)updateStreamPrivacyIndicator {
+    HAStreamingManager *stream = [HAStreamingManager sharedManager];
+    NSUInteger clients = stream.streamClientCount;
+    BOOL live = stream.isCapturing && clients > 0;
+    self.streamPrivacyIndicator.hidden = !live;
+    if (live) {
+        NSString *title = [NSString stringWithFormat:@"Camera + mic live · %lu authenticated %@",
+            (unsigned long)clients, clients == 1 ? @"client" : @"clients"];
+        [self.streamPrivacyIndicator setTitle:title forState:UIControlStateNormal];
+        [self.window bringSubviewToFront:self.streamPrivacyIndicator];
+    }
+}
+
+- (void)streamPrivacyIndicatorTapped:(UIButton *)sender {
+    (void)sender;
+    HAStreamingManager *stream = [HAStreamingManager sharedManager];
+    [stream stopWithTrigger:HAStreamingStopTriggerUser error:nil];
+    [stream setFeatureEnabled:NO error:nil];
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
+    (void)application;
+    [self resumeForegroundServices];
+}
+
+- (void)resumeForegroundServices {
     if ([[HAAuthManager sharedManager] isConfigured]) {
         [[HAConnectionManager sharedManager] connect];
         [[HADeviceIntegrationManager sharedManager] start];
+    }
+
+    // The user-visible Local Camera Stream toggle is persistent consent. A
+    // foreground return resumes it; resigning active always stops capture.
+    HAStreamingManager *localStream = [HAStreamingManager sharedManager];
+    if (localStream.featureEnabled && !localStream.streaming) {
+        [localStream armLocalStreamWithCompletion:nil];
     }
 
     // Request Guided Access if kiosk mode is on and not already in Guided Access.
@@ -211,6 +303,11 @@
 }
 
 - (void)applicationWillResignActive:(UIApplication *)application {
+    (void)application;
+    [self suspendForegroundServices];
+}
+
+- (void)suspendForegroundServices {
     [[HAPerfMonitor sharedMonitor] stop];
     // Flush entity state cache to disk synchronously before disconnect
     [[HADeviceIntegrationManager sharedManager] stop];

--- a/HADashboard/HAAppSceneDelegate.h
+++ b/HADashboard/HAAppSceneDelegate.h
@@ -1,0 +1,8 @@
+#import <UIKit/UIKit.h>
+
+/// iOS 13+/Catalyst scene owner. The class is absent from the iOS 9–12 launch
+/// path and delegates root-controller construction to HAAppDelegate.
+API_AVAILABLE(ios(13.0))
+@interface HAAppSceneDelegate : UIResponder <UIWindowSceneDelegate>
+@property (nonatomic, strong) UIWindow *window;
+@end

--- a/HADashboard/HAAppSceneDelegate.m
+++ b/HADashboard/HAAppSceneDelegate.m
@@ -1,0 +1,35 @@
+#import "HAAppSceneDelegate.h"
+#import "HAAppDelegate.h"
+
+@implementation HAAppSceneDelegate
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session
+     options:(UISceneConnectionOptions *)connectionOptions {
+    (void)session;
+    (void)connectionOptions;
+    if (![scene isKindOfClass:[UIWindowScene class]]) return;
+    if (!self.window) {
+        self.window = [[UIWindow alloc] initWithWindowScene:(UIWindowScene *)scene];
+    }
+    HAAppDelegate *appDelegate = (HAAppDelegate *)[UIApplication sharedApplication].delegate;
+    [appDelegate configureInitialInterfaceInWindow:self.window];
+}
+
+- (void)sceneDidBecomeActive:(UIScene *)scene {
+    (void)scene;
+    // UIKit delivers this callback while applicationState may still be
+    // Inactive. Defer one main-loop turn so the foreground-only stream can
+    // arm itself without treating a normal launch as an invalid request.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        HAAppDelegate *appDelegate = (HAAppDelegate *)[UIApplication sharedApplication].delegate;
+        [appDelegate resumeForegroundServices];
+    });
+}
+
+- (void)sceneWillResignActive:(UIScene *)scene {
+    (void)scene;
+    HAAppDelegate *appDelegate = (HAAppDelegate *)[UIApplication sharedApplication].delegate;
+    [appDelegate suspendForegroundServices];
+}
+
+@end

--- a/HADashboard/HADashboard-Catalyst.entitlements
+++ b/HADashboard/HADashboard-Catalyst.entitlements
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.device.microphone</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	</array>
+</dict>
+</plist>

--- a/HADashboard/Info.plist
+++ b/HADashboard/Info.plist
@@ -32,7 +32,28 @@
 		<string>_home-assistant._tcp</string>
 	</array>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Discover Home Assistant servers on your network</string>
+	<string>Discover Home Assistant servers and host explicitly enabled camera and microphone streams for RTSP clients that connect to this device.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Allow HA Dashboard to stream live video to RTSP clients while Local Camera Stream is enabled.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Allow HA Dashboard to include live audio in Local Camera Streams you enable.</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>HAAppSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>materialdesignicons-webfont.ttf</string>

--- a/HADashboard/Integration/HARemoteCommandHandler.m
+++ b/HADashboard/Integration/HARemoteCommandHandler.m
@@ -46,16 +46,28 @@ NSString *const HARemoteCommandReloadNotification = @"HARemoteCommandReloadNotif
         @"support_confirm": @YES,
     };
     __weak typeof(self) weakSelf = self;
-    self.subscriptionId = [cm subscribeWithCommand:command
-                                           handler:^(NSDictionary *eventData) {
+    __block NSInteger requestedSubscriptionId = 0;
+    requestedSubscriptionId = [cm subscribeWithCommand:command
+                                               handler:^(NSDictionary *eventData) {
         [weakSelf handleNotificationEvent:eventData];
+    } completion:^(BOOL success, NSError *error) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        if (!success) {
+            if (strongSelf.subscriptionId == requestedSubscriptionId) {
+                strongSelf.subscriptionId = 0;
+            }
+            HALogE(@"cmd", @"Home Assistant rejected the local push channel: %@",
+                   error.localizedDescription ?: @"Unknown error");
+            return;
+        }
+        HALogI(@"cmd", @"Push notification channel accepted (id=%ld, webhook credential redacted)",
+               (long)requestedSubscriptionId);
     }];
+    self.subscriptionId = requestedSubscriptionId;
 
     if (self.subscriptionId == 0) {
         HALogE(@"cmd", @"Failed to open push channel (not connected)");
-    } else {
-        HALogI(@"cmd", @"Push notification channel open (id=%ld, webhook=%@)",
-              (long)self.subscriptionId, webhookId);
     }
 }
 
@@ -130,9 +142,10 @@ NSString *const HARemoteCommandReloadNotification = @"HARemoteCommandReloadNotif
 - (void)dispatchCommand:(NSString *)command data:(NSDictionary *)data {
     HALogI(@"cmd", @"Dispatching command: %@", command);
 
-    if ([command isEqualToString:@"command_screen_brightness_level"] ||
-        [command isEqualToString:@"set_brightness"]) {
-        [self handleSetBrightness:data];
+    if ([command isEqualToString:@"command_screen_brightness_level"]) {
+        [self handleSetBrightness:data companionStyle:YES];
+    } else if ([command isEqualToString:@"set_brightness"]) {
+        [self handleSetBrightness:data companionStyle:NO];
     } else if ([command isEqualToString:@"command_screen_on"]) {
         [self handleScreenOn];
     } else if ([command isEqualToString:@"command_screen_off"]) {
@@ -162,22 +175,22 @@ NSString *const HARemoteCommandReloadNotification = @"HARemoteCommandReloadNotif
 
 #pragma mark - Command Handlers
 
-- (void)handleSetBrightness:(NSDictionary *)data {
-    // Accept "level" (0-100) or "brightness" (0-255 companion style)
-    NSNumber *level = data[@"level"];
-    if (!level) level = data[@"brightness"];
-    if (!level) {
-        // Companion style: brightness is in the command data at top level
-        level = data[@"command_screen_brightness_level"];
+- (void)handleSetBrightness:(NSDictionary *)data companionStyle:(BOOL)companionStyle {
+    // Home Assistant's standard command uses data.command on a 0-255 scale.
+    // The app's custom set_brightness route keeps explicit percentage `level`
+    // and 0-255 `brightness` variants for existing automations.
+    NSNumber *level = companionStyle ? data[@"command"] : data[@"level"];
+    BOOL usesByteScale = companionStyle;
+    if (!level && !companionStyle) {
+        level = data[@"brightness"];
+        usesByteScale = level != nil;
     }
     if (![level isKindOfClass:[NSNumber class]]) return;
 
     CGFloat value = [level floatValue];
-    // Normalize: if > 1 assume 0-100 or 0-255 scale
-    if (value > 1.0) {
-        value = value > 100 ? value / 255.0 : value / 100.0;
-    }
-    value = fminf(fmaxf(value, 0.0), 1.0);
+    if (usesByteScale) value /= 255.0;
+    else if (value > 1.0) value /= 100.0;
+    value = fminf(fmaxf(value, 0.0f), 1.0f);
 
     if ([self usesProximityWake]) {
         [[NSNotificationCenter defaultCenter]

--- a/HADashboard/Integration/HASensorReporter.m
+++ b/HADashboard/Integration/HASensorReporter.m
@@ -7,6 +7,7 @@
 #import <netinet/in.h>
 #import "HADeviceRegistration.h"
 #import "HAAuthManager.h"
+#import "HAStreamingManager.h"
 
 /// Sensor unique IDs (must match what we register).
 static NSString *const kSensorBatteryLevel      = @"battery_level";
@@ -20,6 +21,7 @@ static NSString *const kSensorWifiBSSID         = @"wifi_bssid";
 static NSString *const kSensorConnectionType    = @"connection_type";
 static NSString *const kSensorLastUpdateTrigger = @"last_update_trigger";
 static NSString *const kSensorDeviceModel       = @"device_model";
+static NSString *const kSensorCameraStream      = @"camera_stream";
 
 extern NSString *const HAConnectionManagerDidReceiveLovelaceNotification;
 
@@ -27,7 +29,7 @@ static NSArray *allSensorIds(void) {
     return @[kSensorBatteryLevel, kSensorBatteryState, kSensorScreenBrightness,
              kSensorStorage, kSensorAppState, kSensorActiveDashboard,
              kSensorWifiSSID, kSensorWifiBSSID, kSensorConnectionType,
-             kSensorLastUpdateTrigger, kSensorDeviceModel];
+             kSensorLastUpdateTrigger, kSensorDeviceModel, kSensorCameraStream];
 }
 
 @interface HASensorReporter ()
@@ -51,7 +53,12 @@ static NSArray *allSensorIds(void) {
     [self registerSensorWithId:kSensorBatteryLevel     name:@"Battery Level"     deviceClass:@"battery" unit:@"%" stateClass:@"measurement" icon:@"mdi:battery"];
     [self registerSensorWithId:kSensorBatteryState     name:@"Battery State"     deviceClass:nil        unit:nil  stateClass:nil            icon:@"mdi:battery-charging"];
     [self registerSensorWithId:kSensorScreenBrightness name:@"Screen Brightness" deviceClass:nil        unit:@"%" stateClass:@"measurement" icon:@"mdi:brightness-6"];
-    [self registerSensorWithId:kSensorStorage          name:@"Storage Available" deviceClass:nil        unit:@"GB" stateClass:@"measurement" icon:@"mdi:harddisk"];
+    if ([[HADeviceRegistration sharedManager] resolvedWebhookUsesLocalNetwork]) {
+        // Apple's required-reason policy permits displaying disk-space data on
+        // another user-operated device over the local network, but not sending
+        // it over an HA Cloud/remote webhook route.
+        [self registerSensorWithId:kSensorStorage      name:@"Storage Available" deviceClass:nil        unit:@"GB" stateClass:@"measurement" icon:@"mdi:harddisk"];
+    }
     [self registerSensorWithId:kSensorAppState         name:@"App State"         deviceClass:nil        unit:nil  stateClass:nil            icon:@"mdi:application"];
     [self registerSensorWithId:kSensorActiveDashboard  name:@"Active Dashboard"  deviceClass:nil        unit:nil  stateClass:nil            icon:@"mdi:view-dashboard"];
     [self registerSensorWithId:kSensorWifiSSID          name:@"WiFi SSID"         deviceClass:nil        unit:nil  stateClass:nil            icon:@"mdi:wifi"];
@@ -59,6 +66,7 @@ static NSArray *allSensorIds(void) {
     [self registerSensorWithId:kSensorConnectionType    name:@"Connection Type"   deviceClass:nil        unit:nil  stateClass:nil            icon:@"mdi:network"];
     [self registerSensorWithId:kSensorLastUpdateTrigger name:@"Last Update Trigger" deviceClass:nil      unit:nil  stateClass:nil            icon:@"mdi:update"];
     [self registerSensorWithId:kSensorDeviceModel       name:@"Device Model"      deviceClass:nil        unit:nil  stateClass:nil            icon:@"mdi:cellphone"];
+    [self registerSensorWithId:kSensorCameraStream      name:@"Camera Stream"     deviceClass:nil        unit:nil  stateClass:nil            icon:@"mdi:video-wireless"];
 }
 
 - (void)registerSensorWithId:(NSString *)uniqueId name:(NSString *)name
@@ -108,6 +116,8 @@ static NSArray *allSensorIds(void) {
                name:UIApplicationDidEnterBackgroundNotification object:nil];
     [nc addObserver:self selector:@selector(dashboardDidChange:)
                name:HAConnectionManagerDidReceiveLovelaceNotification object:nil];
+    [nc addObserver:self selector:@selector(cameraStreamDidChange:)
+               name:HAStreamingManagerStateDidChangeNotification object:nil];
 
     // Storage timer — every 15 minutes
     self.storageTimer = [NSTimer scheduledTimerWithTimeInterval:900.0
@@ -148,6 +158,7 @@ static NSArray *allSensorIds(void) {
     [self reportSensor:kSensorConnectionType];
 }
 - (void)dashboardDidChange:(NSNotification *)note        { [self reportSensor:kSensorActiveDashboard]; }
+- (void)cameraStreamDidChange:(NSNotification *)note     { [self reportSensor:kSensorCameraStream]; }
 - (void)storageTimerFired:(NSTimer *)timer               { [self reportSensor:kSensorStorage]; }
 
 #pragma mark - Reporting
@@ -157,12 +168,17 @@ static NSArray *allSensorIds(void) {
 
     NSMutableArray *batch = [NSMutableArray array];
     for (NSString *sensorId in allSensorIds()) {
-        [batch addObject:@{
+        if ([sensorId isEqualToString:kSensorStorage] &&
+            ![[HADeviceRegistration sharedManager] resolvedWebhookUsesLocalNetwork]) continue;
+        NSMutableDictionary *entry = [@{
             @"unique_id": sensorId,
             @"type": @"sensor",
             @"state": [self currentValueForSensor:sensorId],
             @"icon": [self iconForSensor:sensorId],
-        }];
+        } mutableCopy];
+        NSDictionary *attributes = [self attributesForSensor:sensorId];
+        if (attributes) entry[@"attributes"] = attributes;
+        [batch addObject:entry];
     }
 
     [[HADeviceRegistration sharedManager] sendWebhookWithType:@"update_sensor_states"
@@ -176,13 +192,17 @@ static NSArray *allSensorIds(void) {
 
 - (void)reportSensor:(NSString *)sensorId {
     if (![HADeviceRegistration sharedManager].isRegistered) return;
+    if ([sensorId isEqualToString:kSensorStorage] &&
+        ![[HADeviceRegistration sharedManager] resolvedWebhookUsesLocalNetwork]) return;
 
-    NSDictionary *entry = @{
+    NSMutableDictionary *entry = [@{
         @"unique_id": sensorId,
         @"type": @"sensor",
         @"state": [self currentValueForSensor:sensorId],
         @"icon": [self iconForSensor:sensorId],
-    };
+    } mutableCopy];
+    NSDictionary *attributes = [self attributesForSensor:sensorId];
+    if (attributes) entry[@"attributes"] = attributes;
 
     [[HADeviceRegistration sharedManager] sendWebhookWithType:@"update_sensor_states"
                                                          data:@[entry]
@@ -207,6 +227,7 @@ static NSArray *allSensorIds(void) {
     if ([sensorId isEqualToString:kSensorConnectionType])    return @"mdi:network";
     if ([sensorId isEqualToString:kSensorLastUpdateTrigger]) return @"mdi:update";
     if ([sensorId isEqualToString:kSensorDeviceModel])       return @"mdi:cellphone";
+    if ([sensorId isEqualToString:kSensorCameraStream])      return @"mdi:video-wireless";
     return @"mdi:cellphone";
 }
 
@@ -268,7 +289,33 @@ static NSArray *allSensorIds(void) {
     if ([sensorId isEqualToString:kSensorDeviceModel]) {
         return [self machineModel];
     }
+    if ([sensorId isEqualToString:kSensorCameraStream]) {
+        HAStreamingManager *stream = [HAStreamingManager sharedManager];
+        if (!stream.featureEnabled) return @"disabled";
+        return stream.streaming && stream.streamClientCount > 0 ? @"streaming" : (stream.streaming ? @"idle" : @"foreground_required");
+    }
     return @"unknown";
+}
+
+- (NSDictionary *)attributesForSensor:(NSString *)sensorId {
+    if (![sensorId isEqualToString:kSensorCameraStream]) return nil;
+    HAStreamingManager *stream = [HAStreamingManager sharedManager];
+    NSMutableDictionary *attributes = [@{
+        @"Transport": @"RTSP over TCP",
+        @"Authentication": @"Digest",
+        @"Authenticated Media Clients": @(stream.streamClientCount),
+        @"Playing Viewers": @(stream.streamPlayingClientCount),
+        @"Open Connections": @(stream.streamConnectionCount),
+    } mutableCopy];
+    if (stream.streamURL) attributes[@"Stream URL"] = stream.streamURL;
+    if (stream.secondaryStreamURL) attributes[@"Secondary Stream URL"] = stream.secondaryStreamURL;
+    NSString *mode = stream.cameraMode == HAStreamingCameraModeBoth ? @"front_and_rear"
+        : (stream.cameraMode == HAStreamingCameraModeRear ? @"rear" : @"front");
+    attributes[@"Camera Mode"] = mode;
+    attributes[@"MultiCam Supported"] = @(stream.multiCamSupported);
+    attributes[@"Quality Scale"] = @(stream.qualityScale);
+    attributes[@"Quality"] = stream.qualityDescription ?: @"unknown";
+    return attributes;
 }
 
 #pragma mark - WiFi Info

--- a/HADashboard/Logging/HALog.h
+++ b/HADashboard/Logging/HALog.h
@@ -31,6 +31,9 @@ typedef NS_ENUM(NSInteger, HALogLevel) {
 + (NSString *)previousLogFilePath;
 + (void)flush;
 
+/// Remove current and rotated logs, then start a fresh local session log.
++ (void)clearLogs;
+
 /// Startup profiling mode (replaces HAStartupLog).
 /// Uses mach_absolute_time offsets for the first 30 seconds, then wall clock.
 + (void)logStartup:(NSString *)message;

--- a/HADashboard/Logging/HALog.m
+++ b/HADashboard/Logging/HALog.m
@@ -181,6 +181,22 @@ static NSDate *_initDate = nil;
     }
 }
 
++ (void)clearLogs {
+    @synchronized(self) {
+        @try {
+            [_fileHandle synchronizeFile];
+            [_fileHandle closeFile];
+        } @catch (NSException *exception) {
+            (void)exception;
+        }
+        _fileHandle = nil;
+        NSFileManager *manager = [NSFileManager defaultManager];
+        if (_currentPath.length) [manager removeItemAtPath:_currentPath error:nil];
+        if (_previousPath.length) [manager removeItemAtPath:_previousPath error:nil];
+        [self _openLogFile];
+    }
+}
+
 #pragma mark - Internal
 
 + (void)_logLevel:(HALogLevel)level

--- a/HADashboard/Networking/HAAPIClient.h
+++ b/HADashboard/Networking/HAAPIClient.h
@@ -6,6 +6,18 @@ typedef void (^HAAPIResponseBlock)(id _Nullable response, NSError * _Nullable er
 
 - (instancetype)initWithBaseURL:(NSURL *)baseURL token:(NSString *)token;
 
+/// Creates an isolated client with endpoint-specific timeouts. The standard
+/// initializer retains the app-wide 15s request / 30s resource limits; slow
+/// Home Assistant config flows can opt into longer bounds without delaying
+/// dashboard, state, or service requests.
+- (instancetype)initWithBaseURL:(NSURL *)baseURL
+                          token:(NSString *)token
+         requestTimeoutInterval:(NSTimeInterval)requestTimeoutInterval
+        resourceTimeoutInterval:(NSTimeInterval)resourceTimeoutInterval;
+
+@property (nonatomic, readonly) NSTimeInterval requestTimeoutInterval;
+@property (nonatomic, readonly) NSTimeInterval resourceTimeoutInterval;
+
 /// GET /api/ — check API availability
 - (void)checkAPIWithCompletion:(HAAPIResponseBlock)completion;
 
@@ -27,6 +39,15 @@ typedef void (^HAAPIResponseBlock)(id _Nullable response, NSError * _Nullable er
 /// POST /api/template — render a Home Assistant Jinja template on the server.
 /// The completion response is the rendered plain-text result.
 - (void)renderTemplate:(NSString *)templateString completion:(HAAPIResponseBlock)completion;
+
+/// Authenticated JSON requests used by Home Assistant config-entry flows.
+- (void)getJSONAtPath:(NSString *)path completion:(HAAPIResponseBlock)completion;
+- (void)postJSONAtPath:(NSString *)path body:(NSDictionary *)body completion:(HAAPIResponseBlock)completion;
+- (void)deleteJSONAtPath:(NSString *)path completion:(HAAPIResponseBlock)completion;
+
+/// Cancels in-flight requests and invalidates this client's session. The
+/// instance must not be reused afterward.
+- (void)cancelAllRequests;
 
 /// GET /api/calendars/<entity_id>?start=<ISO>&end=<ISO>
 - (NSURLSessionDataTask *)getCalendarEventsForEntityId:(NSString *)entityId

--- a/HADashboard/Networking/HAAPIClient.m
+++ b/HADashboard/Networking/HAAPIClient.m
@@ -1,17 +1,35 @@
 #import "HAAPIClient.h"
 #import "HAAuthManager.h"
 #import "NSMutableURLRequest+HAHelpers.h"
+#import "HAURLSessionRedirectGuard.h"
+
+static NSError *HACrossOriginAPIPathError(void) {
+    return [NSError errorWithDomain:@"HAAPIClient" code:-5
+                           userInfo:@{NSLocalizedDescriptionKey:
+                               @"The API request path resolved outside the configured Home Assistant origin."}];
+}
 
 @interface HAAPIClient ()
 @property (nonatomic, strong) NSURL *baseURL;
 @property (nonatomic, copy)   NSString *token;
 @property (nonatomic, strong) NSURLSession *session;
 @property (nonatomic, assign) BOOL isRetrying401;
+@property (nonatomic, assign, getter=isCancelled) BOOL cancelled;
+@property (nonatomic, assign, readwrite) NSTimeInterval requestTimeoutInterval;
+@property (nonatomic, assign, readwrite) NSTimeInterval resourceTimeoutInterval;
 @end
 
 @implementation HAAPIClient
 
 - (instancetype)initWithBaseURL:(NSURL *)baseURL token:(NSString *)token {
+    return [self initWithBaseURL:baseURL token:token
+          requestTimeoutInterval:15.0 resourceTimeoutInterval:30.0];
+}
+
+- (instancetype)initWithBaseURL:(NSURL *)baseURL
+                          token:(NSString *)token
+         requestTimeoutInterval:(NSTimeInterval)requestTimeoutInterval
+        resourceTimeoutInterval:(NSTimeInterval)resourceTimeoutInterval {
     self = [super init];
     if (self) {
         // Ensure trailing slash so relative URL resolution works correctly
@@ -23,8 +41,15 @@
             _baseURL = baseURL;
         }
         _token   = [token copy];
+        _requestTimeoutInterval = MAX(1.0, requestTimeoutInterval);
+        _resourceTimeoutInterval = MAX(_requestTimeoutInterval, resourceTimeoutInterval);
 
-        _session = [NSURLSession sessionWithConfiguration:[NSMutableURLRequest ha_defaultSessionConfiguration]];
+        NSURLSessionConfiguration *configuration = [NSMutableURLRequest ha_defaultSessionConfiguration];
+        configuration.timeoutIntervalForRequest = _requestTimeoutInterval;
+        configuration.timeoutIntervalForResource = _resourceTimeoutInterval;
+        _session = [NSURLSession sessionWithConfiguration:configuration
+                                                  delegate:[HAURLSessionRedirectGuard sharedGuard]
+                                             delegateQueue:nil];
     }
     return self;
 }
@@ -74,6 +99,29 @@
     [self executePlainTextRequest:request completion:completion];
 }
 
+- (void)getJSONAtPath:(NSString *)path completion:(HAAPIResponseBlock)completion {
+    [self GET:path completion:completion];
+}
+
+- (void)postJSONAtPath:(NSString *)path body:(NSDictionary *)body completion:(HAAPIResponseBlock)completion {
+    [self POST:path body:body completion:completion];
+}
+
+- (void)deleteJSONAtPath:(NSString *)path completion:(HAAPIResponseBlock)completion {
+    NSURL *url = [NSURL URLWithString:path relativeToURL:self.baseURL];
+    if (![HAURLSessionRedirectGuard URL:self.baseURL sharesOriginWithURL:url]) {
+        ha_dispatchMainCompletion(completion, nil, HACrossOriginAPIPathError());
+        return;
+    }
+    NSMutableURLRequest *request = [self requestWithURL:url method:@"DELETE"];
+    [self executeRequest:request completion:completion];
+}
+
+- (void)cancelAllRequests {
+    self.cancelled = YES;
+    [self.session invalidateAndCancel];
+}
+
 - (NSURLSessionDataTask *)getCalendarEventsForEntityId:(NSString *)entityId
                                                  start:(NSString *)startISO
                                                    end:(NSString *)endISO
@@ -97,6 +145,10 @@
 
 - (NSURLSessionDataTask *)GETWithTask:(NSString *)path completion:(HAAPIResponseBlock)completion {
     NSURL *url = [NSURL URLWithString:path relativeToURL:self.baseURL];
+    if (![HAURLSessionRedirectGuard URL:self.baseURL sharesOriginWithURL:url]) {
+        ha_dispatchMainCompletion(completion, nil, HACrossOriginAPIPathError());
+        return nil;
+    }
     NSMutableURLRequest *request = [self requestWithURL:url method:@"GET"];
 
     return [self executeRequestWithTask:request completion:completion];
@@ -104,6 +156,10 @@
 
 - (void)POST:(NSString *)path body:(NSDictionary *)body completion:(HAAPIResponseBlock)completion {
     NSURL *url = [NSURL URLWithString:path relativeToURL:self.baseURL];
+    if (![HAURLSessionRedirectGuard URL:self.baseURL sharesOriginWithURL:url]) {
+        ha_dispatchMainCompletion(completion, nil, HACrossOriginAPIPathError());
+        return;
+    }
     NSMutableURLRequest *request = [self requestWithURL:url method:@"POST"];
 
     if (body) {
@@ -125,6 +181,7 @@
 
 - (NSMutableURLRequest *)requestWithURL:(NSURL *)url method:(NSString *)method {
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+    request.timeoutInterval = self.requestTimeoutInterval;
     request.HTTPMethod = method;
     [request ha_setAuthHeaders:self.token];
     return request;
@@ -135,8 +192,14 @@
 }
 
 - (NSURLSessionDataTask *)executeRequestWithTask:(NSURLRequest *)request completion:(HAAPIResponseBlock)completion {
+    if (self.isCancelled) {
+        ha_dispatchMainCompletion(completion, nil,
+            [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:nil]);
+        return nil;
+    }
     NSURLSessionDataTask *task = [self.session dataTaskWithRequest:request
         completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            if (self.isCancelled) return;
             if (error) {
                 dispatch_async(dispatch_get_main_queue(), ^{
                     if (completion) completion(nil, error);
@@ -152,6 +215,7 @@
                     self.isRetrying401 = YES;
                     [[HAAuthManager sharedManager] handleAuthFailureWithCompletion:^(NSString *newToken, NSError *refreshError) {
                         self.isRetrying401 = NO;
+                        if (self.isCancelled) return;
                         if (newToken) {
                             self.token = newToken;
                             NSMutableURLRequest *retry = [request mutableCopy];
@@ -202,8 +266,14 @@
 /// other API endpoints. Keep its decoding isolated so existing callers retain
 /// their JSON response contract.
 - (void)executePlainTextRequest:(NSURLRequest *)request completion:(HAAPIResponseBlock)completion {
+    if (self.isCancelled) {
+        ha_dispatchMainCompletion(completion, nil,
+            [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:nil]);
+        return;
+    }
     NSURLSessionDataTask *task = [self.session dataTaskWithRequest:request
         completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            if (self.isCancelled) return;
             if (error) {
                 ha_dispatchMainCompletion(completion, nil, error);
                 return;
@@ -215,6 +285,7 @@
                 self.isRetrying401 = YES;
                 [[HAAuthManager sharedManager] handleAuthFailureWithCompletion:^(NSString *newToken, NSError *refreshError) {
                     self.isRetrying401 = NO;
+                    if (self.isCancelled) return;
                     if (newToken) {
                         self.token = newToken;
                         NSMutableURLRequest *retry = [request mutableCopy];

--- a/HADashboard/Networking/HACameraRegistrationManager.h
+++ b/HADashboard/Networking/HACameraRegistrationManager.h
@@ -1,0 +1,43 @@
+#import <Foundation/Foundation.h>
+
+extern NSString *const HACameraRegistrationDidChangeNotification;
+
+/// Creates or updates Home Assistant Generic Camera config entries for the
+/// app's local RTSP sources using the currently logged-in user's token.
+@interface HACameraRegistrationManager : NSObject
+
++ (instancetype)sharedManager;
+
+@property (nonatomic, readonly, getter=isRegistering) BOOL registering;
+@property (nonatomic, copy, readonly) NSArray<NSString *> *registeredEntryIDs;
+@property (nonatomic, strong, readonly) NSError *lastError;
+/// A transient Home Assistant/config-flow failure is waiting for its next
+/// retry. `retryAttempt` counts retries after the initial attempt.
+@property (nonatomic, readonly, getter=isRetryScheduled) BOOL retryScheduled;
+@property (nonatomic, readonly) NSUInteger retryAttempt;
+@property (nonatomic, readonly) NSTimeInterval scheduledRetryDelay;
+
+/// YES when the current server is HTTPS or a loopback, .local, link-local, or
+/// private-network HTTP address. Non-local HTTP is refused.
+@property (nonatomic, readonly) BOOL automaticRegistrationTransportAllowed;
+
+/// Reconciliation is asynchronous. A retryable failure keeps `completion`
+/// pending across context-bound retries; it reports eventual success or a
+/// terminal failure. Cancellation invalidates the work without invoking it.
+- (void)ensureCameraEntriesForStreamURLs:(NSArray<NSString *> *)streamURLs
+                              deviceName:(NSString *)deviceName
+                                username:(NSString *)username
+                                password:(NSString *)password
+                      credentialRevision:(NSString *)credentialRevision
+                         framesPerSecond:(NSInteger)framesPerSecond
+                              completion:(void (^)(BOOL success, NSError *error))completion;
+
+/// Cancels in-flight requests and scheduled retries, invalidates their
+/// callbacks, and releases all in-memory copies of the stream credential.
+- (void)cancelRegistration;
+
+/// Cancels registration and clears this manager's in-memory result/error state.
+/// Persistent app defaults are cleared by the caller's full reset transaction.
+- (void)resetLocalRegistrationState;
+
+@end

--- a/HADashboard/Networking/HACameraRegistrationManager.m
+++ b/HADashboard/Networking/HACameraRegistrationManager.m
@@ -1,0 +1,830 @@
+#import "HACameraRegistrationManager.h"
+#import "HAAPIClient.h"
+#import "HAAuthManager.h"
+#import "HAConnectionManager.h"
+#import "HADeviceIntegrationManager.h"
+#import "HAStreamingManager.h"
+#import "HALog.h"
+#import <arpa/inet.h>
+
+NSString *const HACameraRegistrationDidChangeNotification = @"HACameraRegistrationDidChangeNotification";
+
+static NSString *const kHACameraPrimaryEntryIDKey = @"ha_camera_primary_entry_id";
+static NSString *const kHACameraSecondaryEntryIDKey = @"ha_camera_secondary_entry_id";
+static NSString *const kHACameraPrimaryURLKey = @"ha_camera_primary_stream_url";
+static NSString *const kHACameraSecondaryURLKey = @"ha_camera_secondary_stream_url";
+static NSString *const kHACameraPrimaryCredentialRevisionKey = @"ha_camera_primary_credential_revision";
+static NSString *const kHACameraSecondaryCredentialRevisionKey = @"ha_camera_secondary_credential_revision";
+static NSString *const kHACameraPrimaryFramesPerSecondKey = @"ha_camera_primary_frames_per_second";
+static NSString *const kHACameraSecondaryFramesPerSecondKey = @"ha_camera_secondary_frames_per_second";
+static NSString *const kHALegacyCameraInsecureConsentOriginKey = @"ha_camera_insecure_consent_origin";
+static NSString *const HACameraRegistrationErrorDomain = @"HACameraRegistrationErrorDomain";
+static NSString *const HACameraRegistrationRetryableKey = @"HACameraRegistrationRetryable";
+static const NSTimeInterval HACameraRegistrationRequestTimeout = 75.0;
+static const NSTimeInterval HACameraRegistrationResourceTimeout = 120.0;
+static const NSTimeInterval HACameraRegistrationInitialRetryDelay = 2.0;
+static const NSTimeInterval HACameraRegistrationMaximumRetryDelay = 60.0;
+
+static NSTimeInterval HACameraRegistrationRetryDelay(NSUInteger attempt) {
+    // Avoid an unbounded left shift: after 2/4/8/16/32 seconds, retry once a
+    // minute for as long as the exact registration context remains current.
+    switch (attempt) {
+        case 0:
+        case 1: return HACameraRegistrationInitialRetryDelay;
+        case 2: return 4.0;
+        case 3: return 8.0;
+        case 4: return 16.0;
+        case 5: return 32.0;
+        default: return HACameraRegistrationMaximumRetryDelay;
+    }
+}
+
+typedef HAAPIClient *(^HACameraRegistrationAPIClientFactory)(NSURL *baseURL,
+                                                              NSString *token,
+                                                              NSTimeInterval requestTimeout,
+                                                              NSTimeInterval resourceTimeout);
+typedef id (^HACameraRegistrationRetryScheduler)(NSTimeInterval delay,
+                                                  dispatch_block_t block);
+typedef void (^HACameraRegistrationRetryCanceller)(id token);
+
+@interface HACameraRegistrationRetryToken : NSObject
+@property (nonatomic, assign, getter=isCancelled) BOOL cancelled;
+@end
+
+@implementation HACameraRegistrationRetryToken
+@end
+
+static BOOL HACameraHostIsLocalNetwork(NSString *host) {
+    NSString *value = host.lowercaseString;
+    if (!value.length) return NO;
+    if ([value isEqualToString:@"localhost"] || [value hasSuffix:@".local"]) return YES;
+
+    struct in_addr ipv4;
+    if (inet_pton(AF_INET, value.UTF8String, &ipv4) == 1) {
+        uint32_t address = ntohl(ipv4.s_addr);
+        return (address & 0xFF000000) == 0x0A000000 ||
+               (address & 0xFFF00000) == 0xAC100000 ||
+               (address & 0xFFFF0000) == 0xC0A80000 ||
+               (address & 0xFF000000) == 0x7F000000 ||
+               (address & 0xFFFF0000) == 0xA9FE0000;
+    }
+
+    struct in6_addr ipv6;
+    if (inet_pton(AF_INET6, value.UTF8String, &ipv6) == 1) {
+        const uint8_t *bytes = ipv6.s6_addr;
+        return IN6_IS_ADDR_LOOPBACK(&ipv6) ||
+               (bytes[0] == 0xFE && (bytes[1] & 0xC0) == 0x80) ||
+               ((bytes[0] & 0xFE) == 0xFC);
+    }
+    return NO;
+}
+
+@interface HACameraRegistrationManager ()
+@property (nonatomic, assign, readwrite, getter=isRegistering) BOOL registering;
+@property (nonatomic, copy, readwrite) NSArray<NSString *> *registeredEntryIDs;
+@property (nonatomic, strong, readwrite) NSError *lastError;
+@property (nonatomic, assign, readwrite, getter=isRetryScheduled) BOOL retryScheduled;
+@property (nonatomic, assign, readwrite) NSUInteger retryAttempt;
+@property (nonatomic, assign, readwrite) NSTimeInterval scheduledRetryDelay;
+@property (nonatomic, strong) HAAPIClient *apiClient;
+@property (nonatomic, copy) NSArray<NSString *> *pendingURLs;
+@property (nonatomic, copy) NSArray<NSDictionary *> *existingEntries;
+@property (nonatomic, copy) NSString *deviceName;
+@property (nonatomic, copy) NSString *username;
+@property (nonatomic, copy) NSString *password;
+@property (nonatomic, copy) NSString *credentialRevision;
+@property (nonatomic, assign) NSInteger framesPerSecond;
+@property (nonatomic, assign) NSUInteger currentIndex;
+@property (nonatomic, strong) NSMutableArray<NSString *> *resultEntryIDs;
+@property (nonatomic, copy) void (^completion)(BOOL success, NSError *error);
+@property (nonatomic, assign) NSUInteger cancellationGeneration;
+@property (nonatomic, assign) NSUInteger activeAuthenticationRevision;
+@property (nonatomic, copy) NSString *activeServerOriginToken;
+@property (nonatomic, copy) NSString *activeFlowID;
+@property (nonatomic, assign) BOOL activeFlowIsOptionsFlow;
+@property (nonatomic, copy) HACameraRegistrationAPIClientFactory apiClientFactory;
+@property (nonatomic, copy) HACameraRegistrationRetryScheduler retryScheduler;
+@property (nonatomic, copy) HACameraRegistrationRetryCanceller retryCanceller;
+@property (nonatomic, strong) id scheduledRetryToken;
+- (NSDictionary *)cameraConfigurationInputForURL:(NSString *)url
+                                      optionsFlow:(BOOL)optionsFlow;
+- (NSError *)cameraCredentialTransportErrorForURL:(NSURL *)URL;
+@end
+
+@implementation HACameraRegistrationManager
+
++ (instancetype)sharedManager {
+    static HACameraRegistrationManager *manager;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ manager = [[self alloc] init]; });
+    return manager;
+}
+
+- (instancetype)init {
+    return [self initWithAPIClientFactory:nil scheduleRetry:nil cancelScheduledRetry:nil];
+}
+
+- (instancetype)initWithAPIClientFactory:(HACameraRegistrationAPIClientFactory)apiClientFactory
+                            scheduleRetry:(HACameraRegistrationRetryScheduler)retryScheduler
+                     cancelScheduledRetry:(HACameraRegistrationRetryCanceller)retryCanceller {
+    self = [super init];
+    if (self) {
+        _registeredEntryIDs = @[];
+        if (apiClientFactory) {
+            _apiClientFactory = [apiClientFactory copy];
+        } else {
+            _apiClientFactory = [^HAAPIClient *(NSURL *baseURL, NSString *token,
+                                                NSTimeInterval requestTimeout,
+                                                NSTimeInterval resourceTimeout) {
+                return [[HAAPIClient alloc] initWithBaseURL:baseURL token:token
+                                    requestTimeoutInterval:requestTimeout
+                                   resourceTimeoutInterval:resourceTimeout];
+            } copy];
+        }
+        if (retryScheduler) {
+            _retryScheduler = [retryScheduler copy];
+        } else {
+            _retryScheduler = [^id(NSTimeInterval delay, dispatch_block_t block) {
+                HACameraRegistrationRetryToken *token = [[HACameraRegistrationRetryToken alloc] init];
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)),
+                               dispatch_get_main_queue(), ^{
+                    if (!token.isCancelled && block) block();
+                });
+                return token;
+            } copy];
+        }
+        if (retryCanceller) {
+            _retryCanceller = [retryCanceller copy];
+        } else {
+            _retryCanceller = [^(id token) {
+                if ([token isKindOfClass:[HACameraRegistrationRetryToken class]]) {
+                    ((HACameraRegistrationRetryToken *)token).cancelled = YES;
+                }
+            } copy];
+        }
+        // Local-network HTTP registration no longer stores a per-origin
+        // approval. Remove the obsolete value on upgrade as well as reset.
+        [[NSUserDefaults standardUserDefaults]
+            removeObjectForKey:kHALegacyCameraInsecureConsentOriginKey];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+            selector:@selector(authenticationDidChange:)
+            name:HAAuthManagerDidUpdateNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+            selector:@selector(streamingStateDidChange:)
+            name:HAStreamingManagerStateDidChangeNotification object:nil];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    if (self.scheduledRetryToken) self.retryCanceller(self.scheduledRetryToken);
+    [self.apiClient cancelAllRequests];
+}
+
+- (NSString *)currentServerOriginToken {
+    NSURL *URL = [HAAuthManager sharedManager].restBaseURL;
+    NSString *scheme = URL.scheme.lowercaseString;
+    NSString *host = URL.host.lowercaseString;
+    if (!scheme.length || !host.length) return nil;
+    NSNumber *port = URL.port;
+    if (!port) port = [scheme isEqualToString:@"https"] ? @443 : @80;
+    return [NSString stringWithFormat:@"%@|%@|%@", scheme, host, port];
+}
+
+- (NSError *)cameraCredentialTransportErrorForURL:(NSURL *)URL {
+    NSString *scheme = URL.scheme.lowercaseString;
+    if ([scheme isEqualToString:@"https"]) return nil;
+    if ([scheme isEqualToString:@"http"] && HACameraHostIsLocalNetwork(URL.host)) return nil;
+    return [self error:@"Camera registration blocked: this Home Assistant address must use HTTPS."];
+}
+
+- (NSError *)cameraCredentialTransportError {
+    return [self cameraCredentialTransportErrorForURL:[HAAuthManager sharedManager].restBaseURL];
+}
+
+- (BOOL)automaticRegistrationTransportAllowed {
+    return [self cameraCredentialTransportError] == nil;
+}
+
+- (BOOL)activeAuthenticationIsCurrent {
+    if (!self.activeServerOriginToken.length) return NO;
+    HAAuthManager *auth = [HAAuthManager sharedManager];
+    return !auth.isDemoMode &&
+           auth.authenticationRevision == self.activeAuthenticationRevision &&
+           [[self currentServerOriginToken] isEqualToString:self.activeServerOriginToken];
+}
+
+- (BOOL)streamListenerIsArmedForPendingURLs {
+    HAStreamingManager *stream = [HAStreamingManager sharedManager];
+    return stream.streaming && self.pendingURLs.count > 0 &&
+           [stream.streamURLs isEqualToArray:self.pendingURLs];
+}
+
+- (BOOL)registrationCanContinue {
+    return self.isRegistering &&
+           [HADeviceIntegrationManager sharedManager].enabled &&
+           [self activeAuthenticationIsCurrent] &&
+           [self streamListenerIsArmedForPendingURLs];
+}
+
+- (BOOL)requestClientIsCurrent:(HAAPIClient *)requestClient {
+    return self.apiClient == requestClient && [self registrationCanContinue];
+}
+
+- (BOOL)ensureActiveAuthenticationOrCancel {
+    if ([self activeAuthenticationIsCurrent]) return YES;
+    [self cancelRegistration];
+    return NO;
+}
+
+- (void)authenticationDidChange:(NSNotification *)notification {
+    (void)notification;
+    if (self.isRegistering && ![self activeAuthenticationIsCurrent]) {
+        [self cancelRegistration];
+    }
+}
+
+- (void)streamingStateDidChange:(NSNotification *)notification {
+    (void)notification;
+    if (self.isRegistering && ![self streamListenerIsArmedForPendingURLs]) {
+        [self cancelRegistration];
+    }
+}
+
+- (void)failBeforeRegistration:(NSError *)error
+                     completion:(void (^)(BOOL success, NSError *error))completion {
+    self.retryScheduled = NO;
+    self.retryAttempt = 0;
+    self.scheduledRetryDelay = 0;
+    self.lastError = error;
+    [self postChange];
+    if (completion) completion(NO, error);
+}
+
+- (NSError *)registrationPreflightError {
+    if (![HADeviceIntegrationManager sharedManager].enabled) {
+        return [self error:@"Enable Register with Home Assistant before adding protected camera entries."];
+    }
+    HAAuthManager *auth = [HAAuthManager sharedManager];
+    if (!auth.isConfigured || auth.isDemoMode || !auth.accessToken.length) {
+        return [self error:@"Sign in to Home Assistant before registering camera streams."];
+    }
+    return [self cameraCredentialTransportError];
+}
+
+- (BOOL)activeRegistrationMatchesURLs:(NSArray<NSString *> *)streamURLs
+                            deviceName:(NSString *)deviceName
+                              username:(NSString *)username
+                              password:(NSString *)password
+                    credentialRevision:(NSString *)credentialRevision
+                       framesPerSecond:(NSInteger)framesPerSecond {
+    return [self.pendingURLs isEqualToArray:streamURLs] &&
+           [self.deviceName isEqualToString:deviceName] &&
+           [self.username isEqualToString:username] &&
+           [self.password isEqualToString:password] &&
+           [self.credentialRevision isEqualToString:credentialRevision] &&
+           self.framesPerSecond == framesPerSecond;
+}
+
+- (void)coalesceCompletion:(void (^)(BOOL success, NSError *error))completion {
+    if (!completion) return;
+    void (^existingCompletion)(BOOL, NSError *) = self.completion;
+    if (!existingCompletion) {
+        self.completion = completion;
+        return;
+    }
+    if (existingCompletion == completion) return;
+    self.completion = ^(BOOL success, NSError *error) {
+        existingCompletion(success, error);
+        completion(success, error);
+    };
+}
+
+- (void)ensureCameraEntriesForStreamURLs:(NSArray<NSString *> *)streamURLs
+                              deviceName:(NSString *)deviceName
+                                username:(NSString *)username
+                                password:(NSString *)password
+                      credentialRevision:(NSString *)credentialRevision
+                         framesPerSecond:(NSInteger)framesPerSecond
+                              completion:(void (^)(BOOL, NSError *))completion {
+    if (streamURLs.count == 0) {
+        [self failBeforeRegistration:[self error:@"No local RTSP stream is armed."]
+                           completion:completion];
+        return;
+    }
+    if (!username.length || !password.length || !credentialRevision.length) {
+        [self failBeforeRegistration:[self error:@"Protected stream credentials are unavailable."]
+                           completion:completion];
+        return;
+    }
+    if (framesPerSecond <= 0) {
+        [self failBeforeRegistration:[self error:@"The local camera stream frame rate is invalid."]
+                           completion:completion];
+        return;
+    }
+    NSError *preflightError = [self registrationPreflightError];
+    if (preflightError) {
+        [self failBeforeRegistration:preflightError completion:completion];
+        return;
+    }
+    HAAuthManager *auth = [HAAuthManager sharedManager];
+    NSString *normalizedDeviceName = deviceName.length ? [deviceName copy] : @"HA Dashboard";
+    if (self.registering) {
+        if ([self activeRegistrationMatchesURLs:streamURLs
+                                      deviceName:normalizedDeviceName
+                                        username:username
+                                        password:password
+                              credentialRevision:credentialRevision
+                                 framesPerSecond:framesPerSecond]) {
+            // Duplicate lifecycle notifications share the active result; they
+            // do not queue another full run behind an indefinitely retrying one.
+            [self coalesceCompletion:completion];
+            return;
+        }
+
+        // Password rotation, address/camera changes, frame-rate changes, and
+        // device renames must supersede a retry immediately. Cancellation bumps
+        // the generation so even an already-delivered old timer cannot resume.
+        [self cancelRegistration];
+    }
+
+    self.registering = YES;
+    self.lastError = nil;
+    self.pendingURLs = [streamURLs copy];
+    self.deviceName = normalizedDeviceName;
+    self.username = [username copy];
+    self.password = [password copy];
+    self.credentialRevision = [credentialRevision copy];
+    self.framesPerSecond = framesPerSecond;
+    self.currentIndex = 0;
+    self.resultEntryIDs = [NSMutableArray array];
+    self.completion = completion;
+    self.retryAttempt = 0;
+    self.retryScheduled = NO;
+    self.scheduledRetryDelay = 0;
+    self.activeAuthenticationRevision = auth.authenticationRevision;
+    self.activeServerOriginToken = [self currentServerOriginToken];
+    if (!self.activeServerOriginToken.length) {
+        [self finish:NO error:[self error:@"The Home Assistant server origin is invalid."]];
+        return;
+    }
+    [self postChange];
+    [self beginRegistrationAttempt];
+}
+
+- (void)beginRegistrationAttempt {
+    if (![self registrationCanContinue]) {
+        [self cancelRegistration];
+        return;
+    }
+
+    if (self.scheduledRetryToken) {
+        self.retryCanceller(self.scheduledRetryToken);
+        self.scheduledRetryToken = nil;
+    }
+    self.retryScheduled = NO;
+    self.scheduledRetryDelay = 0;
+    [self.apiClient cancelAllRequests];
+    self.apiClient = nil;
+    self.activeFlowID = nil;
+    self.activeFlowIsOptionsFlow = NO;
+    self.currentIndex = 0;
+    self.resultEntryIDs = [NSMutableArray array];
+
+    HAAuthManager *auth = [HAAuthManager sharedManager];
+    self.apiClient = self.apiClientFactory(auth.restBaseURL, auth.accessToken,
+        HACameraRegistrationRequestTimeout, HACameraRegistrationResourceTimeout);
+    if (!self.apiClient) {
+        [self finish:NO error:[self error:@"Could not create a Home Assistant camera-registration client."]];
+        return;
+    }
+    [self postChange];
+
+    __weak typeof(self) weakSelf = self;
+    HAAPIClient *requestClient = self.apiClient;
+    [requestClient getJSONAtPath:@"config/config_entries/entry?domain=generic" completion:^(id response, NSError *error) {
+        if (![weakSelf requestClientIsCurrent:requestClient]) return;
+        if (error) {
+            [weakSelf handleRegistrationError:[weakSelf cameraPermissionError:error]
+                                requestClient:requestClient];
+            return;
+        }
+        weakSelf.existingEntries = [response isKindOfClass:[NSArray class]] ? response : @[];
+        [weakSelf processCurrentURL];
+    }];
+}
+
+- (void)processCurrentURL {
+    if (![self ensureActiveAuthenticationOrCancel]) return;
+    if (self.currentIndex >= self.pendingURLs.count) {
+        self.registeredEntryIDs = [self.resultEntryIDs copy];
+        [self finish:YES error:nil];
+        return;
+    }
+
+    NSString *url = self.pendingURLs[self.currentIndex];
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSString *entryKey = self.currentIndex == 0 ? kHACameraPrimaryEntryIDKey : kHACameraSecondaryEntryIDKey;
+    NSString *urlKey = self.currentIndex == 0 ? kHACameraPrimaryURLKey : kHACameraSecondaryURLKey;
+    NSString *revisionKey = self.currentIndex == 0
+        ? kHACameraPrimaryCredentialRevisionKey : kHACameraSecondaryCredentialRevisionKey;
+    NSString *frameRateKey = self.currentIndex == 0
+        ? kHACameraPrimaryFramesPerSecondKey : kHACameraSecondaryFramesPerSecondKey;
+    NSString *storedEntryID = [defaults stringForKey:entryKey];
+    NSString *storedURL = [defaults stringForKey:urlKey];
+    NSString *storedRevision = [defaults stringForKey:revisionKey];
+    NSNumber *storedFramesPerSecond = [defaults objectForKey:frameRateKey];
+    NSDictionary *storedEntry = [self entryWithID:storedEntryID];
+
+    if (storedEntry && [storedURL isEqualToString:url] &&
+        [storedRevision isEqualToString:self.credentialRevision] &&
+        storedFramesPerSecond.integerValue == self.framesPerSecond) {
+        [self acceptEntry:storedEntry[@"entry_id"] forURL:url];
+        return;
+    }
+    if (storedEntry) {
+        [self updateEntry:storedEntry[@"entry_id"] forURL:url];
+        return;
+    }
+
+    // Only reuse an entry whose ID this app previously stored. Generic Camera
+    // list responses do not expose enough source options to prove that a title
+    // or host belongs to this stream; guessing could rename an unrelated entry.
+    [self createEntryForURL:url];
+}
+
+- (NSDictionary *)entryWithID:(NSString *)entryID {
+    if (!entryID.length) return nil;
+    for (NSDictionary *entry in self.existingEntries) {
+        if ([entry[@"entry_id"] isEqualToString:entryID]) return entry;
+    }
+    return nil;
+}
+
+- (void)createEntryForURL:(NSString *)url {
+    if (![self ensureActiveAuthenticationOrCancel]) return;
+    __weak typeof(self) weakSelf = self;
+    HAAPIClient *requestClient = self.apiClient;
+    [requestClient postJSONAtPath:@"config/config_entries/flow"
+                              body:@{@"handler": @"generic", @"show_advanced_options": @YES}
+                        completion:^(id response, NSError *error) {
+        if (![weakSelf requestClientIsCurrent:requestClient]) return;
+        if (error) {
+            [weakSelf handleRegistrationError:[weakSelf cameraPermissionError:error]
+                                requestClient:requestClient];
+            return;
+        }
+        NSString *flowID = [response isKindOfClass:[NSDictionary class]] ? response[@"flow_id"] : nil;
+        if (!flowID.length) {
+            [weakSelf handleRegistrationError:[weakSelf flowError:response]
+                                requestClient:requestClient];
+            return;
+        }
+        weakSelf.activeFlowID = flowID;
+        weakSelf.activeFlowIsOptionsFlow = NO;
+        [weakSelf submitURL:url toFlow:flowID optionsFlow:NO existingEntryID:nil];
+    }];
+}
+
+- (void)updateEntry:(NSString *)entryID forURL:(NSString *)url {
+    if (![self ensureActiveAuthenticationOrCancel]) return;
+    __weak typeof(self) weakSelf = self;
+    HAAPIClient *requestClient = self.apiClient;
+    [requestClient postJSONAtPath:@"config/config_entries/options/flow"
+                              body:@{@"handler": entryID}
+                        completion:^(id response, NSError *error) {
+        if (![weakSelf requestClientIsCurrent:requestClient]) return;
+        if (error) {
+            [weakSelf handleRegistrationError:[weakSelf cameraPermissionError:error]
+                                requestClient:requestClient];
+            return;
+        }
+        NSString *flowID = [response isKindOfClass:[NSDictionary class]] ? response[@"flow_id"] : nil;
+        if (!flowID.length) {
+            [weakSelf handleRegistrationError:[weakSelf flowError:response]
+                                requestClient:requestClient];
+            return;
+        }
+        weakSelf.activeFlowID = flowID;
+        weakSelf.activeFlowIsOptionsFlow = YES;
+        [weakSelf submitURL:url toFlow:flowID optionsFlow:YES existingEntryID:entryID];
+    }];
+}
+
+- (void)submitURL:(NSString *)url
+            toFlow:(NSString *)flowID
+       optionsFlow:(BOOL)optionsFlow
+   existingEntryID:(NSString *)existingEntryID {
+    if (![self ensureActiveAuthenticationOrCancel]) return;
+    NSDictionary *input = [self cameraConfigurationInputForURL:url
+                                                   optionsFlow:optionsFlow];
+    NSString *path = [NSString stringWithFormat:@"config/config_entries/%@/flow/%@",
+        optionsFlow ? @"options" : @"", flowID];
+    if (!optionsFlow) path = [NSString stringWithFormat:@"config/config_entries/flow/%@", flowID];
+
+    __weak typeof(self) weakSelf = self;
+    HAAPIClient *requestClient = self.apiClient;
+    [requestClient postJSONAtPath:path body:input completion:^(id response, NSError *error) {
+        if (![weakSelf requestClientIsCurrent:requestClient]) return;
+        if (error) {
+            [weakSelf handleRegistrationError:[weakSelf cameraPermissionError:error]
+                                requestClient:requestClient];
+            return;
+        }
+        if ([response[@"type"] isEqualToString:@"create_entry"]) {
+            weakSelf.activeFlowID = nil;
+            NSString *entryID = existingEntryID ?: response[@"result"][@"entry_id"];
+            [weakSelf acceptEntry:entryID forURL:url];
+            return;
+        }
+        if ([response[@"step_id"] isEqualToString:@"user_confirm"] && [response[@"flow_id"] length]) {
+            [weakSelf confirmFlow:response[@"flow_id"] optionsFlow:optionsFlow
+                   existingEntryID:existingEntryID url:url];
+            return;
+        }
+        [weakSelf handleRegistrationError:[weakSelf flowError:response]
+                            requestClient:requestClient];
+    }];
+}
+
+- (NSDictionary *)cameraConfigurationInputForURL:(NSString *)url
+                                      optionsFlow:(BOOL)optionsFlow {
+    NSMutableDictionary *advanced = [@{
+        @"authentication": @"digest",
+        @"framerate": @(self.framesPerSecond),
+        @"verify_ssl": @YES,
+        @"rtsp_transport": @"tcp",
+    } mutableCopy];
+    if (optionsFlow) {
+        advanced[@"limit_refetch_to_url_change"] = @NO;
+        advanced[@"use_wallclock_as_timestamps"] = @NO;
+    }
+    NSDictionary *input = @{
+        @"stream_source": url,
+        @"still_image_url": @"",
+        @"username": self.username,
+        @"password": self.password,
+        @"advanced": advanced,
+    };
+    return input;
+}
+
+- (void)confirmFlow:(NSString *)flowID
+         optionsFlow:(BOOL)optionsFlow
+     existingEntryID:(NSString *)existingEntryID
+                 url:(NSString *)url {
+    if (![self ensureActiveAuthenticationOrCancel]) return;
+    NSString *path = optionsFlow
+        ? [NSString stringWithFormat:@"config/config_entries/options/flow/%@", flowID]
+        : [NSString stringWithFormat:@"config/config_entries/flow/%@", flowID];
+    __weak typeof(self) weakSelf = self;
+    HAAPIClient *requestClient = self.apiClient;
+    [requestClient postJSONAtPath:path body:@{@"confirmed_ok": @YES} completion:^(id response, NSError *error) {
+        if (![weakSelf requestClientIsCurrent:requestClient]) return;
+        if (error) {
+            [weakSelf handleRegistrationError:[weakSelf cameraPermissionError:error]
+                                requestClient:requestClient];
+            return;
+        }
+        if (![response[@"type"] isEqualToString:@"create_entry"]) {
+            [weakSelf handleRegistrationError:[weakSelf flowError:response]
+                                requestClient:requestClient];
+            return;
+        }
+        weakSelf.activeFlowID = nil;
+        NSString *entryID = existingEntryID ?: response[@"result"][@"entry_id"];
+        [weakSelf acceptEntry:entryID forURL:url];
+    }];
+}
+
+- (void)acceptEntry:(NSString *)entryID forURL:(NSString *)url {
+    if (![self ensureActiveAuthenticationOrCancel]) return;
+    if (!entryID.length) {
+        [self finish:NO error:[self error:@"Home Assistant did not return a camera config-entry ID."]];
+        return;
+    }
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSString *entryKey = self.currentIndex == 0 ? kHACameraPrimaryEntryIDKey : kHACameraSecondaryEntryIDKey;
+    NSString *urlKey = self.currentIndex == 0 ? kHACameraPrimaryURLKey : kHACameraSecondaryURLKey;
+    NSString *revisionKey = self.currentIndex == 0
+        ? kHACameraPrimaryCredentialRevisionKey : kHACameraSecondaryCredentialRevisionKey;
+    NSString *frameRateKey = self.currentIndex == 0
+        ? kHACameraPrimaryFramesPerSecondKey : kHACameraSecondaryFramesPerSecondKey;
+    [defaults setObject:entryID forKey:entryKey];
+    [defaults setObject:url forKey:urlKey];
+    [defaults setObject:self.credentialRevision forKey:revisionKey];
+    [defaults setInteger:self.framesPerSecond forKey:frameRateKey];
+    [defaults synchronize];
+    [self.resultEntryIDs addObject:entryID];
+
+    NSString *role = self.pendingURLs.count > 1
+        ? (self.currentIndex == 0 ? @"Front Camera" : @"Rear Camera")
+        : @"Camera";
+    [self renameEntry:entryID role:role];
+
+    HALogI(@"localstream", @"Home Assistant protected camera entry is ready");
+    self.currentIndex++;
+    [self processCurrentURL];
+}
+
+- (void)renameEntry:(NSString *)entryID role:(NSString *)role {
+    NSString *name = self.deviceName.length ? self.deviceName : @"HA Dashboard";
+    NSString *title = [NSString stringWithFormat:@"%@ %@", name, role];
+    [[HAConnectionManager sharedManager] sendCommand:@{
+        @"type": @"config_entries/update", @"entry_id": entryID, @"title": title
+    } completion:^(id result, NSError *error) {
+        if (error) HALogW(@"localstream", @"Camera entry created but could not be renamed: %@", error.localizedDescription);
+    }];
+}
+
+- (NSError *)flowError:(id)response {
+    NSString *message = @"Home Assistant rejected the camera config flow.";
+    BOOL retryable = NO;
+    if ([response isKindOfClass:[NSDictionary class]]) {
+        id errors = response[@"errors"];
+        if (errors) {
+            message = [NSString stringWithFormat:@"%@ %@", message, errors];
+            NSString *lowercaseErrors = [[errors description] lowercaseString];
+            retryable = [lowercaseErrors containsString:@"cannot_connect"] ||
+                        [lowercaseErrors containsString:@"timed_out"] ||
+                        [lowercaseErrors containsString:@"timeout"] ||
+                        [lowercaseErrors containsString:@"temporarily_unavailable"];
+        }
+    }
+    return [self error:message retryable:retryable];
+}
+
+- (NSError *)cameraPermissionError:(NSError *)error {
+    if (error.code == 401 || error.code == 403) {
+        return [self error:@"Camera registration requires a Home Assistant administrator token."];
+    }
+    return error;
+}
+
+- (BOOL)isRetryableRegistrationError:(NSError *)error {
+    if (!error) return NO;
+    if ([error.userInfo[HACameraRegistrationRetryableKey] boolValue]) return YES;
+    if ([error.domain isEqualToString:NSURLErrorDomain]) {
+        switch (error.code) {
+            case NSURLErrorTimedOut:
+            case NSURLErrorCannotFindHost:
+            case NSURLErrorCannotConnectToHost:
+            case NSURLErrorNetworkConnectionLost:
+            case NSURLErrorDNSLookupFailed:
+            case NSURLErrorResourceUnavailable:
+            case NSURLErrorNotConnectedToInternet:
+            case NSURLErrorInternationalRoamingOff:
+            case NSURLErrorCallIsActive:
+            case NSURLErrorDataNotAllowed:
+            case NSURLErrorRequestBodyStreamExhausted:
+            case NSURLErrorCannotLoadFromNetwork:
+                return YES;
+            default:
+                break;
+        }
+    }
+    if ([error.domain isEqualToString:@"HAAPIClient"] &&
+        (error.code == 408 || error.code == 429 || error.code >= 500)) {
+        return YES;
+    }
+    NSError *underlyingError = error.userInfo[NSUnderlyingErrorKey];
+    return underlyingError && underlyingError != error &&
+           [self isRetryableRegistrationError:underlyingError];
+}
+
+- (void)discardActiveFlowUsingClient:(HAAPIClient *)requestClient {
+    NSString *flowID = self.activeFlowID;
+    BOOL optionsFlow = self.activeFlowIsOptionsFlow;
+    self.activeFlowID = nil;
+    self.activeFlowIsOptionsFlow = NO;
+    if (!flowID.length || !requestClient) return;
+
+    NSString *path = optionsFlow
+        ? [NSString stringWithFormat:@"config/config_entries/options/flow/%@", flowID]
+        : [NSString stringWithFormat:@"config/config_entries/flow/%@", flowID];
+    [requestClient deleteJSONAtPath:path completion:^(id response, NSError *cleanupError) {
+        (void)response;
+        if (cleanupError && cleanupError.code != NSURLErrorCancelled && cleanupError.code != 404) {
+            HALogW(@"localstream", @"Could not discard a failed Home Assistant camera config flow: %@",
+                   cleanupError.localizedDescription);
+        }
+    }];
+}
+
+- (void)handleRegistrationError:(NSError *)error requestClient:(HAAPIClient *)requestClient {
+    if (![self requestClientIsCurrent:requestClient]) return;
+    NSError *registrationError = error ?: [self error:@"Home Assistant camera registration failed."];
+    [self discardActiveFlowUsingClient:requestClient];
+    if (![self isRetryableRegistrationError:registrationError]) {
+        [self finish:NO error:registrationError];
+        return;
+    }
+
+    if (self.retryAttempt < NSUIntegerMax) self.retryAttempt++;
+    self.scheduledRetryDelay = HACameraRegistrationRetryDelay(self.retryAttempt);
+    self.retryScheduled = YES;
+    self.lastError = registrationError;
+    self.existingEntries = nil;
+    NSUInteger generation = self.cancellationGeneration;
+    HALogW(@"localstream", @"Home Assistant camera registration will retry %lu in %.0f seconds: %@",
+           (unsigned long)self.retryAttempt,
+           self.scheduledRetryDelay, registrationError.localizedDescription);
+    [self postChange];
+
+    __weak typeof(self) weakSelf = self;
+    self.scheduledRetryToken = self.retryScheduler(self.scheduledRetryDelay, ^{
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf || strongSelf.cancellationGeneration != generation) return;
+        strongSelf.scheduledRetryToken = nil;
+        if (![strongSelf registrationCanContinue]) {
+            [strongSelf cancelRegistration];
+            return;
+        }
+        [strongSelf beginRegistrationAttempt];
+    });
+}
+
+- (NSError *)error:(NSString *)description {
+    return [self error:description retryable:NO];
+}
+
+- (NSError *)error:(NSString *)description retryable:(BOOL)retryable {
+    NSMutableDictionary *userInfo = [@{NSLocalizedDescriptionKey: description} mutableCopy];
+    if (retryable) userInfo[HACameraRegistrationRetryableKey] = @YES;
+    return [NSError errorWithDomain:HACameraRegistrationErrorDomain code:1 userInfo:userInfo];
+}
+
+- (void)finish:(BOOL)success error:(NSError *)error {
+    self.lastError = error;
+    self.registering = NO;
+    if (self.scheduledRetryToken) {
+        self.retryCanceller(self.scheduledRetryToken);
+        self.scheduledRetryToken = nil;
+    }
+    self.retryScheduled = NO;
+    self.scheduledRetryDelay = 0;
+    if (success) self.retryAttempt = 0;
+    HAAPIClient *finishedClient = self.apiClient;
+    self.apiClient = nil;
+    self.pendingURLs = nil;
+    self.existingEntries = nil;
+    self.username = nil;
+    self.password = nil;
+    self.credentialRevision = nil;
+    self.framesPerSecond = 0;
+    self.activeAuthenticationRevision = 0;
+    self.activeServerOriginToken = nil;
+    self.activeFlowID = nil;
+    self.activeFlowIsOptionsFlow = NO;
+    void (^completion)(BOOL, NSError *) = self.completion;
+    self.completion = nil;
+    [finishedClient cancelAllRequests];
+    [self postChange];
+    if (completion) completion(success, error);
+}
+
+- (void)cancelRegistration {
+    self.cancellationGeneration++;
+    if (self.scheduledRetryToken) {
+        self.retryCanceller(self.scheduledRetryToken);
+        self.scheduledRetryToken = nil;
+    }
+    HAAPIClient *cancelledClient = self.apiClient;
+    self.apiClient = nil;
+    self.registering = NO;
+    self.pendingURLs = nil;
+    self.existingEntries = nil;
+    self.deviceName = nil;
+    self.username = nil;
+    self.password = nil;
+    self.credentialRevision = nil;
+    self.framesPerSecond = 0;
+    self.activeAuthenticationRevision = 0;
+    self.activeServerOriginToken = nil;
+    self.activeFlowID = nil;
+    self.activeFlowIsOptionsFlow = NO;
+    self.retryScheduled = NO;
+    self.retryAttempt = 0;
+    self.scheduledRetryDelay = 0;
+    self.currentIndex = 0;
+    self.resultEntryIDs = nil;
+    self.completion = nil;
+    [cancelledClient cancelAllRequests];
+    [self postChange];
+}
+
+- (void)resetLocalRegistrationState {
+    [self cancelRegistration];
+    [[NSUserDefaults standardUserDefaults]
+        removeObjectForKey:kHALegacyCameraInsecureConsentOriginKey];
+    self.registeredEntryIDs = @[];
+    self.lastError = nil;
+    [self postChange];
+}
+
+- (void)postChange {
+    [[NSNotificationCenter defaultCenter] postNotificationName:HACameraRegistrationDidChangeNotification object:self];
+}
+
+@end

--- a/HADashboard/Networking/HAConnectionManager.h
+++ b/HADashboard/Networking/HAConnectionManager.h
@@ -117,9 +117,17 @@ extern NSString *const HAConnectionManagerHADidStartNotification;              /
                           handler:(void (^)(NSDictionary *eventData))handler;
 
 /// Subscribe with an arbitrary WebSocket command (e.g. mobile_app/push_notification_channel).
-/// Returns subscription message ID. The handler is called for each message on that subscription.
+/// Returns subscription message ID. The handler receives the raw `event`
+/// object for each message on that subscription.
 - (NSInteger)subscribeWithCommand:(NSDictionary *)command
                           handler:(void (^)(NSDictionary *eventData))handler;
+
+/// Subscribe with an arbitrary command and report whether Home Assistant
+/// accepted the subscription. The event handler remains registered only after
+/// a successful result response.
+- (NSInteger)subscribeWithCommand:(NSDictionary *)command
+                          handler:(void (^)(NSDictionary *eventData))handler
+                       completion:(void (^)(BOOL success, NSError *error))completion;
 
 /// Unsubscribe from a previously registered event subscription.
 - (void)unsubscribeFromEventWithId:(NSInteger)subscriptionId;

--- a/HADashboard/Networking/HAConnectionManager.m
+++ b/HADashboard/Networking/HAConnectionManager.m
@@ -615,14 +615,30 @@ static const NSTimeInterval kReconnectMaxInterval  = 60.0;
     return [self subscribeWithCommand:@{
         @"type": @"subscribe_events",
         @"event_type": eventType,
-    } handler:handler];
+    } handler:^(NSDictionary *event) {
+        handler(event[@"data"] ?: event);
+    }];
 }
 
 - (NSInteger)subscribeWithCommand:(NSDictionary *)command
                           handler:(void (^)(NSDictionary *eventData))handler {
+    return [self subscribeWithCommand:command handler:handler completion:nil];
+}
+
+- (NSInteger)subscribeWithCommand:(NSDictionary *)command
+                          handler:(void (^)(NSDictionary *eventData))handler
+                       completion:(void (^)(BOOL success, NSError *error))completion {
     if (!self.wsClient.isAuthenticated || !handler) return 0;
     NSInteger msgId = [self.wsClient sendCommand:command];
     self.eventHandlers[@(msgId)] = [handler copy];
+    if (completion) {
+        __weak typeof(self) weakSelf = self;
+        self.pendingCompletions[@(msgId)] = ^(id result, NSError *error) {
+            (void)result;
+            if (error) [weakSelf.eventHandlers removeObjectForKey:@(msgId)];
+            completion(error == nil, error);
+        };
+    }
     return msgId;
 }
 
@@ -1236,9 +1252,12 @@ static const NSTimeInterval kReconnectMaxInterval  = 60.0;
         NSInteger subId = [message[@"id"] integerValue];
         void (^handler)(NSDictionary *) = self.eventHandlers[@(subId)];
         if (handler) {
-            NSDictionary *eventData = event[@"data"] ?: event;
             dispatch_async(dispatch_get_main_queue(), ^{
-                handler(eventData);
+                // Arbitrary subscriptions receive the raw event object. A
+                // mobile-app push payload has its own `data` member; unwrapping
+                // it here would discard message and hass_confirm_id. Typed
+                // subscribe_events callers unwrap their event data explicitly.
+                handler(event);
             });
         }
 

--- a/HADashboard/Networking/HADeviceIntegrationManager.m
+++ b/HADashboard/Networking/HADeviceIntegrationManager.m
@@ -5,6 +5,7 @@
 #import "HANotificationPresenter.h"
 #import "HADeviceRegistration.h"
 #import "HAConnectionManager.h"
+#import "HACameraRegistrationManager.h"
 
 extern NSString *const HARemoteCommandReloadNotification;
 
@@ -14,6 +15,10 @@ static NSString *const kEnabledKey = @"HADeviceIntegration_enabled";
 @property (nonatomic, strong) HASensorReporter *sensorReporter;
 @property (nonatomic, strong) HARemoteCommandHandler *commandHandler;
 @property (nonatomic, assign) BOOL running;
+@property (nonatomic, assign) BOOL registering;
+@property (nonatomic, assign) BOOL registrationMetadataRefreshInFlight;
+@property (nonatomic, assign) BOOL registrationMetadataRefreshComplete;
+- (void)refreshRegistrationMetadataIfNeeded;
 @end
 
 @implementation HADeviceIntegrationManager
@@ -58,10 +63,13 @@ static NSString *const kEnabledKey = @"HADeviceIntegration_enabled";
 - (void)setEnabled:(BOOL)enabled {
     _enabled = enabled;
     [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kEnabledKey];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+    CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
 
-    if (enabled && self.isRegistered && [HAConnectionManager sharedManager].isConnected) {
-        [self start];
+    if (enabled && [HAConnectionManager sharedManager].isConnected) {
+        [self ensureRegistrationThenStart];
     } else if (!enabled) {
+        [[HACameraRegistrationManager sharedManager] cancelRegistration];
         [self stop];
     }
 }
@@ -73,6 +81,8 @@ static NSString *const kEnabledKey = @"HADeviceIntegration_enabled";
     if (!self.enabled || !self.isRegistered) return;
 
     self.running = YES;
+
+    [self refreshRegistrationMetadataIfNeeded];
 
     // Start sensor reporting
     self.sensorReporter = [[HASensorReporter alloc] init];
@@ -87,6 +97,26 @@ static NSString *const kEnabledKey = @"HADeviceIntegration_enabled";
 
     // Start notification presenter (displays non-command notifications as banners)
     [[HANotificationPresenter sharedPresenter] start];
+}
+
+- (void)refreshRegistrationMetadataIfNeeded {
+    if (self.registrationMetadataRefreshComplete ||
+        self.registrationMetadataRefreshInFlight) return;
+
+    self.registrationMetadataRefreshInFlight = YES;
+    __weak typeof(self) weakSelf = self;
+    [[HADeviceRegistration sharedManager]
+        updateRegistrationMetadataWithCompletion:^(BOOL success, NSError *error) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        strongSelf.registrationMetadataRefreshInFlight = NO;
+        if (success) {
+            strongSelf.registrationMetadataRefreshComplete = YES;
+        } else {
+            HALogW(@"device", @"Will retry registration metadata refresh after reconnect: %@",
+                   error.localizedDescription ?: @"Unknown error");
+        }
+    }];
 }
 
 - (void)stop {
@@ -104,15 +134,26 @@ static NSString *const kEnabledKey = @"HADeviceIntegration_enabled";
 #pragma mark - Notifications
 
 - (void)connectionDidConnect:(NSNotification *)note {
-    if (self.enabled && self.isRegistered) {
-        if (self.running) {
-            // Already running (e.g. registration completed before WS was ready).
-            // Retry the push channel now that WS is authenticated.
-            [self.commandHandler startListening];
-        } else {
-            [self start];
-        }
+    if (self.enabled) [self ensureRegistrationThenStart];
+}
+
+- (void)ensureRegistrationThenStart {
+    if (!self.enabled || ![HAConnectionManager sharedManager].isConnected) return;
+    if (self.isRegistered) {
+        if (self.running) [self.commandHandler startListening];
+        else [self start];
+        return;
     }
+    if (self.registering) return;
+    self.registering = YES;
+    [[HADeviceRegistration sharedManager] registerWithCompletion:^(BOOL success, NSError *error) {
+        self.registering = NO;
+        if (success) {
+            [self start];
+        } else {
+            HALogE(@"device", @"Automatic registration failed: %@", error.localizedDescription);
+        }
+    }];
 }
 
 - (void)connectionDidDisconnect:(NSNotification *)note {

--- a/HADashboard/Networking/HADeviceRegistration.h
+++ b/HADashboard/Networking/HADeviceRegistration.h
@@ -30,9 +30,18 @@ extern NSString *const HADeviceRegistrationDidInvalidateNotification;
 /// Calls completion on the main queue.
 - (void)registerWithCompletion:(void (^)(BOOL success, NSError *error))completion;
 
+/// Refresh the existing Home Assistant mobile-app registration with the
+/// current device metadata and WebSocket-only local-push capability. This also
+/// removes obsolete placeholder cloud-push fields from older registrations.
+- (void)updateRegistrationMetadataWithCompletion:(void (^)(BOOL success, NSError *error))completion;
+
 /// Clear local registration (webhook_id, cloudhook, remote_ui).
 /// Does NOT unregister from HA server (no API for that).
 - (void)unregister;
+
+/// Clear all local registration state, including the persistent device ID.
+/// Home Assistant entities/config entries remain on the user's server.
+- (void)resetLocalRegistration;
 
 /// Send a webhook request to HA.
 /// @param type The webhook type (e.g. "register_sensor", "update_sensor_states").
@@ -44,5 +53,9 @@ extern NSString *const HADeviceRegistrationDidInvalidateNotification;
 
 /// Resolved webhook URL (cloudhook > remote_ui > local). Nil if not registered.
 - (NSURL *)resolvedWebhookURL;
+
+/// YES only when the currently selected webhook endpoint is a loopback,
+/// link-local, RFC1918, or .local address.
+- (BOOL)resolvedWebhookUsesLocalNetwork;
 
 @end

--- a/HADashboard/Networking/HADeviceRegistration.m
+++ b/HADashboard/Networking/HADeviceRegistration.m
@@ -3,7 +3,9 @@
 #import "HAAuthManager.h"
 #import "HAKeychainHelper.h"
 #import "NSMutableURLRequest+HAHelpers.h"
+#import "HAURLSessionRedirectGuard.h"
 #import <UIKit/UIKit.h>
+#import <arpa/inet.h>
 #import <sys/utsname.h>
 
 NSString *const HADeviceRegistrationDidCompleteNotification  = @"HADeviceRegistrationDidComplete";
@@ -17,11 +19,40 @@ static NSString *const kKeychainDeviceId     = @"ha_device_id";
 /// NSUserDefaults key for user-overridden device name (from Settings UI).
 static NSString *const kDeviceNameOverride   = @"ha_device_name_override";
 
+static BOOL HAWebhookHostIsLocalNetwork(NSString *host) {
+    NSString *value = host.lowercaseString;
+    if (!value.length) return NO;
+    if ([value isEqualToString:@"localhost"] || [value hasSuffix:@".local"]) return YES;
+
+    struct in_addr ipv4;
+    if (inet_pton(AF_INET, value.UTF8String, &ipv4) == 1) {
+        uint32_t address = ntohl(ipv4.s_addr);
+        return (address & 0xFF000000) == 0x0A000000 ||
+               (address & 0xFFF00000) == 0xAC100000 ||
+               (address & 0xFFFF0000) == 0xC0A80000 ||
+               (address & 0xFF000000) == 0x7F000000 ||
+               (address & 0xFFFF0000) == 0xA9FE0000;
+    }
+
+    struct in6_addr ipv6;
+    if (inet_pton(AF_INET6, value.UTF8String, &ipv6) == 1) {
+        const uint8_t *bytes = ipv6.s6_addr;
+        BOOL loopback = IN6_IS_ADDR_LOOPBACK(&ipv6);
+        BOOL linkLocal = bytes[0] == 0xFE && (bytes[1] & 0xC0) == 0x80;
+        BOOL uniqueLocal = (bytes[0] & 0xFE) == 0xFC;
+        return loopback || linkLocal || uniqueLocal;
+    }
+    return NO;
+}
+
 @interface HADeviceRegistration ()
 @property (nonatomic, copy) NSString *webhookId;
 @property (nonatomic, copy) NSString *cloudhookURL;
 @property (nonatomic, copy) NSString *remoteUIURL;
 @property (nonatomic, strong) NSURLSession *session;
+- (NSDictionary *)registrationBody;
+- (NSDictionary *)registrationUpdateBody;
+- (NSDictionary *)webSocketPushAppData;
 @end
 
 @implementation HADeviceRegistration
@@ -38,7 +69,9 @@ static NSString *const kDeviceNameOverride   = @"ha_device_name_override";
 - (instancetype)init {
     self = [super init];
     if (self) {
-        _session = [NSURLSession sessionWithConfiguration:[NSMutableURLRequest ha_defaultSessionConfiguration]];
+        _session = [NSURLSession sessionWithConfiguration:[NSMutableURLRequest ha_defaultSessionConfiguration]
+                                                  delegate:[HAURLSessionRedirectGuard sharedGuard]
+                                             delegateQueue:nil];
         // Restore from Keychain
         _webhookId    = [HAKeychainHelper stringForKey:kKeychainWebhookId];
         _cloudhookURL = [HAKeychainHelper stringForKey:kKeychainCloudhookURL];
@@ -135,7 +168,7 @@ static NSString *const kDeviceNameOverride   = @"ha_device_name_override";
             if (strongSelf.cloudhookURL) [HAKeychainHelper setString:strongSelf.cloudhookURL forKey:kKeychainCloudhookURL];
             if (strongSelf.remoteUIURL)  [HAKeychainHelper setString:strongSelf.remoteUIURL forKey:kKeychainRemoteUIURL];
 
-            HALogI(@"device", @"Registered with webhook_id: %@", strongSelf.webhookId);
+            HALogI(@"device", @"Registered; webhook credential stored in Keychain");
 
             dispatch_async(dispatch_get_main_queue(), ^{
                 [[NSNotificationCenter defaultCenter] postNotificationName:HADeviceRegistrationDidCompleteNotification
@@ -147,6 +180,30 @@ static NSString *const kDeviceNameOverride   = @"ha_device_name_override";
     [task resume];
 }
 
+- (void)updateRegistrationMetadataWithCompletion:(void (^)(BOOL, NSError *))completion {
+    if (!self.isRegistered) {
+        NSError *error = [NSError errorWithDomain:@"HADeviceRegistration" code:-3
+            userInfo:@{NSLocalizedDescriptionKey: @"Not registered — no webhook URL"}];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (completion) completion(NO, error);
+        });
+        return;
+    }
+
+    [self sendWebhookWithType:@"update_registration"
+                         data:[self registrationUpdateBody]
+                   completion:^(id response, NSError *error) {
+        (void)response;
+        if (error) {
+            HALogW(@"device", @"Registration metadata refresh failed: %@",
+                   error.localizedDescription);
+        } else {
+            HALogI(@"device", @"Registration metadata refreshed for WebSocket-only local push");
+        }
+        if (completion) completion(error == nil, error);
+    }];
+}
+
 - (void)unregister {
     self.webhookId    = nil;
     self.cloudhookURL = nil;
@@ -155,6 +212,12 @@ static NSString *const kDeviceNameOverride   = @"ha_device_name_override";
     [HAKeychainHelper removeItemForKey:kKeychainCloudhookURL];
     [HAKeychainHelper removeItemForKey:kKeychainRemoteUIURL];
     HALogI(@"device", @"Unregistered (local credentials cleared)");
+}
+
+- (void)resetLocalRegistration {
+    [self unregister];
+    [HAKeychainHelper removeItemForKey:kKeychainDeviceId];
+    HALogI(@"device", @"Persistent local device identity cleared");
 }
 
 #pragma mark - Webhook
@@ -179,6 +242,10 @@ static NSString *const kDeviceNameOverride   = @"ha_device_name_override";
     NSString *base = [serverURL stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"/"]];
     NSString *url = [NSString stringWithFormat:@"%@/api/webhook/%@", base, self.webhookId];
     return [NSURL URLWithString:url];
+}
+
+- (BOOL)resolvedWebhookUsesLocalNetwork {
+    return HAWebhookHostIsLocalNetwork(self.resolvedWebhookURL.host);
 }
 
 - (void)sendWebhookWithType:(NSString *)type
@@ -271,19 +338,27 @@ static NSString *const kDeviceNameOverride   = @"ha_device_name_override";
         @"os_name":              @"iOS",
         @"os_version":           [UIDevice currentDevice].systemVersion,
         @"supports_encryption":  @NO,
-        // push_url + push_token tell HA to create the notify platform for this device.
-        // We use the WebSocket push_notification_channel instead of actual APNs,
-        // so push_url is never called — but both fields are required for HA to
-        // register the notify.mobile_app_<device> service. HA validates them as
-        // an inclusion group ("push_cloud") and rejects if only one is present.
-        // Explicitly advertise the local delivery channel as well; this makes
-        // the WebSocket route first-class rather than relying on cloud-push
-        // capability inference from the placeholder fields above.
-        @"app_data":             @{
-            @"push_url": @"https://mobile-apps.home-assistant.io/api/sendPush/ios",
-            @"push_token": @"websocket-local-push",
-            @"push_websocket_channel": @YES,
-        },
+        // Home Assistant creates the notify.mobile_app_<device> target from
+        // this capability alone. Do not advertise placeholder APNs/cloud-push
+        // fields: when the local channel is absent HA would otherwise attempt
+        // an unnecessary external fallback with a fake token.
+        @"app_data":             [self webSocketPushAppData],
+    };
+}
+
+- (NSDictionary *)webSocketPushAppData {
+    return @{ @"push_websocket_channel": @YES };
+}
+
+- (NSDictionary *)registrationUpdateBody {
+    NSDictionary *info = [[NSBundle mainBundle] infoDictionary];
+    return @{
+        @"app_version": info[@"CFBundleShortVersionString"] ?: @"0.0.0",
+        @"device_name": self.deviceName,
+        @"manufacturer": @"Apple",
+        @"model": [self machineModel],
+        @"os_version": [UIDevice currentDevice].systemVersion,
+        @"app_data": [self webSocketPushAppData],
     };
 }
 

--- a/HADashboard/Networking/HAURLSessionRedirectGuard.h
+++ b/HADashboard/Networking/HAURLSessionRedirectGuard.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Stateless NSURLSession delegate that permits redirects only when scheme,
+/// host, and effective port match the task's original request URL.
+@interface HAURLSessionRedirectGuard : NSObject <NSURLSessionTaskDelegate>
+
+@property (class, nonatomic, readonly) HAURLSessionRedirectGuard *sharedGuard;
+
+/// Returns YES when both URLs have the same scheme, host, and effective port.
++ (BOOL)URL:(NSURL *)left sharesOriginWithURL:(NSURL *)right;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/HADashboard/Networking/HAURLSessionRedirectGuard.m
+++ b/HADashboard/Networking/HAURLSessionRedirectGuard.m
@@ -1,0 +1,41 @@
+#import "HAURLSessionRedirectGuard.h"
+
+static NSNumber *HAEffectiveURLPort(NSURL *URL) {
+    if (URL.port) return URL.port;
+    NSString *scheme = URL.scheme.lowercaseString;
+    if ([scheme isEqualToString:@"https"]) return @443;
+    if ([scheme isEqualToString:@"http"]) return @80;
+    return nil;
+}
+
+@implementation HAURLSessionRedirectGuard
+
++ (HAURLSessionRedirectGuard *)sharedGuard {
+    static HAURLSessionRedirectGuard *guard;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ guard = [[self alloc] init]; });
+    return guard;
+}
+
++ (BOOL)URL:(NSURL *)left sharesOriginWithURL:(NSURL *)right {
+    if (!left || !right) return NO;
+    NSNumber *leftPort = HAEffectiveURLPort(left);
+    NSNumber *rightPort = HAEffectiveURLPort(right);
+    return leftPort && rightPort &&
+           [left.scheme.lowercaseString isEqualToString:right.scheme.lowercaseString] &&
+           [left.host.lowercaseString isEqualToString:right.host.lowercaseString] &&
+           [leftPort isEqualToNumber:rightPort];
+}
+
+- (void)URLSession:(NSURLSession *)session
+              task:(NSURLSessionTask *)task
+willPerformHTTPRedirection:(NSHTTPURLResponse *)response
+        newRequest:(NSURLRequest *)request
+ completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
+    (void)session;
+    (void)response;
+    completionHandler([[self class] URL:task.originalRequest.URL
+                          sharesOriginWithURL:request.URL] ? request : nil);
+}
+
+@end

--- a/HADashboard/PrivacyInfo.xcprivacy
+++ b/HADashboard/PrivacyInfo.xcprivacy
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>85F4.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/HADashboard/Streaming/HAAACEncoder.h
+++ b/HADashboard/Streaming/HAAACEncoder.h
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+#import <CoreMedia/CoreMedia.h>
+
+/// In-tree linear-PCM-to-AAC-LC encoder. AVCaptureAudioDataOutput provides
+/// PCM on iOS, so this avoids depending on an unavailable capture-output
+/// compression setting or a Swift publisher library.
+@interface HAAACEncoder : NSObject
+
+@property (nonatomic, copy, readonly) NSData *audioSpecificConfig;
+@property (nonatomic, readonly) NSUInteger channelCount;
+
+- (instancetype)initWithInputFormat:(CMAudioFormatDescriptionRef)inputFormat error:(NSError **)error;
+- (NSData *)encodeSampleBuffer:(CMSampleBufferRef)sampleBuffer error:(NSError **)error;
+
+@end

--- a/HADashboard/Streaming/HAAACEncoder.m
+++ b/HADashboard/Streaming/HAAACEncoder.m
@@ -1,0 +1,190 @@
+#import "HAAACEncoder.h"
+#import <AudioToolbox/AudioToolbox.h>
+#include <math.h>
+
+static NSString *const HAAACEncoderErrorDomain = @"HAAACEncoderErrorDomain";
+// AudioConverter treats zero packets plus noErr as permanent end-of-stream.
+// Live capture is only temporarily out of input at the end of each callback,
+// so return a private status instead and keep the converter reusable.
+static const OSStatus HAAACEncoderNoInputAvailable = -77701;
+
+@interface HAAACEncoder ()
+@property (nonatomic, assign) AudioConverterRef converter;
+@property (nonatomic, assign) UInt32 maximumOutputPacketSize;
+@property (nonatomic, assign) AudioBufferList *inputBufferList;
+@property (nonatomic, assign) UInt32 inputPacketCount;
+@property (nonatomic, assign) BOOL consumedInput;
+@property (nonatomic, assign) UInt32 inputBytesPerFrame;
+@property (nonatomic, assign) UInt32 inputFramesPerPacket;
+@property (nonatomic, assign) UInt32 framesPerAACPacket;
+@property (nonatomic, strong) NSMutableData *pendingPCM;
+@property (nonatomic, copy, readwrite) NSData *audioSpecificConfig;
+@property (nonatomic, assign, readwrite) NSUInteger channelCount;
+@end
+
+static OSStatus HAAACEncoderInputProc(AudioConverterRef inAudioConverter,
+                                      UInt32 *ioNumberDataPackets,
+                                      AudioBufferList *ioData,
+                                      AudioStreamPacketDescription **outDataPacketDescription,
+                                      void *inUserData) {
+    (void)inAudioConverter;
+    HAAACEncoder *encoder = (__bridge HAAACEncoder *)inUserData;
+    if (encoder.consumedInput || !encoder.inputBufferList) {
+        *ioNumberDataPackets = 0;
+        if (ioData) {
+            for (UInt32 index = 0; index < ioData->mNumberBuffers; index++) {
+                ioData->mBuffers[index].mData = NULL;
+                ioData->mBuffers[index].mDataByteSize = 0;
+            }
+        }
+        return HAAACEncoderNoInputAvailable;
+    }
+    *ioNumberDataPackets = encoder.inputPacketCount;
+    *ioData = *encoder.inputBufferList;
+    if (outDataPacketDescription) *outDataPacketDescription = NULL;
+    encoder.consumedInput = YES;
+    return noErr;
+}
+
+@implementation HAAACEncoder
+
+- (instancetype)initWithInputFormat:(CMAudioFormatDescriptionRef)inputFormat error:(NSError **)error {
+    const AudioStreamBasicDescription *input = CMAudioFormatDescriptionGetStreamBasicDescription(inputFormat);
+    if (!input || input->mFormatID != kAudioFormatLinearPCM || input->mChannelsPerFrame == 0 || input->mChannelsPerFrame > 2) {
+        if (error) *error = [self errorWithDescription:@"The microphone format cannot be encoded as AAC-LC."];
+        return nil;
+    }
+    self = [super init];
+    if (self) {
+        AudioStreamBasicDescription output = {0};
+        output.mSampleRate = input->mSampleRate;
+        output.mFormatID = kAudioFormatMPEG4AAC;
+        output.mChannelsPerFrame = input->mChannelsPerFrame;
+        UInt32 outputSize = sizeof(output);
+        OSStatus formatStatus = AudioFormatGetProperty(kAudioFormatProperty_FormatInfo, 0, NULL, &outputSize, &output);
+        OSStatus converterStatus = formatStatus == noErr ? AudioConverterNew(input, &output, &_converter) : formatStatus;
+        if (converterStatus != noErr || !_converter) {
+            if (error) *error = [self errorWithDescription:@"The device could not create an AAC-LC microphone encoder."];
+            return nil;
+        }
+        if (input->mBytesPerFrame == 0 || input->mFramesPerPacket == 0 || output.mFramesPerPacket == 0) {
+            AudioConverterDispose(_converter);
+            _converter = NULL;
+            if (error) *error = [self errorWithDescription:@"The microphone packet format is unsupported by the AAC publisher."];
+            return nil;
+        }
+        UInt32 packetSizeLength = sizeof(_maximumOutputPacketSize);
+        AudioConverterGetProperty(_converter, kAudioConverterPropertyMaximumOutputPacketSize, &packetSizeLength, &_maximumOutputPacketSize);
+        if (_maximumOutputPacketSize == 0) _maximumOutputPacketSize = 8192;
+        NSInteger frequencyIndex = [self frequencyIndexForSampleRate:output.mSampleRate];
+        if (frequencyIndex < 0) {
+            AudioConverterDispose(_converter);
+            _converter = NULL;
+            if (error) *error = [self errorWithDescription:@"The microphone sample rate is unsupported by the AAC publisher."];
+            return nil;
+        }
+        _channelCount = output.mChannelsPerFrame;
+        _inputBytesPerFrame = input->mBytesPerFrame;
+        _inputFramesPerPacket = input->mFramesPerPacket;
+        _framesPerAACPacket = output.mFramesPerPacket;
+        _pendingPCM = [NSMutableData data];
+        uint16_t asc = (uint16_t)((2 << 11) | (frequencyIndex << 7) | (_channelCount << 3));
+        uint8_t ascBytes[2] = { (uint8_t)(asc >> 8), (uint8_t)asc };
+        _audioSpecificConfig = [NSData dataWithBytes:ascBytes length:sizeof(ascBytes)];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    if (_converter) AudioConverterDispose(_converter);
+}
+
+- (NSData *)encodeSampleBuffer:(CMSampleBufferRef)sampleBuffer error:(NSError **)error {
+    if (!_converter || !sampleBuffer) return nil;
+    size_t listSize = 0;
+    OSStatus sizeStatus = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(sampleBuffer, &listSize, NULL, 0,
+        kCFAllocatorDefault, kCFAllocatorDefault, 0, NULL);
+    if (sizeStatus != noErr || listSize == 0) {
+        if (error) *error = [self errorWithDescription:@"The microphone audio buffer could not be read."];
+        return nil;
+    }
+    AudioBufferList *list = malloc(listSize);
+    CMBlockBufferRef blockBuffer = NULL;
+    OSStatus listStatus = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(sampleBuffer, &listSize, list, listSize,
+        kCFAllocatorDefault, kCFAllocatorDefault, 0, &blockBuffer);
+    if (listStatus != noErr) {
+        free(list);
+        if (error) *error = [self errorWithDescription:@"The microphone audio buffer could not be prepared."];
+        return nil;
+    }
+    if (list->mNumberBuffers != 1 || !list->mBuffers[0].mData || list->mBuffers[0].mDataByteSize == 0) {
+        if (blockBuffer) CFRelease(blockBuffer);
+        free(list);
+        if (error) *error = [self errorWithDescription:@"The microphone format cannot be packetized as AAC-LC."];
+        return nil;
+    }
+    [self.pendingPCM appendBytes:list->mBuffers[0].mData length:list->mBuffers[0].mDataByteSize];
+    if (blockBuffer) CFRelease(blockBuffer);
+    free(list);
+
+    UInt32 requiredBytes = self.framesPerAACPacket * self.inputBytesPerFrame;
+    if (requiredBytes == 0 || self.pendingPCM.length < requiredBytes) return nil;
+
+    AudioBufferList input = {0};
+    input.mNumberBuffers = 1;
+    input.mBuffers[0].mNumberChannels = (UInt32)self.channelCount;
+    input.mBuffers[0].mDataByteSize = requiredBytes;
+    input.mBuffers[0].mData = (void *)self.pendingPCM.bytes;
+    self.inputBufferList = &input;
+    self.inputPacketCount = self.framesPerAACPacket / self.inputFramesPerPacket;
+    self.consumedInput = NO;
+
+    uint8_t *outputBytes = malloc(self.maximumOutputPacketSize);
+    AudioBufferList output = {0};
+    output.mNumberBuffers = 1;
+    output.mBuffers[0].mNumberChannels = (UInt32)self.channelCount;
+    output.mBuffers[0].mDataByteSize = self.maximumOutputPacketSize;
+    output.mBuffers[0].mData = outputBytes;
+    UInt32 outputPackets = 1;
+    AudioStreamPacketDescription packetDescription = {0};
+    OSStatus encodeStatus = AudioConverterFillComplexBuffer(self.converter, HAAACEncoderInputProc, (__bridge void *)self,
+        &outputPackets, &output, &packetDescription);
+
+    self.inputBufferList = NULL;
+    if (self.consumedInput) [self.pendingPCM replaceBytesInRange:NSMakeRange(0, requiredBytes) withBytes:NULL length:0];
+    if (encodeStatus == HAAACEncoderNoInputAvailable &&
+        packetDescription.mDataByteSize == 0) {
+        outputPackets = 0;
+        output.mBuffers[0].mDataByteSize = 0;
+    } else if (encodeStatus != noErr && encodeStatus != HAAACEncoderNoInputAvailable) {
+        free(outputBytes);
+        if (error) *error = [self errorWithDescription:@"The AAC microphone encoder failed."];
+        return nil;
+    }
+    UInt32 offset = outputPackets > 0 ? packetDescription.mStartOffset : 0;
+    UInt32 length = outputPackets > 0 ? packetDescription.mDataByteSize : 0;
+    if (length == 0 && outputPackets > 0) length = output.mBuffers[0].mDataByteSize;
+    if (offset > output.mBuffers[0].mDataByteSize || length > output.mBuffers[0].mDataByteSize - offset) {
+        free(outputBytes);
+        if (error) *error = [self errorWithDescription:@"The AAC microphone encoder produced an invalid packet."];
+        return nil;
+    }
+    NSData *encoded = outputPackets > 0 && length > 0
+        ? [NSData dataWithBytes:outputBytes + offset length:length] : nil;
+    free(outputBytes);
+    return encoded;
+}
+
+- (NSInteger)frequencyIndexForSampleRate:(Float64)sampleRate {
+    static const NSInteger frequencies[] = { 96000, 88200, 64000, 48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000 };
+    for (NSInteger index = 0; index < 12; index++) {
+        if (fabs(sampleRate - frequencies[index]) < 1.0) return index;
+    }
+    return -1;
+}
+
+- (NSError *)errorWithDescription:(NSString *)description {
+    return [NSError errorWithDomain:HAAACEncoderErrorDomain code:1 userInfo:@{NSLocalizedDescriptionKey: description}];
+}
+
+@end

--- a/HADashboard/Streaming/HARTSPCredentialManager.h
+++ b/HADashboard/Streaming/HARTSPCredentialManager.h
@@ -1,0 +1,68 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+FOUNDATION_EXPORT NSString *const HARTSPCredentialErrorDomain;
+FOUNDATION_EXPORT NSString *const HARTSPCredentialUsername;
+
+typedef NS_ENUM(NSInteger, HARTSPCredentialErrorCode) {
+    HARTSPCredentialErrorRandomGenerationFailed = 1,
+    HARTSPCredentialErrorKeychainFailure = 2,
+    HARTSPCredentialErrorInvalidStoredCredential = 3,
+};
+
+/// An immutable username/password pair for authenticating an RTSP client.
+///
+/// Passwords are intentionally absent from `description` and `debugDescription`.
+/// Callers must also avoid placing the password in logs, telemetry, sensor state,
+/// or a URL that may be retained outside the app.
+@interface HARTSPCredentials : NSObject <NSCopying>
+
+@property (nonatomic, copy, readonly) NSString *username;
+@property (nonatomic, copy, readonly) NSString *password;
+
+/// Opaque, non-secret identifier that changes whenever the password rotates.
+///
+/// This value is safe to persist as an options-flow synchronization marker. It
+/// is not an authenticator and must not be accepted in place of the password.
+@property (nonatomic, copy, readonly) NSString *revision;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+@end
+
+/// Owns the single per-device RTSP credential used by HA Dashboard streams.
+///
+/// The password is generated lazily, survives feature toggles and application
+/// upgrades, and is stored only in the device Keychain. This-device-only
+/// accessibility deliberately prevents backup or migration to another device.
+@interface HARTSPCredentialManager : NSObject
+
+@property (class, nonatomic, readonly) HARTSPCredentialManager *sharedManager;
+
+/// The fixed, non-secret username (`hadashboard`).
+@property (nonatomic, copy, readonly) NSString *username;
+
+/// Creates a manager backed by a specific Keychain service.
+///
+/// The shared manager should be used in production. This initializer permits
+/// isolated Keychain stores in focused tests without changing process state.
+- (nullable instancetype)initWithServiceIdentifier:(NSString *)serviceIdentifier
+    NS_DESIGNATED_INITIALIZER;
+
+/// Uses a bundle-identifier-scoped Keychain service.
+- (instancetype)init;
+
+/// Returns the stored credential, generating and persisting it when absent.
+- (nullable HARTSPCredentials *)credentialsWithError:(NSError **)error;
+
+/// Atomically replaces the password and revision and returns the new values.
+- (nullable HARTSPCredentials *)rotateCredentialsWithError:(NSError **)error;
+
+/// Deletes the credential. A later access generates a fresh password/revision.
+- (BOOL)deleteCredentialsWithError:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/HADashboard/Streaming/HARTSPCredentialManager.m
+++ b/HADashboard/Streaming/HARTSPCredentialManager.m
@@ -1,0 +1,413 @@
+#import "HARTSPCredentialManager.h"
+
+#import <Security/Security.h>
+
+NSString *const HARTSPCredentialErrorDomain = @"HARTSPCredentialErrorDomain";
+NSString *const HARTSPCredentialUsername = @"hadashboard";
+
+static NSUInteger const HARTSPPasswordRandomByteCount = 24;
+static NSUInteger const HARTSPRevisionRandomByteCount = 16;
+static NSString *const HARTSPDefaultServiceSuffix = @".rtsp-stream-credentials";
+
+@interface HARTSPCredentials ()
+
+- (instancetype)initWithPassword:(NSString *)password revision:(NSString *)revision;
+
+@end
+
+@implementation HARTSPCredentials
+
+- (instancetype)initWithPassword:(NSString *)password revision:(NSString *)revision {
+    self = [super init];
+    if (self) {
+        _username = [HARTSPCredentialUsername copy];
+        _password = [password copy];
+        _revision = [revision copy];
+    }
+    return self;
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    return self;
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@: %p; username=%@; revision=%@; password=<redacted>>",
+            NSStringFromClass([self class]), self, self.username, self.revision];
+}
+
+- (NSString *)debugDescription {
+    return self.description;
+}
+
+@end
+
+@interface HARTSPCredentialManager ()
+
+@property (nonatomic, copy) NSString *serviceIdentifier;
+
+@end
+
+@implementation HARTSPCredentialManager
+
++ (HARTSPCredentialManager *)sharedManager {
+    static HARTSPCredentialManager *manager = nil;
+    @synchronized(self) {
+        if (!manager) {
+            manager = [[self alloc] init];
+        }
+    }
+    return manager;
+}
+
+- (instancetype)init {
+    NSString *bundleIdentifier = [NSBundle mainBundle].bundleIdentifier;
+    if (bundleIdentifier.length == 0) {
+        bundleIdentifier = @"com.hadashboard.app";
+    }
+    return [self initWithServiceIdentifier:
+            [bundleIdentifier stringByAppendingString:HARTSPDefaultServiceSuffix]];
+}
+
+- (instancetype)initWithServiceIdentifier:(NSString *)serviceIdentifier {
+    if (serviceIdentifier.length == 0) {
+        return nil;
+    }
+
+    self = [super init];
+    if (self) {
+        _serviceIdentifier = [serviceIdentifier copy];
+    }
+    return self;
+}
+
+- (NSString *)username {
+    return HARTSPCredentialUsername;
+}
+
+- (HARTSPCredentials *)credentialsWithError:(NSError **)error {
+    if (error) {
+        *error = nil;
+    }
+
+    // Serialize in-process access across instances as well as the singleton.
+    // SecItemAdd's duplicate handling below also closes the lazy-create race.
+    @synchronized([HARTSPCredentialManager class]) {
+        OSStatus readStatus = errSecSuccess;
+        NSError *readError = nil;
+        HARTSPCredentials *stored = [self storedCredentialsWithStatus:&readStatus error:&readError];
+        if (stored) {
+            return stored;
+        }
+
+        // A malformed record cannot authenticate any legitimate client. Replace
+        // it atomically with a fresh credential so a damaged or pre-release
+        // Keychain item does not permanently strand the feature. Other Keychain
+        // failures remain fail-closed and are surfaced without modifying data.
+        if (readStatus == errSecSuccess &&
+            [readError.domain isEqualToString:HARTSPCredentialErrorDomain] &&
+            readError.code == HARTSPCredentialErrorInvalidStoredCredential) {
+            HARTSPCredentials *replacement = [self generateCredentialsWithError:error];
+            if (!replacement) {
+                return nil;
+            }
+            OSStatus replacementStatus = SecItemUpdate(
+                (__bridge CFDictionaryRef)[self baseQuery],
+                (__bridge CFDictionaryRef)[self valuesForCredentials:replacement
+                                                  includeAccessibility:YES]);
+            if (replacementStatus == errSecSuccess) {
+                return replacement;
+            }
+            [self assignError:error
+                          code:HARTSPCredentialErrorKeychainFailure
+                        status:replacementStatus
+                   description:@"The invalid RTSP access credential could not be replaced."];
+            return nil;
+        }
+        if (readStatus != errSecItemNotFound) {
+            if (error) {
+                *error = readError;
+            }
+            return nil;
+        }
+
+        HARTSPCredentials *generated = [self generateCredentialsWithError:error];
+        if (!generated) {
+            return nil;
+        }
+
+        OSStatus addStatus = [self addCredentials:generated];
+        if (addStatus == errSecSuccess) {
+            return generated;
+        }
+
+        // Another manager may have created the same service between the read
+        // and add. Prefer that stored value rather than rotating it.
+        if (addStatus == errSecDuplicateItem) {
+            OSStatus retryStatus = errSecSuccess;
+            NSError *retryError = nil;
+            HARTSPCredentials *retry = [self storedCredentialsWithStatus:&retryStatus
+                                                                    error:&retryError];
+            if (retry) {
+                return retry;
+            }
+            if (retryStatus != errSecItemNotFound && retryError) {
+                if (error) {
+                    *error = retryError;
+                }
+                return nil;
+            }
+            [self assignError:error
+                          code:HARTSPCredentialErrorKeychainFailure
+                        status:retryStatus
+                   description:@"The RTSP access credential changed while it was being saved."];
+            return nil;
+        }
+
+        [self assignError:error
+                      code:HARTSPCredentialErrorKeychainFailure
+                    status:addStatus
+               description:@"The RTSP access credential could not be saved."];
+        return nil;
+    }
+}
+
+- (HARTSPCredentials *)rotateCredentialsWithError:(NSError **)error {
+    if (error) {
+        *error = nil;
+    }
+
+    @synchronized([HARTSPCredentialManager class]) {
+        HARTSPCredentials *generated = [self generateCredentialsWithError:error];
+        if (!generated) {
+            return nil;
+        }
+
+        OSStatus status = SecItemUpdate((__bridge CFDictionaryRef)[self baseQuery],
+                                        (__bridge CFDictionaryRef)[self valuesForCredentials:generated
+                                                                         includeAccessibility:YES]);
+        if (status == errSecItemNotFound) {
+            status = [self addCredentials:generated];
+        }
+
+        if (status != errSecSuccess) {
+            [self assignError:error
+                          code:HARTSPCredentialErrorKeychainFailure
+                        status:status
+                   description:@"The RTSP access credential could not be rotated."];
+            return nil;
+        }
+        return generated;
+    }
+}
+
+- (BOOL)deleteCredentialsWithError:(NSError **)error {
+    if (error) {
+        *error = nil;
+    }
+
+    @synchronized([HARTSPCredentialManager class]) {
+        OSStatus status = SecItemDelete((__bridge CFDictionaryRef)[self baseQuery]);
+        if (status == errSecSuccess || status == errSecItemNotFound) {
+            return YES;
+        }
+
+        [self assignError:error
+                      code:HARTSPCredentialErrorKeychainFailure
+                    status:status
+               description:@"The RTSP access credential could not be deleted."];
+        return NO;
+    }
+}
+
+#pragma mark - Keychain
+
+- (NSDictionary *)baseQuery {
+    return @{
+        (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrService: self.serviceIdentifier,
+        (__bridge id)kSecAttrAccount: HARTSPCredentialUsername,
+    };
+}
+
+- (NSDictionary *)valuesForCredentials:(HARTSPCredentials *)credentials
+                   includeAccessibility:(BOOL)includeAccessibility {
+    NSMutableDictionary *values = [@{
+        (__bridge id)kSecValueData: [credentials.password dataUsingEncoding:NSUTF8StringEncoding],
+        (__bridge id)kSecAttrGeneric: [credentials.revision dataUsingEncoding:NSUTF8StringEncoding],
+    } mutableCopy];
+    if (includeAccessibility) {
+        values[(__bridge id)kSecAttrAccessible] =
+            (__bridge id)kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
+    }
+    return values;
+}
+
+- (OSStatus)addCredentials:(HARTSPCredentials *)credentials {
+    NSMutableDictionary *item = [[self baseQuery] mutableCopy];
+    [item addEntriesFromDictionary:[self valuesForCredentials:credentials includeAccessibility:YES]];
+    return SecItemAdd((__bridge CFDictionaryRef)item, NULL);
+}
+
+- (HARTSPCredentials *)storedCredentialsWithStatus:(OSStatus *)statusOut
+                                              error:(NSError **)error {
+    NSMutableDictionary *query = [[self baseQuery] mutableCopy];
+    query[(__bridge id)kSecReturnAttributes] = @YES;
+    query[(__bridge id)kSecReturnData] = @YES;
+    query[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitOne;
+
+    CFTypeRef rawResult = NULL;
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &rawResult);
+    if (statusOut) {
+        *statusOut = status;
+    }
+    if (status == errSecItemNotFound) {
+        return nil;
+    }
+    if (status != errSecSuccess) {
+        [self assignError:error
+                      code:HARTSPCredentialErrorKeychainFailure
+                    status:status
+               description:@"The RTSP access credential could not be read."];
+        if (rawResult) {
+            CFRelease(rawResult);
+        }
+        return nil;
+    }
+
+    id result = CFBridgingRelease(rawResult);
+    if (![result isKindOfClass:[NSDictionary class]]) {
+        [self assignError:error
+                      code:HARTSPCredentialErrorInvalidStoredCredential
+                    status:errSecSuccess
+               description:@"The stored RTSP access credential has an invalid format."];
+        return nil;
+    }
+
+    NSDictionary *attributes = result;
+    NSData *passwordData = attributes[(__bridge id)kSecValueData];
+    NSData *revisionData = attributes[(__bridge id)kSecAttrGeneric];
+    NSString *password = [[NSString alloc] initWithData:passwordData
+                                               encoding:NSUTF8StringEncoding];
+    NSString *revision = [[NSString alloc] initWithData:revisionData
+                                               encoding:NSUTF8StringEncoding];
+
+    if (![self token:password representsByteCount:HARTSPPasswordRandomByteCount]) {
+        [self assignError:error
+                      code:HARTSPCredentialErrorInvalidStoredCredential
+                    status:errSecSuccess
+               description:@"The stored RTSP access credential has an invalid format."];
+        return nil;
+    }
+
+    if (revision.length == 0) {
+        // Preserve an otherwise valid password if a pre-revision build created
+        // it. Adding only a non-secret revision avoids silently breaking HA.
+        revision = [self randomURLSafeTokenWithByteCount:HARTSPRevisionRandomByteCount error:error];
+        if (!revision) {
+            return nil;
+        }
+        OSStatus updateStatus = SecItemUpdate((__bridge CFDictionaryRef)[self baseQuery],
+                                              (__bridge CFDictionaryRef)@{
+                                                  (__bridge id)kSecAttrGeneric:
+                                                      [revision dataUsingEncoding:NSUTF8StringEncoding],
+                                                  (__bridge id)kSecAttrAccessible:
+                                                      (__bridge id)kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+                                              });
+        if (updateStatus != errSecSuccess) {
+            [self assignError:error
+                          code:HARTSPCredentialErrorKeychainFailure
+                        status:updateStatus
+                   description:@"The RTSP credential revision could not be saved."];
+            return nil;
+        }
+    } else if (![self token:revision representsByteCount:HARTSPRevisionRandomByteCount]) {
+        [self assignError:error
+                      code:HARTSPCredentialErrorInvalidStoredCredential
+                    status:errSecSuccess
+               description:@"The stored RTSP credential revision has an invalid format."];
+        return nil;
+    }
+
+    return [[HARTSPCredentials alloc] initWithPassword:password revision:revision];
+}
+
+#pragma mark - Generation and validation
+
+- (HARTSPCredentials *)generateCredentialsWithError:(NSError **)error {
+    NSString *password = [self randomURLSafeTokenWithByteCount:HARTSPPasswordRandomByteCount
+                                                          error:error];
+    if (!password) {
+        return nil;
+    }
+    NSString *revision = [self randomURLSafeTokenWithByteCount:HARTSPRevisionRandomByteCount
+                                                          error:error];
+    if (!revision) {
+        return nil;
+    }
+    return [[HARTSPCredentials alloc] initWithPassword:password revision:revision];
+}
+
+- (NSString *)randomURLSafeTokenWithByteCount:(NSUInteger)byteCount error:(NSError **)error {
+    NSMutableData *randomData = [NSMutableData dataWithLength:byteCount];
+    OSStatus status = SecRandomCopyBytes(kSecRandomDefault, byteCount, randomData.mutableBytes);
+    if (status != errSecSuccess) {
+        [self assignError:error
+                      code:HARTSPCredentialErrorRandomGenerationFailed
+                    status:status
+               description:@"A secure RTSP access credential could not be generated."];
+        return nil;
+    }
+
+    NSString *token = [randomData base64EncodedStringWithOptions:0];
+    token = [token stringByReplacingOccurrencesOfString:@"+" withString:@"-"];
+    token = [token stringByReplacingOccurrencesOfString:@"/" withString:@"_"];
+    token = [token stringByReplacingOccurrencesOfString:@"=" withString:@""];
+    return token;
+}
+
+- (BOOL)token:(NSString *)token representsByteCount:(NSUInteger)byteCount {
+    if (token.length == 0) {
+        return NO;
+    }
+
+    NSCharacterSet *invalidCharacters =
+        [[NSCharacterSet characterSetWithCharactersInString:
+          @"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"] invertedSet];
+    if ([token rangeOfCharacterFromSet:invalidCharacters].location != NSNotFound) {
+        return NO;
+    }
+
+    NSString *base64 = [token stringByReplacingOccurrencesOfString:@"-" withString:@"+"];
+    base64 = [base64 stringByReplacingOccurrencesOfString:@"_" withString:@"/"];
+    NSUInteger remainder = base64.length % 4;
+    if (remainder != 0) {
+        base64 = [base64 stringByPaddingToLength:base64.length + (4 - remainder)
+                                      withString:@"="
+                                 startingAtIndex:0];
+    }
+    NSData *decoded = [[NSData alloc] initWithBase64EncodedString:base64 options:0];
+    return decoded.length == byteCount;
+}
+
+#pragma mark - Errors
+
+- (BOOL)assignError:(NSError **)error
+                code:(HARTSPCredentialErrorCode)code
+              status:(OSStatus)status
+         description:(NSString *)description {
+    if (!error) {
+        return NO;
+    }
+
+    NSMutableDictionary *userInfo = [@{NSLocalizedDescriptionKey: description} mutableCopy];
+    if (status != errSecSuccess) {
+        userInfo[NSUnderlyingErrorKey] = [NSError errorWithDomain:NSOSStatusErrorDomain
+                                                             code:status
+                                                         userInfo:nil];
+    }
+    *error = [NSError errorWithDomain:HARTSPCredentialErrorDomain code:code userInfo:userInfo];
+    return NO;
+}
+
+@end

--- a/HADashboard/Streaming/HARTSPServer.h
+++ b/HADashboard/Streaming/HARTSPServer.h
@@ -1,0 +1,39 @@
+#import <Foundation/Foundation.h>
+
+@class HARTSPServer;
+
+@protocol HARTSPServerDelegate <NSObject>
+- (void)rtspServerDidChangeClientCount:(HARTSPServer *)server;
+- (void)rtspServerNeedsVideoKeyFrame:(HARTSPServer *)server;
+- (void)rtspServerNeedsMediaConfiguration:(HARTSPServer *)server;
+- (void)rtspServer:(HARTSPServer *)server didFailWithError:(NSError *)error;
+@end
+
+/// Local, in-process RTSP server. It exposes H.264/AAC only while a
+/// foreground local client is connected; Home Assistant is the client, not a controller.
+@interface HARTSPServer : NSObject
+@property (nonatomic, weak) id<HARTSPServerDelegate> delegate;
+@property (nonatomic, readonly, getter=isRunning) BOOL running;
+/// Authenticated clients that have requested this stream's media. This is the
+/// capture-demand count; unauthenticated TCP connections are deliberately excluded.
+@property (nonatomic, readonly) NSUInteger clientCount;
+/// All accepted TCP connections, including clients that have not authenticated.
+@property (nonatomic, readonly) NSUInteger connectionCount;
+/// Authenticated clients that have completed PLAY and are receiving media.
+@property (nonatomic, readonly) NSUInteger playingClientCount;
+@property (nonatomic, copy, readonly) NSString *streamURL;
+@property (nonatomic, copy, readonly) NSString *authenticationUsername;
+- (instancetype)initWithHost:(NSString *)host
+                         port:(uint16_t)port
+                     username:(NSString *)username
+                     password:(NSString *)password NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithHost:(NSString *)host port:(uint16_t)port NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+- (BOOL)start:(NSError **)error;
+- (void)stop;
+- (void)setVideoConfiguration:(NSData *)avcDecoderConfigurationRecord;
+- (void)setAudioConfiguration:(NSData *)audioSpecificConfig channels:(NSUInteger)channels sampleRate:(NSUInteger)sampleRate;
+- (void)clearMediaConfiguration;
+- (void)sendVideoSample:(NSData *)avccNalus keyFrame:(BOOL)keyFrame timestamp:(uint32_t)milliseconds;
+- (void)sendAudioSample:(NSData *)aacRaw timestamp:(uint32_t)milliseconds;
+@end

--- a/HADashboard/Streaming/HARTSPServer.m
+++ b/HADashboard/Streaming/HARTSPServer.m
@@ -1,0 +1,1009 @@
+#import "HARTSPServer.h"
+#import "HALog.h"
+#import <CFNetwork/CFNetwork.h>
+#import <CommonCrypto/CommonDigest.h>
+#import <Security/Security.h>
+#import <arpa/inet.h>
+#import <errno.h>
+#import <fcntl.h>
+#import <limits.h>
+#import <netinet/tcp.h>
+#import <sys/socket.h>
+
+static NSString *const HARTSPServerErrorDomain = @"HARTSPServerErrorDomain";
+static NSString *const HARTSPAuthenticationRealm = @"HA Dashboard";
+static const NSUInteger kHARTSPMaxRTPPayload = 1200;
+static const NSUInteger kHARTSPMaxInputBytes = 16 * 1024;
+static const NSUInteger kHARTSPMaxConnections = 8;
+static const NSUInteger kHARTSPMaxAuthenticationFailures = 3;
+static const NSUInteger kHARTSPMaxPendingOutputBytes = 1024 * 1024;
+static const NSTimeInterval kHARTSPAuthenticationTimeout = 5.0;
+static const NSTimeInterval kHARTSPClientIdleTimeout = 10.0;
+static const NSTimeInterval kHARTSPOutputBackpressureTimeout = 2.0;
+
+typedef ssize_t (^HARTSPSendFunction)(CFSocketNativeHandle socket,
+                                      const void *bytes,
+                                      size_t length,
+                                      int *errorOut);
+
+static NSString *HARTSPRandomNonce(void) {
+    uint8_t bytes[16];
+    if (SecRandomCopyBytes(kSecRandomDefault, sizeof(bytes), bytes) != errSecSuccess) return nil;
+    NSMutableString *nonce = [NSMutableString stringWithCapacity:sizeof(bytes) * 2];
+    for (NSUInteger index = 0; index < sizeof(bytes); index++) {
+        [nonce appendFormat:@"%02x", bytes[index]];
+    }
+    return nonce;
+}
+
+static NSString *HARTSPMD5Hex(NSString *value) {
+    NSData *data = [value dataUsingEncoding:NSUTF8StringEncoding];
+    if (!data || data.length > UINT32_MAX) return nil;
+    unsigned char digest[CC_MD5_DIGEST_LENGTH];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    CC_MD5(data.bytes, (CC_LONG)data.length, digest);
+#pragma clang diagnostic pop
+    NSMutableString *hex = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
+    for (NSUInteger index = 0; index < CC_MD5_DIGEST_LENGTH; index++) {
+        [hex appendFormat:@"%02x", digest[index]];
+    }
+    return hex;
+}
+
+static BOOL HARTSPConstantTimeEqualHex(NSString *left, NSString *right) {
+    NSData *leftData = [[left lowercaseString] dataUsingEncoding:NSASCIIStringEncoding];
+    NSData *rightData = [[right lowercaseString] dataUsingEncoding:NSASCIIStringEncoding];
+    if (!leftData || !rightData || leftData.length != rightData.length) return NO;
+    const uint8_t *leftBytes = leftData.bytes;
+    const uint8_t *rightBytes = rightData.bytes;
+    uint8_t difference = 0;
+    for (NSUInteger index = 0; index < leftData.length; index++) {
+        difference |= leftBytes[index] ^ rightBytes[index];
+    }
+    return difference == 0;
+}
+
+static NSDictionary<NSString *, NSString *> *HARTSPDigestParameters(NSString *authorization) {
+    if (!authorization.length ||
+        [authorization rangeOfString:@"Digest " options:(NSCaseInsensitiveSearch | NSAnchoredSearch)].location == NSNotFound) {
+        return nil;
+    }
+    NSString *parameters = [authorization substringFromIndex:7];
+    NSMutableDictionary *result = [NSMutableDictionary dictionary];
+    NSUInteger index = 0;
+    while (index < parameters.length) {
+        while (index < parameters.length &&
+               ([[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:[parameters characterAtIndex:index]] ||
+                [parameters characterAtIndex:index] == ',')) index++;
+        NSUInteger keyStart = index;
+        while (index < parameters.length && [parameters characterAtIndex:index] != '=' &&
+               [parameters characterAtIndex:index] != ',') index++;
+        if (index >= parameters.length || [parameters characterAtIndex:index] != '=') return nil;
+        NSString *key = [[[parameters substringWithRange:NSMakeRange(keyStart, index - keyStart)]
+                          stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+        index++;
+        while (index < parameters.length &&
+               [[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:[parameters characterAtIndex:index]]) index++;
+        NSMutableString *value = [NSMutableString string];
+        if (index < parameters.length && [parameters characterAtIndex:index] == '"') {
+            index++;
+            BOOL closedQuote = NO;
+            while (index < parameters.length) {
+                unichar character = [parameters characterAtIndex:index++];
+                if (character == '"') { closedQuote = YES; break; }
+                if (character == '\\' && index < parameters.length) {
+                    character = [parameters characterAtIndex:index++];
+                }
+                [value appendFormat:@"%C", character];
+            }
+            if (!closedQuote) return nil;
+        } else {
+            NSUInteger valueStart = index;
+            while (index < parameters.length && [parameters characterAtIndex:index] != ',') index++;
+            [value appendString:[[parameters substringWithRange:NSMakeRange(valueStart, index - valueStart)]
+                                 stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];
+        }
+        if (!key.length || !value.length || result[key]) return nil;
+        result[key] = value;
+        while (index < parameters.length && [parameters characterAtIndex:index] != ',') {
+            if (![[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:[parameters characterAtIndex:index]]) return nil;
+            index++;
+        }
+    }
+    return result;
+}
+
+static NSString *HARTSPResourcePath(NSString *uri) {
+    if (!uri.length) return nil;
+    NSURL *URL = [NSURL URLWithString:uri];
+    if (!URL.scheme.length) return uri;
+    NSString *path = URL.path.length ? URL.path : @"/";
+    return URL.query.length ? [path stringByAppendingFormat:@"?%@", URL.query] : path;
+}
+
+static BOOL HARTSPURIMatchesRequest(NSString *digestURI, NSString *requestURI) {
+    if ([digestURI isEqualToString:requestURI]) return YES;
+    NSString *digestPath = HARTSPResourcePath(digestURI);
+    NSString *requestPath = HARTSPResourcePath(requestURI);
+    return digestPath.length && [digestPath isEqualToString:requestPath];
+}
+
+static BOOL HARTSPValidCSeq(NSString *cseq) {
+    if (!cseq.length || cseq.length > 10) return NO;
+    for (NSUInteger index = 0; index < cseq.length; index++) {
+        unichar character = [cseq characterAtIndex:index];
+        if (character < '0' || character > '9') return NO;
+    }
+    return YES;
+}
+
+static BOOL HARTSPParseUnsigned(NSString *value, NSUInteger maximum, NSUInteger *result) {
+    if (!value.length || value.length > 20) return NO;
+    unsigned long long parsed = 0;
+    for (NSUInteger index = 0; index < value.length; index++) {
+        unichar character = [value characterAtIndex:index];
+        if (character < '0' || character > '9') return NO;
+        unsigned digit = (unsigned)(character - '0');
+        if (parsed > (ULLONG_MAX - digit) / 10) return NO;
+        parsed = parsed * 10 + digit;
+    }
+    if (parsed > maximum) return NO;
+    if (result) *result = (NSUInteger)parsed;
+    return YES;
+}
+
+@interface HARTSPClient : NSObject
+@property (nonatomic, weak) HARTSPServer *server;
+@property (nonatomic, strong) NSMutableData *inputBuffer;
+@property (nonatomic, strong) NSMutableData *outputBuffer;
+@property (nonatomic, assign) NSUInteger outputOffset;
+@property (nonatomic, assign) CFAbsoluteTime outputBacklogStartedAt;
+@property (nonatomic, assign) BOOL closeAfterOutputDrains;
+@property (nonatomic, assign) CFSocketNativeHandle nativeSocket;
+@property (nonatomic, assign) CFSocketRef socket;
+@property (nonatomic, assign) CFRunLoopSourceRef socketSource;
+@property (nonatomic, assign) BOOL closed;
+@property (nonatomic, copy) NSString *sessionID;
+@property (nonatomic, assign) BOOL videoSetup;
+@property (nonatomic, assign) BOOL audioSetup;
+@property (nonatomic, assign) BOOL playing;
+@property (nonatomic, assign) uint8_t videoChannel;
+@property (nonatomic, assign) uint8_t audioChannel;
+@property (nonatomic, assign) uint16_t videoSequence;
+@property (nonatomic, assign) uint16_t audioSequence;
+@property (nonatomic, assign) uint32_t videoSSRC;
+@property (nonatomic, assign) uint32_t audioSSRC;
+@property (nonatomic, assign) BOOL loggedVideoPacket;
+@property (nonatomic, assign) BOOL loggedAudioPacket;
+@property (nonatomic, assign) BOOL needsVideoParameterSets;
+@property (nonatomic, copy) NSString *pendingDescribeCSeq;
+@property (nonatomic, assign, getter=isAuthenticated) BOOL authenticated;
+@property (nonatomic, assign) BOOL mediaDemand;
+@property (nonatomic, assign) NSUInteger authenticationFailures;
+@property (nonatomic, copy) NSString *authenticationNonce;
+@property (nonatomic, assign) CFAbsoluteTime connectedAt;
+@property (nonatomic, assign) CFAbsoluteTime lastActivity;
+@property (nonatomic, strong) NSTimer *idleTimer;
+- (instancetype)initWithNativeSocket:(CFSocketNativeHandle)socket server:(HARTSPServer *)server;
+- (void)close;
+- (void)queue:(NSData *)data;
+- (void)flushOutput;
+- (void)closeAfterFlushingOutput;
+- (NSUInteger)pendingOutputLength;
+- (void)sendPendingDescriptionIfReady;
+- (void)readAvailable;
+- (void)parse;
+- (void)respond:(NSString *)request;
+- (BOOL)contentLengthInRequest:(NSString *)request length:(NSUInteger *)length;
+- (BOOL)authenticateMethod:(NSString *)method URL:(NSString *)URL headers:(NSDictionary *)headers cseq:(NSString *)cseq;
+- (void)markMediaDemand;
+- (void)response:(NSInteger)status cseq:(NSString *)cseq headers:(NSDictionary *)headers body:(NSData *)body;
+- (void)checkIdleTimer:(NSTimer *)timer;
+@end
+
+@interface HARTSPServer ()
+@property (nonatomic, copy) NSString *host;
+@property (nonatomic, assign) uint16_t port;
+@property (nonatomic, copy, readwrite) NSString *authenticationUsername;
+@property (nonatomic, copy) NSString *authenticationPassword;
+@property (nonatomic, assign) CFSocketRef listener;
+@property (nonatomic, assign) CFRunLoopSourceRef listenerSource;
+@property (nonatomic, strong) NSMutableArray<HARTSPClient *> *clients;
+@property (nonatomic, strong) NSData *avcConfiguration;
+@property (nonatomic, strong) NSData *aacConfiguration;
+@property (nonatomic, assign) NSUInteger audioChannels;
+@property (nonatomic, assign) NSUInteger audioSampleRate;
+@property (nonatomic, copy) NSString *spsBase64;
+@property (nonatomic, copy) NSString *ppsBase64;
+@property (nonatomic, strong) NSData *spsNAL;
+@property (nonatomic, strong) NSData *ppsNAL;
+@property (nonatomic, copy) NSString *profileLevelID;
+@property (nonatomic, assign) BOOL hasVideoTimestamp;
+@property (nonatomic, assign) BOOL hasAudioTimestamp;
+@property (nonatomic, assign) uint32_t lastVideoTimestamp;
+@property (nonatomic, assign) uint32_t lastAudioTimestamp;
+@property (nonatomic, assign) uint32_t videoTimestampStep;
+@property (nonatomic, assign, getter=isRunning) BOOL running;
+@property (nonatomic, copy) HARTSPSendFunction sendFunctionForTesting;
+@property (nonatomic, assign) NSUInteger maximumPendingOutputBytes;
+- (void)addClient:(HARTSPClient *)client;
+- (void)removeClient:(HARTSPClient *)client;
+- (BOOL)canAcceptClient;
+- (void)clientStateDidChange;
+- (NSArray<HARTSPClient *> *)clientSnapshot;
+- (NSString *)sessionDescription;
+- (ssize_t)sendBytes:(const void *)bytes
+              length:(size_t)length
+              socket:(CFSocketNativeHandle)socket
+               error:(int *)errorOut;
+- (NSUInteger)pendingOutputByteCountForTesting;
+- (void)flushPendingClientWritesForTesting;
+@end
+
+static void HARTSPAccept(CFSocketRef socket, CFSocketCallBackType type, CFDataRef address,
+                         const void *data, void *info) {
+    (void)socket; (void)address;
+    if (type != kCFSocketAcceptCallBack || !data) return;
+    HARTSPServer *server = (__bridge HARTSPServer *)info;
+    CFSocketNativeHandle nativeSocket = *(const CFSocketNativeHandle *)data;
+    if (![server canAcceptClient]) {
+        HALogW(@"rtsp", @"Port %u rejected a connection because the client limit was reached.", server.port);
+        close(nativeSocket);
+        return;
+    }
+    HARTSPClient *client = [[HARTSPClient alloc] initWithNativeSocket:nativeSocket server:server];
+    if (!client) { close(nativeSocket); return; }
+    [server addClient:client];
+}
+
+static void HARTSPSocketActivity(CFSocketRef socket, CFSocketCallBackType type, CFDataRef address,
+                                const void *data, void *info) {
+    (void)socket; (void)address; (void)data;
+    HARTSPClient *client = (__bridge HARTSPClient *)info;
+    if (type == kCFSocketReadCallBack) {
+        [client readAvailable];
+    } else if (type == kCFSocketWriteCallBack) {
+        [client flushOutput];
+    }
+}
+
+@implementation HARTSPServer
+
+- (instancetype)initWithHost:(NSString *)host
+                         port:(uint16_t)port
+                     username:(NSString *)username
+                     password:(NSString *)password {
+    self = [super init];
+    if (self) {
+        _host = [host copy];
+        _port = port;
+        _authenticationUsername = [username copy];
+        _authenticationPassword = [password copy];
+        _clients = [NSMutableArray array];
+        _maximumPendingOutputBytes = kHARTSPMaxPendingOutputBytes;
+    }
+    return self;
+}
+
+- (NSString *)streamURL { return self.running ? [NSString stringWithFormat:@"rtsp://%@:%u/live", self.host, self.port] : nil; }
+- (NSArray<HARTSPClient *> *)clientSnapshot {
+    @synchronized (self.clients) { return [self.clients copy]; }
+}
+- (NSUInteger)connectionCount {
+    @synchronized (self.clients) { return self.clients.count; }
+}
+- (NSUInteger)clientCount {
+    NSUInteger count = 0;
+    for (HARTSPClient *client in [self clientSnapshot]) {
+        if (client.isAuthenticated && client.mediaDemand && !client.closed) count++;
+    }
+    return count;
+}
+- (NSUInteger)playingClientCount {
+    NSUInteger count = 0;
+    for (HARTSPClient *client in [self clientSnapshot]) {
+        if (client.isAuthenticated && client.playing && !client.closed) count++;
+    }
+    return count;
+}
+
+- (BOOL)start:(NSError **)error {
+    if (self.running) return YES;
+    if (!self.authenticationUsername.length || !self.authenticationPassword.length) {
+        if (error) *error = [self error:@"RTSP authentication credentials are required."];
+        return NO;
+    }
+    CFSocketContext context = {0, (__bridge void *)self, NULL, NULL, NULL};
+    self.listener = CFSocketCreate(kCFAllocatorDefault, PF_INET, SOCK_STREAM, IPPROTO_TCP,
+        kCFSocketAcceptCallBack, HARTSPAccept, &context);
+    if (!self.listener) { if (error) *error = [self error:@"Could not create the local RTSP listener."]; return NO; }
+    int reuse = 1;
+    setsockopt(CFSocketGetNative(self.listener), SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+    struct sockaddr_in address;
+    memset(&address, 0, sizeof(address));
+    address.sin_len = sizeof(address);
+    address.sin_family = AF_INET;
+    address.sin_port = htons(self.port);
+    if (inet_pton(AF_INET, self.host.UTF8String, &address.sin_addr) != 1) {
+        CFRelease(self.listener); self.listener = NULL;
+        if (error) *error = [self error:@"The selected local RTSP address is invalid."];
+        return NO;
+    }
+    NSData *addressData = [NSData dataWithBytes:&address length:sizeof(address)];
+    if (CFSocketSetAddress(self.listener, (__bridge CFDataRef)addressData) != kCFSocketSuccess) {
+        CFRelease(self.listener); self.listener = NULL;
+        if (error) *error = [self error:[NSString stringWithFormat:@"Port %u is unavailable for the local RTSP stream.", self.port]];
+        return NO;
+    }
+    self.listenerSource = CFSocketCreateRunLoopSource(kCFAllocatorDefault, self.listener, 0);
+    if (!self.listenerSource) {
+        CFSocketInvalidate(self.listener);
+        CFRelease(self.listener);
+        self.listener = NULL;
+        if (error) *error = [self error:@"Could not create the local RTSP listener source."];
+        return NO;
+    }
+    CFRunLoopAddSource(CFRunLoopGetMain(), self.listenerSource, kCFRunLoopCommonModes);
+    self.running = YES;
+    return YES;
+}
+
+- (void)stop {
+    for (HARTSPClient *client in [self clientSnapshot]) [client close];
+    @synchronized (self.clients) { [self.clients removeAllObjects]; }
+    if (self.listenerSource) { CFRunLoopRemoveSource(CFRunLoopGetMain(), self.listenerSource, kCFRunLoopCommonModes); CFRelease(self.listenerSource); self.listenerSource = NULL; }
+    if (self.listener) { CFSocketInvalidate(self.listener); CFRelease(self.listener); self.listener = NULL; }
+    self.running = NO;
+}
+
+- (BOOL)canAcceptClient { return self.running && self.connectionCount < kHARTSPMaxConnections; }
+- (void)addClient:(HARTSPClient *)client {
+    @synchronized (self.clients) { [self.clients addObject:client]; }
+    HALogI(@"rtsp", @"Port %u client connected (%lu sockets, %lu media clients)", self.port,
+           (unsigned long)self.connectionCount, (unsigned long)self.clientCount);
+    [self.delegate rtspServerDidChangeClientCount:self];
+}
+- (void)removeClient:(HARTSPClient *)client {
+    @synchronized (self.clients) {
+        if (![self.clients containsObject:client]) return;
+        [self.clients removeObject:client];
+    }
+    HALogI(@"rtsp", @"Port %u client disconnected (%lu sockets, %lu media clients)", self.port,
+           (unsigned long)self.connectionCount, (unsigned long)self.clientCount);
+    [self.delegate rtspServerDidChangeClientCount:self];
+}
+- (void)clientStateDidChange {
+    HALogI(@"rtsp", @"Port %u client state changed (%lu media clients, %lu playing)", self.port,
+           (unsigned long)self.clientCount, (unsigned long)self.playingClientCount);
+    [self.delegate rtspServerDidChangeClientCount:self];
+}
+
+- (ssize_t)sendBytes:(const void *)bytes
+              length:(size_t)length
+              socket:(CFSocketNativeHandle)socket
+               error:(int *)errorOut {
+    if (errorOut) *errorOut = 0;
+    if (self.sendFunctionForTesting) {
+        return self.sendFunctionForTesting(socket, bytes, length, errorOut);
+    }
+    ssize_t sent = send(socket, bytes, length, 0);
+    if (sent < 0 && errorOut) *errorOut = errno;
+    return sent;
+}
+
+- (NSUInteger)pendingOutputByteCountForTesting {
+    NSUInteger count = 0;
+    for (HARTSPClient *client in [self clientSnapshot]) {
+        count += client.pendingOutputLength;
+    }
+    return count;
+}
+
+- (void)flushPendingClientWritesForTesting {
+    for (HARTSPClient *client in [self clientSnapshot]) [client flushOutput];
+}
+
+- (void)setVideoConfiguration:(NSData *)configuration {
+    if ([self.avcConfiguration isEqualToData:configuration]) return;
+    self.avcConfiguration = [configuration copy];
+    const uint8_t *b = configuration.bytes;
+    if (configuration.length < 11 || b[0] != 1) return;
+    NSUInteger offset = 6;
+    NSUInteger spsLength = ((NSUInteger)b[offset] << 8) | b[offset + 1]; offset += 2;
+    if (offset + spsLength + 3 > configuration.length || spsLength < 4) return;
+    NSData *sps = [NSData dataWithBytes:b + offset length:spsLength]; offset += spsLength;
+    offset += 1; NSUInteger ppsLength = ((NSUInteger)b[offset] << 8) | b[offset + 1]; offset += 2;
+    if (offset + ppsLength > configuration.length) return;
+    NSData *pps = [NSData dataWithBytes:b + offset length:ppsLength];
+    self.spsNAL = sps;
+    self.ppsNAL = pps;
+    self.spsBase64 = [sps base64EncodedStringWithOptions:0];
+    self.ppsBase64 = [pps base64EncodedStringWithOptions:0];
+    self.profileLevelID = [NSString stringWithFormat:@"%02X%02X%02X", b[1], b[2], b[3]];
+    for (HARTSPClient *client in [self clientSnapshot]) {
+        client.needsVideoParameterSets = YES;
+        [client sendPendingDescriptionIfReady];
+    }
+}
+
+- (void)setAudioConfiguration:(NSData *)configuration channels:(NSUInteger)channels sampleRate:(NSUInteger)sampleRate {
+    if ([self.aacConfiguration isEqualToData:configuration] &&
+        self.audioChannels == channels && self.audioSampleRate == sampleRate) return;
+    self.aacConfiguration = [configuration copy]; self.audioChannels = channels; self.audioSampleRate = sampleRate;
+    for (HARTSPClient *client in [self clientSnapshot]) [client sendPendingDescriptionIfReady];
+}
+
+- (void)clearMediaConfiguration {
+    self.avcConfiguration = nil;
+    self.aacConfiguration = nil;
+    self.audioChannels = 0;
+    self.audioSampleRate = 0;
+    self.spsBase64 = nil;
+    self.ppsBase64 = nil;
+    self.spsNAL = nil;
+    self.ppsNAL = nil;
+    self.profileLevelID = nil;
+    self.hasVideoTimestamp = NO;
+    self.hasAudioTimestamp = NO;
+    self.videoTimestampStep = 0;
+}
+
+- (void)sendVideoSample:(NSData *)avccNalus keyFrame:(BOOL)keyFrame timestamp:(uint32_t)milliseconds {
+    if (!self.running || self.playingClientCount == 0) return;
+    uint32_t timestamp = (uint32_t)(((uint64_t)milliseconds * 90));
+    if (self.hasVideoTimestamp && (int32_t)(timestamp - self.lastVideoTimestamp) <= 0) {
+        timestamp = self.lastVideoTimestamp + (self.videoTimestampStep ?: 3000);
+    } else if (self.hasVideoTimestamp) {
+        uint32_t step = timestamp - self.lastVideoTimestamp;
+        if (step > 0 && step < 90000) self.videoTimestampStep = step;
+    }
+    self.hasVideoTimestamp = YES;
+    self.lastVideoTimestamp = timestamp;
+    for (HARTSPClient *client in [self clientSnapshot]) if (client.isAuthenticated && client.playing && client.videoSetup) [self sendVideo:avccNalus keyFrame:keyFrame timestamp:timestamp client:client];
+}
+
+- (void)sendAudioSample:(NSData *)aacRaw timestamp:(uint32_t)milliseconds {
+    if (!self.running || self.audioSampleRate == 0 || self.playingClientCount == 0) return;
+    uint32_t timestamp = (uint32_t)(((uint64_t)milliseconds * self.audioSampleRate) / 1000);
+    if (self.hasAudioTimestamp && (int32_t)(timestamp - self.lastAudioTimestamp) <= 0) {
+        timestamp = self.lastAudioTimestamp + 1;
+    }
+    self.hasAudioTimestamp = YES;
+    self.lastAudioTimestamp = timestamp;
+    for (HARTSPClient *client in [self clientSnapshot]) if (client.isAuthenticated && client.playing && client.audioSetup) {
+        NSMutableData *payload = [NSMutableData dataWithCapacity:aacRaw.length + 4];
+        uint8_t auLength[2] = {0, 16}; [payload appendBytes:auLength length:2];
+        uint16_t header = htons((uint16_t)MIN((aacRaw.length << 3), 0xFFFF)); [payload appendBytes:&header length:2]; [payload appendData:aacRaw];
+        uint16_t sequence = client.audioSequence; client.audioSequence = sequence + 1;
+        [self sendRTPPayload:payload payloadType:97 marker:YES timestamp:timestamp sequence:sequence ssrc:client.audioSSRC channel:client.audioChannel client:client];
+    }
+}
+
+- (void)sendVideo:(NSData *)avcc keyFrame:(BOOL)keyFrame timestamp:(uint32_t)timestamp client:(HARTSPClient *)client {
+    if (keyFrame && client.needsVideoParameterSets && self.spsNAL.length && self.ppsNAL.length) {
+        NSArray<NSData *> *parameterSets = @[self.spsNAL, self.ppsNAL];
+        for (NSData *parameterSet in parameterSets) {
+            uint16_t sequence = client.videoSequence;
+            client.videoSequence = sequence + 1;
+            [self sendRTPPayload:parameterSet payloadType:96 marker:NO timestamp:timestamp
+                        sequence:sequence ssrc:client.videoSSRC channel:client.videoChannel client:client];
+        }
+        client.needsVideoParameterSets = NO;
+    }
+    const uint8_t *bytes = avcc.bytes; NSUInteger offset = 0;
+    while (offset + 4 <= avcc.length) {
+        uint32_t nalLength = ((uint32_t)bytes[offset] << 24) | ((uint32_t)bytes[offset+1] << 16) | ((uint32_t)bytes[offset+2] << 8) | bytes[offset+3]; offset += 4;
+        if (nalLength == 0 || offset + nalLength > avcc.length) return;
+        BOOL lastNal = (offset + nalLength == avcc.length); const uint8_t *nal = bytes + offset;
+        if (nalLength <= kHARTSPMaxRTPPayload) {
+            NSData *payload = [NSData dataWithBytes:nal length:nalLength]; uint16_t sequence=client.videoSequence; client.videoSequence=sequence+1; [self sendRTPPayload:payload payloadType:96 marker:lastNal timestamp:timestamp sequence:sequence ssrc:client.videoSSRC channel:client.videoChannel client:client];
+        } else {
+            uint8_t indicator = (nal[0] & 0xE0) | 28; uint8_t nalType = nal[0] & 0x1F; NSUInteger position = 1;
+            while (position < nalLength) { NSUInteger length = MIN(kHARTSPMaxRTPPayload - 2, nalLength - position); BOOL start = position == 1; BOOL end = position + length == nalLength; uint8_t header[2] = { indicator, (uint8_t)(nalType | (start ? 0x80 : 0) | (end ? 0x40 : 0)) }; NSMutableData *fragment = [NSMutableData dataWithBytes:header length:2]; [fragment appendBytes:nal + position length:length]; uint16_t sequence=client.videoSequence; client.videoSequence=sequence+1; [self sendRTPPayload:fragment payloadType:96 marker:(lastNal && end) timestamp:timestamp sequence:sequence ssrc:client.videoSSRC channel:client.videoChannel client:client]; position += length; }
+        }
+        offset += nalLength;
+    }
+}
+
+- (void)sendRTPPayload:(NSData *)payload payloadType:(uint8_t)payloadType marker:(BOOL)marker timestamp:(uint32_t)timestamp sequence:(uint16_t)sequence ssrc:(uint32_t)ssrc channel:(uint8_t)channel client:(HARTSPClient *)client {
+    if (payloadType == 96 && !client.loggedVideoPacket) { client.loggedVideoPacket = YES; HALogI(@"rtsp", @"Sending first H.264 RTP packet to a client."); }
+    if (payloadType == 97 && !client.loggedAudioPacket) { client.loggedAudioPacket = YES; HALogI(@"rtsp", @"Sending first AAC RTP packet to a client."); }
+    NSMutableData *rtp = [NSMutableData dataWithCapacity:payload.length + 12]; uint8_t head[2] = {0x80, (uint8_t)(payloadType | (marker ? 0x80 : 0))}; [rtp appendBytes:head length:2]; uint16_t seq = htons(sequence); [rtp appendBytes:&seq length:2]; uint32_t ts = htonl(timestamp), source = htonl(ssrc); [rtp appendBytes:&ts length:4]; [rtp appendBytes:&source length:4]; [rtp appendData:payload];
+    NSMutableData *interleaved = [NSMutableData dataWithCapacity:rtp.length + 4]; uint8_t dollar = '$'; [interleaved appendBytes:&dollar length:1]; [interleaved appendBytes:&channel length:1]; uint16_t len = htons((uint16_t)rtp.length); [interleaved appendBytes:&len length:2]; [interleaved appendData:rtp]; [client queue:interleaved];
+}
+
+- (NSString *)sessionDescription {
+    if (!self.spsBase64.length || !self.ppsBase64.length || !self.aacConfiguration.length) return nil;
+    NSMutableString *asc = [NSMutableString stringWithCapacity:self.aacConfiguration.length * 2];
+    const uint8_t *ascBytes = self.aacConfiguration.bytes;
+    for (NSUInteger index = 0; index < self.aacConfiguration.length; index++) {
+        [asc appendFormat:@"%02X", ascBytes[index]];
+    }
+    return [NSString stringWithFormat:@"v=0\r\no=- 0 0 IN IP4 %@\r\ns=HA Dashboard\r\nc=IN IP4 %@\r\nt=0 0\r\na=control:*\r\nm=video 0 RTP/AVP 96\r\na=rtpmap:96 H264/90000\r\na=fmtp:96 packetization-mode=1;profile-level-id=%@;sprop-parameter-sets=%@,%@\r\na=control:trackID=0\r\nm=audio 0 RTP/AVP 97\r\na=rtpmap:97 MPEG4-GENERIC/%lu/%lu\r\na=fmtp:97 streamtype=5;profile-level-id=1;mode=AAC-hbr;config=%@;SizeLength=13;IndexLength=3;IndexDeltaLength=3\r\na=control:trackID=1\r\n", self.host, self.host, self.profileLevelID, self.spsBase64, self.ppsBase64, (unsigned long)self.audioSampleRate, (unsigned long)self.audioChannels, asc];
+}
+
+- (NSError *)error:(NSString *)description { return [NSError errorWithDomain:HARTSPServerErrorDomain code:1 userInfo:@{NSLocalizedDescriptionKey:description}]; }
+@end
+
+@implementation HARTSPClient
+- (instancetype)initWithNativeSocket:(CFSocketNativeHandle)socket server:(HARTSPServer *)server {
+    self = [super init];
+    if (!self) return nil;
+    _server = server;
+    _nativeSocket = socket;
+    _inputBuffer = [NSMutableData data];
+    _outputBuffer = [NSMutableData data];
+    _sessionID = [[NSUUID UUID] UUIDString];
+    _videoSequence = arc4random_uniform(UINT16_MAX);
+    _audioSequence = arc4random_uniform(UINT16_MAX);
+    _videoSSRC = arc4random();
+    _audioSSRC = arc4random();
+    _connectedAt = CFAbsoluteTimeGetCurrent();
+    _lastActivity = _connectedAt;
+    _authenticationNonce = HARTSPRandomNonce();
+    if (!_authenticationNonce.length) return nil;
+    int flags = fcntl(socket, F_GETFL, 0);
+    if (flags < 0 || fcntl(socket, F_SETFL, flags | O_NONBLOCK) < 0) return nil;
+    int noSignal = 1;
+    if (setsockopt(socket, SOL_SOCKET, SO_NOSIGPIPE, &noSignal, sizeof(noSignal)) != 0) return nil;
+    int noDelay = 1; setsockopt(socket, IPPROTO_TCP, TCP_NODELAY, &noDelay, sizeof(noDelay));
+    CFSocketContext context = {0, (__bridge void *)self, NULL, NULL, NULL};
+    _socket = CFSocketCreateWithNative(kCFAllocatorDefault, socket,
+        kCFSocketReadCallBack | kCFSocketWriteCallBack, HARTSPSocketActivity, &context);
+    if (!_socket) return nil;
+    CFOptionFlags socketFlags = CFSocketGetSocketFlags(_socket);
+    socketFlags |= kCFSocketCloseOnInvalidate | kCFSocketAutomaticallyReenableReadCallBack;
+    socketFlags &= ~kCFSocketAutomaticallyReenableWriteCallBack;
+    CFSocketSetSocketFlags(_socket, socketFlags);
+    CFSocketDisableCallBacks(_socket, kCFSocketWriteCallBack);
+    _socketSource = CFSocketCreateRunLoopSource(kCFAllocatorDefault, _socket, 0);
+    if (!_socketSource) {
+        // The accept callback still owns the native descriptor on init failure.
+        // Prevent invalidation here from closing it before that callback does.
+        CFSocketSetSocketFlags(_socket,
+            CFSocketGetSocketFlags(_socket) & ~kCFSocketCloseOnInvalidate);
+        CFSocketInvalidate(_socket);
+        CFRelease(_socket);
+        _socket = NULL;
+        return nil;
+    }
+    CFRunLoopAddSource(CFRunLoopGetMain(), _socketSource, kCFRunLoopCommonModes);
+    _idleTimer = [NSTimer timerWithTimeInterval:1.0 target:self selector:@selector(checkIdleTimer:) userInfo:nil repeats:YES];
+    [[NSRunLoop mainRunLoop] addTimer:_idleTimer forMode:NSRunLoopCommonModes];
+    return self;
+}
+- (void)close {
+    if (self.closed) return;
+    self.closed = YES;
+    [self.idleTimer invalidate];
+    self.idleTimer = nil;
+    self.pendingDescribeCSeq = nil;
+    self.closeAfterOutputDrains = NO;
+    self.outputBacklogStartedAt = 0;
+    self.outputOffset = 0;
+    [self.outputBuffer setLength:0];
+    if (_socketSource) {
+        CFRunLoopRemoveSource(CFRunLoopGetMain(), _socketSource, kCFRunLoopCommonModes);
+        CFRelease(_socketSource);
+        _socketSource = NULL;
+    }
+    if (_socket) {
+        CFSocketInvalidate(_socket);
+        CFRelease(_socket);
+        _socket = NULL;
+    }
+    [_server removeClient:self];
+}
+- (void)queue:(NSData *)data {
+    if (self.closed || self.closeAfterOutputDrains || data.length == 0) return;
+    NSUInteger pending = self.pendingOutputLength;
+    NSUInteger maximum = self.server.maximumPendingOutputBytes ?: kHARTSPMaxPendingOutputBytes;
+    if (data.length > maximum || pending > maximum - data.length) {
+        HALogW(@"rtsp", @"Closing an RTSP client whose pending output exceeded %lu bytes.",
+               (unsigned long)maximum);
+        [self close];
+        return;
+    }
+    BOOL wasEmpty = pending == 0;
+    [self.outputBuffer appendData:data];
+    if (wasEmpty) {
+        self.outputBacklogStartedAt = CFAbsoluteTimeGetCurrent();
+        [self flushOutput];
+    }
+}
+
+- (NSUInteger)pendingOutputLength {
+    return self.outputBuffer.length > self.outputOffset
+        ? self.outputBuffer.length - self.outputOffset : 0;
+}
+
+- (void)flushOutput {
+    if (self.closed) return;
+    if (self.socket) CFSocketDisableCallBacks(self.socket, kCFSocketWriteCallBack);
+    while (self.pendingOutputLength > 0) {
+        const uint8_t *bytes = self.outputBuffer.bytes;
+        int sendError = 0;
+        ssize_t sent = [self.server sendBytes:bytes + self.outputOffset
+                                       length:self.pendingOutputLength
+                                       socket:self.nativeSocket
+                                        error:&sendError];
+        if (sent > 0) {
+            self.outputOffset += (NSUInteger)sent;
+            self.lastActivity = CFAbsoluteTimeGetCurrent();
+            if (!self.closeAfterOutputDrains) self.outputBacklogStartedAt = self.lastActivity;
+            continue;
+        }
+        if (sent < 0 && sendError == EINTR) continue;
+        if (sent < 0 && (sendError == EAGAIN || sendError == EWOULDBLOCK)) {
+            if (self.outputOffset > 0) {
+                [self.outputBuffer replaceBytesInRange:NSMakeRange(0, self.outputOffset)
+                                             withBytes:NULL
+                                                length:0];
+                self.outputOffset = 0;
+            }
+            if (self.socket && !self.closed) {
+                CFSocketEnableCallBacks(self.socket, kCFSocketWriteCallBack);
+            }
+            return;
+        }
+        HALogW(@"rtsp", @"Socket write failed: %s", strerror(sendError));
+        [self close];
+        return;
+    }
+    [self.outputBuffer setLength:0];
+    self.outputOffset = 0;
+    self.outputBacklogStartedAt = 0;
+    if (self.closeAfterOutputDrains) [self close];
+}
+
+- (void)closeAfterFlushingOutput {
+    if (self.closed) return;
+    BOOL mediaStateChanged = self.mediaDemand || self.playing;
+    self.mediaDemand = NO;
+    self.playing = NO;
+    self.closeAfterOutputDrains = YES;
+    if (self.socket) CFSocketDisableCallBacks(self.socket, kCFSocketReadCallBack);
+    BOOL waitingForDrain = self.pendingOutputLength > 0;
+    if (!waitingForDrain) {
+        [self close];
+    } else if (self.socket) {
+        self.outputBacklogStartedAt = CFAbsoluteTimeGetCurrent();
+        CFSocketEnableCallBacks(self.socket, kCFSocketWriteCallBack);
+    }
+    if (waitingForDrain && mediaStateChanged) [self.server clientStateDidChange];
+}
+- (void)readAvailable {
+    if (self.closed || self.closeAfterOutputDrains) return;
+    uint8_t bytes[4096];
+    while (YES) {
+        ssize_t received = recv(self.nativeSocket, bytes, sizeof(bytes), 0);
+        if (received > 0) {
+            self.lastActivity = CFAbsoluteTimeGetCurrent();
+            if (self.inputBuffer.length + (NSUInteger)received > kHARTSPMaxInputBytes) {
+                HALogW(@"rtsp", @"Closing a client that exceeded the RTSP input limit.");
+                [self response:413 cseq:@"0" headers:nil body:nil];
+                [self closeAfterFlushingOutput];
+                return;
+            }
+            [self.inputBuffer appendBytes:bytes length:(NSUInteger)received];
+            [self parse];
+            if (self.closed || self.closeAfterOutputDrains) return;
+            continue;
+        }
+        if (received == 0) { [self close]; return; }
+        if (errno == EINTR) continue;
+        if (errno == EAGAIN || errno == EWOULDBLOCK) return;
+        HALogW(@"rtsp", @"Socket read failed: %s", strerror(errno));
+        [self close];
+        return;
+    }
+}
+- (void)parse {
+    NSData *end = [@"\r\n\r\n" dataUsingEncoding:NSUTF8StringEncoding];
+    while (_inputBuffer.length) {
+        const uint8_t *bytes = _inputBuffer.bytes;
+        if (bytes[0] == '$') {
+            if (_inputBuffer.length < 4) return;
+            NSUInteger length = ((NSUInteger)bytes[2] << 8) | bytes[3];
+            if (length + 4 > kHARTSPMaxInputBytes) { [self close]; return; }
+            if (_inputBuffer.length < length + 4) return;
+            // Interleaved RTCP arrives from clients on the paired RTP channel.
+            // It is not an RTSP request and must not poison the request buffer.
+            [_inputBuffer replaceBytesInRange:NSMakeRange(0, length + 4) withBytes:NULL length:0];
+            continue;
+        }
+        NSRange r = [_inputBuffer rangeOfData:end options:0 range:NSMakeRange(0, _inputBuffer.length)];
+        if (r.location == NSNotFound) return;
+        NSUInteger headerLength = r.location + 4;
+        NSData *request = [_inputBuffer subdataWithRange:NSMakeRange(0, headerLength)];
+        NSString *text = [[NSString alloc] initWithData:request encoding:NSUTF8StringEncoding];
+        if (!text) {
+            [self response:400 cseq:@"0" headers:nil body:nil];
+            [self closeAfterFlushingOutput];
+            return;
+        }
+        NSUInteger bodyLength = 0;
+        if (![self contentLengthInRequest:text length:&bodyLength]) {
+            [self response:400 cseq:@"0" headers:nil body:nil];
+            [self closeAfterFlushingOutput];
+            return;
+        }
+        if (bodyLength > kHARTSPMaxInputBytes - headerLength) {
+            [self response:413 cseq:@"0" headers:nil body:nil];
+            [self closeAfterFlushingOutput];
+            return;
+        }
+        NSUInteger requestLength = headerLength + bodyLength;
+        if (_inputBuffer.length < requestLength) return;
+        [_inputBuffer replaceBytesInRange:NSMakeRange(0, requestLength) withBytes:NULL length:0];
+        [self respond:text];
+        if (self.closed || self.closeAfterOutputDrains) return;
+    }
+}
+- (BOOL)contentLengthInRequest:(NSString *)request length:(NSUInteger *)length {
+    NSUInteger parsedLength = 0;
+    BOOL found = NO;
+    NSArray *lines = [request componentsSeparatedByString:@"\r\n"];
+    for (NSUInteger index = 1; index < lines.count; index++) {
+        NSString *line = lines[index];
+        if (!line.length) break;
+        NSRange separator = [line rangeOfString:@":"];
+        if (separator.location == NSNotFound) return NO;
+        NSString *key = [[[line substringToIndex:separator.location]
+                          stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] lowercaseString];
+        if (![key isEqualToString:@"content-length"]) continue;
+        if (found) return NO;
+        NSString *value = [[line substringFromIndex:separator.location + 1]
+                           stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        if (!HARTSPParseUnsigned(value, kHARTSPMaxInputBytes, &parsedLength)) return NO;
+        found = YES;
+    }
+    if (length) *length = parsedLength;
+    return YES;
+}
+- (void)respond:(NSString *)request {
+    NSArray *lines = [request componentsSeparatedByString:@"\r\n"];
+    NSString *first = lines.firstObject ?: @"";
+    NSArray *rawParts = [first componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    NSMutableArray *parts = [NSMutableArray arrayWithCapacity:rawParts.count];
+    for (NSString *part in rawParts) if (part.length) [parts addObject:part];
+
+    NSMutableDictionary *headers = [NSMutableDictionary dictionary];
+    BOOL malformedHeaders = NO;
+    for (NSUInteger index = 1; index < lines.count; index++) {
+        NSString *line = lines[index];
+        if (!line.length) break;
+        NSRange separator = [line rangeOfString:@":"];
+        if (separator.location == NSNotFound) { malformedHeaders = YES; break; }
+        NSString *key = [[[line substringToIndex:separator.location]
+                          stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] lowercaseString];
+        NSString *value = [[line substringFromIndex:separator.location + 1]
+                           stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        if (!key.length || headers[key]) { malformedHeaders = YES; break; }
+        headers[key] = value;
+    }
+    NSString *cseq = headers[@"cseq"];
+    if (malformedHeaders || parts.count != 3 || ![parts[2] isEqualToString:@"RTSP/1.0"] ||
+        !HARTSPValidCSeq(cseq)) {
+        [self response:400 cseq:@"0" headers:nil body:nil];
+        [self closeAfterFlushingOutput];
+        return;
+    }
+
+    NSString *method = parts[0];
+    NSString *URL = parts[1];
+    NSSet *knownMethods = [NSSet setWithObjects:@"OPTIONS", @"DESCRIBE", @"SETUP", @"PLAY", @"TEARDOWN", nil];
+    HALogI(@"rtsp", @"Request %@ CSeq %@", [knownMethods containsObject:method] ? method : @"UNKNOWN", cseq);
+
+    BOOL protectedMethod = [method isEqualToString:@"DESCRIBE"] || [method isEqualToString:@"SETUP"] ||
+                           [method isEqualToString:@"PLAY"] || [method isEqualToString:@"TEARDOWN"];
+    if (protectedMethod && ![self authenticateMethod:method URL:URL headers:headers cseq:cseq]) return;
+
+    NSString *requestSession = headers[@"session"];
+    NSRange sessionSeparator = [requestSession rangeOfString:@";"];
+    if (sessionSeparator.location != NSNotFound) {
+        requestSession = [requestSession substringToIndex:sessionSeparator.location];
+    }
+    BOOL requiresSession = [method isEqualToString:@"PLAY"] || [method isEqualToString:@"TEARDOWN"];
+    if ((requiresSession && ![requestSession isEqualToString:self.sessionID]) ||
+        ([method isEqualToString:@"SETUP"] && requestSession.length &&
+         ![requestSession isEqualToString:self.sessionID])) {
+        [self response:454 cseq:cseq headers:nil body:nil];
+        return;
+    }
+
+    if ([method isEqualToString:@"OPTIONS"]) {
+        [self response:200 cseq:cseq headers:@{ @"Public": @"OPTIONS, DESCRIBE, SETUP, PLAY, TEARDOWN" } body:nil];
+        return;
+    }
+    if ([method isEqualToString:@"DESCRIBE"]) {
+        [self markMediaDemand];
+        NSString *description = [_server sessionDescription];
+        if (!description) {
+            self.pendingDescribeCSeq = cseq;
+            [_server.delegate rtspServerNeedsMediaConfiguration:_server];
+            return;
+        }
+        [self response:200 cseq:cseq
+                headers:@{ @"Content-Type": @"application/sdp", @"Content-Base": [_server streamURL] }
+                   body:[description dataUsingEncoding:NSUTF8StringEncoding]];
+        return;
+    }
+    if ([method isEqualToString:@"SETUP"]) {
+        NSString *transport = headers[@"transport"];
+        if ([transport rangeOfString:@"RTP/AVP/TCP" options:NSCaseInsensitiveSearch].location == NSNotFound) {
+            [self response:461 cseq:cseq headers:nil body:nil];
+            return;
+        }
+        BOOL video = [URL rangeOfString:@"trackID=0" options:NSCaseInsensitiveSearch].location != NSNotFound;
+        BOOL audio = [URL rangeOfString:@"trackID=1" options:NSCaseInsensitiveSearch].location != NSNotFound;
+        if (!video && !audio) {
+            [self response:404 cseq:cseq headers:nil body:nil];
+            return;
+        }
+        uint8_t channel = video ? 0 : 2;
+        NSRange interleavedRange = [transport rangeOfString:@"interleaved=" options:NSCaseInsensitiveSearch];
+        if (interleavedRange.location != NSNotFound) {
+            NSString *tail = [transport substringFromIndex:interleavedRange.location + interleavedRange.length];
+            NSRange semicolon = [tail rangeOfString:@";"];
+            NSString *channels = semicolon.location == NSNotFound ? tail : [tail substringToIndex:semicolon.location];
+            NSArray *channelParts = [channels componentsSeparatedByString:@"-"];
+            NSUInteger firstChannel = 0, secondChannel = 0;
+            if (channelParts.count != 2 || !HARTSPParseUnsigned(channelParts[0], 254, &firstChannel) ||
+                !HARTSPParseUnsigned(channelParts[1], 255, &secondChannel) || secondChannel != firstChannel + 1) {
+                [self response:461 cseq:cseq headers:nil body:nil];
+                return;
+            }
+            channel = (uint8_t)firstChannel;
+        }
+        [self markMediaDemand];
+        if (video) { self.videoSetup = YES; self.videoChannel = channel; }
+        else { self.audioSetup = YES; self.audioChannel = channel; }
+        [self response:200 cseq:cseq
+                headers:@{ @"Transport": [NSString stringWithFormat:@"RTP/AVP/TCP;unicast;interleaved=%u-%u", channel, channel + 1],
+                           @"Session": self.sessionID }
+                   body:nil];
+        return;
+    }
+    if ([method isEqualToString:@"PLAY"]) {
+        if (!self.videoSetup && !self.audioSetup) {
+            [self response:455 cseq:cseq headers:nil body:nil];
+            return;
+        }
+        [self markMediaDemand];
+        if (!self.playing) {
+            self.playing = YES;
+            [_server clientStateDidChange];
+        }
+        [_server.delegate rtspServerNeedsVideoKeyFrame:_server];
+        [self response:200 cseq:cseq headers:@{ @"Session": self.sessionID, @"Range": @"npt=0.000-" } body:nil];
+        return;
+    }
+    if ([method isEqualToString:@"TEARDOWN"]) {
+        [self response:200 cseq:cseq headers:@{ @"Session": self.sessionID } body:nil];
+        [self closeAfterFlushingOutput];
+        return;
+    }
+    [self response:405 cseq:cseq headers:nil body:nil];
+}
+- (BOOL)authenticateMethod:(NSString *)method URL:(NSString *)URL headers:(NSDictionary *)headers cseq:(NSString *)cseq {
+    // VLC 3.x reuses its authenticated DESCRIBE Authorization value for later
+    // SETUP and PLAY requests on the same TCP connection. Digest establishes
+    // the connection's identity once; RTSP session/state validation below still
+    // applies independently to every subsequent protected request.
+    if (self.isAuthenticated) return YES;
+
+    NSString *authorization = headers[@"authorization"];
+    NSDictionary *parameters = HARTSPDigestParameters(authorization);
+    if (!authorization.length) {
+        HALogI(@"rtsp", @"RTSP authentication is required for this connection.");
+        [self response:401 cseq:cseq headers:@{
+            @"WWW-Authenticate": [NSString stringWithFormat:
+                @"Digest realm=\"%@\", nonce=\"%@\", algorithm=MD5",
+                HARTSPAuthenticationRealm, self.authenticationNonce]
+        } body:nil];
+        return NO;
+    }
+    NSString *username = parameters[@"username"];
+    NSString *realm = parameters[@"realm"];
+    NSString *nonce = parameters[@"nonce"];
+    NSString *digestURI = parameters[@"uri"];
+    NSString *providedResponse = parameters[@"response"];
+    NSString *algorithm = parameters[@"algorithm"];
+
+    BOOL fieldsValid = username.length && realm.length && nonce.length && digestURI.length &&
+        providedResponse.length == CC_MD5_DIGEST_LENGTH * 2 &&
+        [username isEqualToString:_server.authenticationUsername] &&
+        [realm isEqualToString:HARTSPAuthenticationRealm] &&
+        HARTSPURIMatchesRequest(digestURI, URL) && !parameters[@"qop"] &&
+        (!algorithm.length || [algorithm caseInsensitiveCompare:@"MD5"] == NSOrderedSame);
+    BOOL digestValid = NO;
+    if (fieldsValid) {
+        NSString *HA1 = HARTSPMD5Hex([NSString stringWithFormat:@"%@:%@:%@", _server.authenticationUsername,
+                                      HARTSPAuthenticationRealm, _server.authenticationPassword]);
+        NSString *HA2 = HARTSPMD5Hex([NSString stringWithFormat:@"%@:%@", method, digestURI]);
+        NSString *expected = HARTSPMD5Hex([NSString stringWithFormat:@"%@:%@:%@", HA1,
+                                           nonce, HA2]);
+        digestValid = HARTSPConstantTimeEqualHex(expected, providedResponse);
+    }
+    BOOL currentNonce = nonce.length && HARTSPConstantTimeEqualHex(nonce, self.authenticationNonce);
+    if (digestValid && currentNonce) {
+        self.authenticated = YES;
+        self.authenticationFailures = 0;
+        return YES;
+    }
+
+    if (digestValid && !currentNonce) {
+        HALogI(@"rtsp", @"Requested a fresh RTSP Digest nonce for a reconnecting client.");
+        [self response:401 cseq:cseq headers:@{
+            @"WWW-Authenticate": [NSString stringWithFormat:
+                @"Digest realm=\"%@\", nonce=\"%@\", algorithm=MD5, stale=true",
+                HARTSPAuthenticationRealm, self.authenticationNonce]
+        } body:nil];
+        return NO;
+    }
+
+    self.authenticationFailures++;
+    HALogW(@"rtsp", @"Rejected invalid RTSP credentials (%lu of %lu).",
+           (unsigned long)self.authenticationFailures, (unsigned long)kHARTSPMaxAuthenticationFailures);
+    NSMutableDictionary *challengeHeaders = [@{
+        @"WWW-Authenticate": [NSString stringWithFormat:@"Digest realm=\"%@\", nonce=\"%@\", algorithm=MD5",
+                              HARTSPAuthenticationRealm, self.authenticationNonce]
+    } mutableCopy];
+    BOOL closeAfterResponse = self.authenticationFailures >= kHARTSPMaxAuthenticationFailures;
+    if (closeAfterResponse) challengeHeaders[@"Connection"] = @"close";
+    [self response:401 cseq:cseq headers:challengeHeaders body:nil];
+    if (closeAfterResponse) [self closeAfterFlushingOutput];
+    return NO;
+}
+- (void)markMediaDemand {
+    if (self.mediaDemand) return;
+    self.mediaDemand = YES;
+    [_server clientStateDidChange];
+}
+- (void)response:(NSInteger)status cseq:(NSString *)cseq headers:(NSDictionary *)headers body:(NSData *)body {
+    NSDictionary *reasons = @{
+        @200: @"OK", @400: @"Bad Request", @401: @"Unauthorized", @404: @"Not Found",
+        @405: @"Method Not Allowed", @413: @"Request Entity Too Large", @454: @"Session Not Found",
+        @455: @"Method Not Valid in This State", @461: @"Unsupported Transport",
+        @503: @"Service Unavailable"
+    };
+    NSString *reason = reasons[@(status)] ?: @"Error";
+    NSMutableString *head = [NSMutableString stringWithFormat:@"RTSP/1.0 %ld %@\r\nCSeq: %@\r\n",
+                             (long)status, reason, HARTSPValidCSeq(cseq) ? cseq : @"0"];
+    for (NSString *key in headers) [head appendFormat:@"%@: %@\r\n", key, headers[key]];
+    [head appendFormat:@"Content-Length: %lu\r\n\r\n", (unsigned long)body.length];
+    NSMutableData *data = [[head dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
+    if (body.length) [data appendData:body];
+    HALogI(@"rtsp", @"Response %ld CSeq %@", (long)status, HARTSPValidCSeq(cseq) ? cseq : @"0");
+    [self queue:data];
+}
+- (void)sendPendingDescriptionIfReady {
+    if (!self.isAuthenticated || !self.mediaDemand || !self.pendingDescribeCSeq.length) return;
+    NSString *description = [_server sessionDescription];
+    if (!description) return;
+    NSString *cseq = self.pendingDescribeCSeq;
+    self.pendingDescribeCSeq = nil;
+    [self response:200 cseq:cseq
+            headers:@{ @"Content-Type": @"application/sdp", @"Content-Base": [_server streamURL] }
+               body:[description dataUsingEncoding:NSUTF8StringEncoding]];
+}
+- (void)checkIdleTimer:(NSTimer *)timer {
+    (void)timer;
+    if (self.closed) return;
+    CFAbsoluteTime now = CFAbsoluteTimeGetCurrent();
+    if (!self.isAuthenticated && now - self.connectedAt >= kHARTSPAuthenticationTimeout) {
+        HALogI(@"rtsp", @"Closing an RTSP client that did not authenticate in time.");
+        [self close];
+    } else if (self.pendingOutputLength > 0 && self.outputBacklogStartedAt > 0 &&
+               now - self.outputBacklogStartedAt >= kHARTSPOutputBackpressureTimeout) {
+        HALogW(@"rtsp", @"Closing an RTSP client whose output remained blocked for %.0f seconds.",
+               kHARTSPOutputBackpressureTimeout);
+        [self close];
+    } else if (now - self.lastActivity >= kHARTSPClientIdleTimeout) {
+        HALogI(@"rtsp", @"Closing an idle RTSP client.");
+        [self close];
+    }
+}
+@end

--- a/HADashboard/Streaming/HAStreamingManager.h
+++ b/HADashboard/Streaming/HAStreamingManager.h
@@ -1,0 +1,56 @@
+#import <Foundation/Foundation.h>
+
+extern NSString *const HAStreamingManagerStateDidChangeNotification;
+extern NSString *const HAStreamingManagerErrorKey;
+
+typedef NS_ENUM(NSInteger, HAStreamingStopTrigger) {
+    HAStreamingStopTriggerUser, HAStreamingStopTriggerFeatureDisabled,
+    HAStreamingStopTriggerAppWillResignActive, HAStreamingStopTriggerAppDidEnterBackground,
+    HAStreamingStopTriggerLogout, HAStreamingStopTriggerPermissionLost,
+    HAStreamingStopTriggerServerFailure, HAStreamingStopTriggerCaptureInterrupted,
+};
+
+typedef NS_ENUM(NSInteger, HAStreamingCameraMode) {
+    HAStreamingCameraModeFront = 0,
+    HAStreamingCameraModeRear = 1,
+    HAStreamingCameraModeBoth = 2,
+};
+
+/// Foreground-only local H.264/AAC source for Home Assistant. It contains its
+/// own RTSP listener; no relay, recording, remote start, or cloud service.
+@interface HAStreamingManager : NSObject
+@property (nonatomic, readonly) BOOL featureEnabled;
+@property (nonatomic, readonly) BOOL configured;
+@property (nonatomic, readonly, getter=isCapturing) BOOL capturing;
+@property (nonatomic, readonly) BOOL streaming;
+@property (nonatomic, readonly) BOOL supported;
+@property (nonatomic, copy, readonly) NSString *streamURL;
+@property (nonatomic, copy, readonly) NSString *secondaryStreamURL;
+@property (nonatomic, copy, readonly) NSArray<NSString *> *streamURLs;
+@property (nonatomic, readonly) NSUInteger streamClientCount;
+@property (nonatomic, readonly) NSUInteger streamConnectionCount;
+@property (nonatomic, readonly) NSUInteger streamPlayingClientCount;
+@property (nonatomic, readonly) BOOL frontCameraAvailable;
+@property (nonatomic, readonly) BOOL rearCameraAvailable;
+@property (nonatomic, readonly) BOOL multiCamSupported;
+@property (nonatomic, readonly) HAStreamingCameraMode cameraMode;
+@property (nonatomic, readonly) float qualityScale;
+@property (nonatomic, copy, readonly) NSString *qualityDescription;
+/// Frame rate of the currently selected device-quality profile.
+@property (nonatomic, readonly) NSInteger targetFrameRate;
+@property (nonatomic, readonly) BOOL useRearCamera;
++ (instancetype)sharedManager;
+- (BOOL)setFeatureEnabled:(BOOL)enabled error:(NSError **)error;
+- (BOOL)setCameraMode:(HAStreamingCameraMode)cameraMode error:(NSError **)error;
+- (BOOL)setQualityScale:(float)qualityScale error:(NSError **)error;
+- (NSString *)qualityDescriptionForScale:(float)qualityScale;
+- (void)setUseRearCamera:(BOOL)useRearCamera;
+- (void)clearLocalStreamConfiguration;
+- (void)armLocalStreamWithCompletion:(void (^)(BOOL success, NSError *error))completion;
+/// Rotates the local credential and re-arms the protected listener. Completion
+/// does not wait for Home Assistant; when registration is enabled, camera-entry
+/// reconciliation starts afterward and may continue retrying asynchronously.
+- (void)rotateStreamCredentialWithCompletion:(void (^)(BOOL success, NSError *error))completion;
+- (void)stopWithTrigger:(HAStreamingStopTrigger)trigger error:(NSError *)error;
++ (BOOL)shouldStopForTrigger:(HAStreamingStopTrigger)trigger;
+@end

--- a/HADashboard/Streaming/HAStreamingManager.m
+++ b/HADashboard/Streaming/HAStreamingManager.m
@@ -1,0 +1,1477 @@
+#import "HAStreamingManager.h"
+#import "HARTSPServer.h"
+#import "HAAACEncoder.h"
+#import "HARTSPCredentialManager.h"
+#import "HAAuthManager.h"
+#import "HACameraRegistrationManager.h"
+#import "HADeviceIntegrationManager.h"
+#import "HADeviceRegistration.h"
+#import "HALog.h"
+#import <UIKit/UIKit.h>
+#import <AVFoundation/AVFoundation.h>
+#import <CoreMedia/CoreMedia.h>
+#import <CoreVideo/CoreVideo.h>
+#import <VideoToolbox/VideoToolbox.h>
+#import <ifaddrs.h>
+#import <net/if.h>
+#import <arpa/inet.h>
+#import <math.h>
+
+NSString *const HAStreamingManagerStateDidChangeNotification = @"HAStreamingManagerStateDidChangeNotification";
+NSString *const HAStreamingManagerErrorKey = @"HAStreamingManagerErrorKey";
+
+static NSString *const kHAStreamingEnabledKey = @"ha_local_camera_stream_enabled";
+static NSString *const kHAStreamingCameraModeKey = @"ha_local_camera_stream_mode";
+static NSString *const kHAStreamingQualityScaleKey = @"ha_local_camera_stream_quality_scale";
+static NSString *const kHAStreamingLegacyQualityPresetKey = @"ha_local_camera_stream_quality";
+static NSString *const kHAStreamingLegacyRearCameraKey = @"ha_local_camera_stream_rear";
+static NSString *const HAStreamingManagerErrorDomain = @"HAStreamingManagerErrorDomain";
+static char HAStreamingAudioCaptureQueueKey;
+
+@interface HAStreamingQualityProfile : NSObject
+@property (nonatomic, strong) AVCaptureDeviceFormat *format;
+@property (nonatomic, assign) CMVideoDimensions dimensions;
+@property (nonatomic, assign) NSInteger frameRate;
+@property (nonatomic, assign) NSInteger bitRate;
+@end
+
+@implementation HAStreamingQualityProfile
+@end
+
+@interface HAStreamingManager () <AVCaptureVideoDataOutputSampleBufferDelegate,
+                                  AVCaptureAudioDataOutputSampleBufferDelegate,
+                                  HARTSPServerDelegate>
+@property (nonatomic, assign, readwrite) BOOL featureEnabled;
+@property (nonatomic, assign, readwrite, getter=isCapturing) BOOL capturing;
+@property (nonatomic, assign, readwrite) BOOL streaming;
+@property (nonatomic, assign, readwrite) HAStreamingCameraMode cameraMode;
+@property (nonatomic, assign, readwrite) float qualityScale;
+@property (nonatomic, strong) AVCaptureSession *captureSession;
+@property (nonatomic, strong) AVCaptureVideoDataOutput *frontVideoOutput;
+@property (nonatomic, strong) AVCaptureVideoDataOutput *rearVideoOutput;
+@property (nonatomic, strong) AVCaptureAudioDataOutput *audioOutput;
+@property (nonatomic, strong) dispatch_queue_t captureQueue;
+@property (nonatomic, strong) dispatch_queue_t audioCaptureQueue;
+@property (nonatomic, assign) BOOL configuringCapture;
+@property (nonatomic, assign) VTCompressionSessionRef frontCompressionSession;
+@property (nonatomic, assign) VTCompressionSessionRef rearCompressionSession;
+@property (nonatomic, assign) BOOL forceFrontKeyFrame;
+@property (nonatomic, assign) BOOL forceRearKeyFrame;
+@property (nonatomic, strong) HAAACEncoder *audioEncoder;
+@property (nonatomic, strong) HARTSPServer *primaryRTSPServer;
+@property (nonatomic, strong) HARTSPServer *secondaryRTSPServer;
+@property (nonatomic, strong) NSData *publishedFrontConfiguration;
+@property (nonatomic, strong) NSData *publishedRearConfiguration;
+@property (nonatomic, strong) NSData *publishedAudioConfiguration;
+@property (nonatomic, assign) NSUInteger publishedAudioChannels;
+@property (nonatomic, assign) NSUInteger publishedAudioSampleRate;
+@property (nonatomic, assign) CMTime mediaStartTime;
+@property (nonatomic, assign) BOOL loggedFrontVideo;
+@property (nonatomic, assign) BOOL loggedRearVideo;
+@property (nonatomic, assign) BOOL loggedAudioInput;
+@property (nonatomic, assign) NSUInteger audioInputBufferCount;
+@property (nonatomic, assign) BOOL loggedAudioConfiguration;
+@property (nonatomic, assign) BOOL loggedEncodedAudio;
+@property (nonatomic, assign) AVCaptureVideoOrientation captureOrientation;
+@property (nonatomic, assign) NSUInteger orientationChangeGeneration;
+@property (nonatomic, assign) NSUInteger observedAuthenticationRevision;
+@property (nonatomic, assign) BOOL observedDemoMode;
++ (BOOL)supportsOperatingSystemVersion:(NSOperatingSystemVersion)version;
++ (BOOL)usesAudioCompatiblePresetForOperatingSystemVersion:(NSOperatingSystemVersion)version;
++ (NSArray<NSString *> *)preferredLegacySessionPresetsForQualityScale:(float)qualityScale;
+- (void)handleCompressedVideoSample:(CMSampleBufferRef)sampleBuffer
+                             status:(OSStatus)status
+                             output:(AVCaptureVideoDataOutput *)output;
+- (void)clearAudioMediaStateSynchronously;
+@end
+
+static void HAStreamingCompressionOutput(void *context,
+                                         void *sourceFrameRefCon,
+                                         OSStatus status,
+                                         VTEncodeInfoFlags flags,
+                                         CMSampleBufferRef sampleBuffer) {
+    (void)flags;
+    HAStreamingManager *manager = (__bridge HAStreamingManager *)context;
+    AVCaptureVideoDataOutput *output = (__bridge AVCaptureVideoDataOutput *)sourceFrameRefCon;
+    [manager handleCompressedVideoSample:sampleBuffer status:status output:output];
+}
+
+@implementation HAStreamingManager
+
++ (instancetype)sharedManager {
+    static HAStreamingManager *manager;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ manager = [[self alloc] init]; });
+    return manager;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (!self) return nil;
+
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    BOOL persistedEnabled = [defaults boolForKey:kHAStreamingEnabledKey];
+    _featureEnabled = persistedEnabled && self.supported;
+    if (persistedEnabled && !_featureEnabled) {
+        // A restored preference or legacy deployment must never bypass the
+        // platform gate and request camera/microphone access on iOS 9.
+        [defaults setBool:NO forKey:kHAStreamingEnabledKey];
+        [defaults synchronize];
+    }
+    _captureQueue = dispatch_queue_create("com.hadashboard.localstream.capture", DISPATCH_QUEUE_SERIAL);
+    _audioCaptureQueue = dispatch_queue_create("com.hadashboard.localstream.audio", DISPATCH_QUEUE_SERIAL);
+    dispatch_queue_set_specific(_audioCaptureQueue, &HAStreamingAudioCaptureQueueKey,
+                                &HAStreamingAudioCaptureQueueKey, NULL);
+    _mediaStartTime = kCMTimeInvalid;
+    _captureOrientation = [self currentVideoOrientation];
+    _observedAuthenticationRevision = [HAAuthManager sharedManager].authenticationRevision;
+    _observedDemoMode = [HAAuthManager sharedManager].isDemoMode;
+
+    NSNumber *storedMode = [defaults objectForKey:kHAStreamingCameraModeKey];
+    if (storedMode) {
+        _cameraMode = (HAStreamingCameraMode)storedMode.integerValue;
+    } else if ([defaults boolForKey:kHAStreamingLegacyRearCameraKey]) {
+        _cameraMode = HAStreamingCameraModeRear;
+    } else {
+        _cameraMode = [self cameraForPosition:AVCaptureDevicePositionBack]
+            ? HAStreamingCameraModeRear : HAStreamingCameraModeFront;
+    }
+    _cameraMode = [self validatedCameraMode:_cameraMode];
+    NSNumber *storedScale = [defaults objectForKey:kHAStreamingQualityScaleKey];
+    if (storedScale) {
+        _qualityScale = MIN(1.0f, MAX(0.0f, storedScale.floatValue));
+    } else {
+        NSNumber *legacyPreset = [defaults objectForKey:kHAStreamingLegacyQualityPresetKey];
+        if (legacyPreset.integerValue <= 0 && legacyPreset) _qualityScale = 0.0f;
+        else if (legacyPreset.integerValue >= 2) _qualityScale = 1.0f;
+        else _qualityScale = [self defaultQualityScale];
+    }
+
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    [center addObserver:self selector:@selector(resign:) name:UIApplicationWillResignActiveNotification object:nil];
+    [center addObserver:self selector:@selector(background:) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    [center addObserver:self selector:@selector(active:) name:UIApplicationDidBecomeActiveNotification object:nil];
+    [center addObserver:self selector:@selector(auth:) name:HAAuthManagerDidUpdateNotification object:nil];
+    [center addObserver:self selector:@selector(interrupted:) name:AVCaptureSessionWasInterruptedNotification object:nil];
+    [center addObserver:self selector:@selector(interrupted:) name:AVCaptureSessionRuntimeErrorNotification object:nil];
+    [center addObserver:self selector:@selector(orientationChanged:) name:UIDeviceOrientationDidChangeNotification object:nil];
+    [center addObserver:self selector:@selector(orientationChanged:) name:UIApplicationDidChangeStatusBarOrientationNotification object:nil];
+    [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
+    return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
+    [self stopWithTrigger:HAStreamingStopTriggerUser error:nil];
+}
+
+#pragma mark - Public state
+
+- (BOOL)supported {
+    return [[self class] supportsOperatingSystemVersion:[NSProcessInfo processInfo].operatingSystemVersion];
+}
+
++ (BOOL)supportsOperatingSystemVersion:(NSOperatingSystemVersion)version {
+    if (version.majorVersion > 10) return YES;
+    if (version.majorVersion < 10 || version.minorVersion < 3) return NO;
+    if (version.minorVersion > 3) return YES;
+    return version.patchVersion >= 3;
+}
+
+- (BOOL)configured { return YES; }
+- (NSString *)streamURL { return self.primaryRTSPServer.streamURL; }
+- (NSString *)secondaryStreamURL { return self.secondaryRTSPServer.streamURL; }
+
+- (NSArray<NSString *> *)streamURLs {
+    NSMutableArray<NSString *> *urls = [NSMutableArray array];
+    if (self.streamURL.length) [urls addObject:self.streamURL];
+    if (self.secondaryStreamURL.length) [urls addObject:self.secondaryStreamURL];
+    return urls;
+}
+
+- (NSUInteger)streamClientCount {
+    return self.primaryRTSPServer.clientCount + self.secondaryRTSPServer.clientCount;
+}
+
+- (NSUInteger)streamConnectionCount {
+    return self.primaryRTSPServer.connectionCount + self.secondaryRTSPServer.connectionCount;
+}
+
+- (NSUInteger)streamPlayingClientCount {
+    return self.primaryRTSPServer.playingClientCount + self.secondaryRTSPServer.playingClientCount;
+}
+
+- (BOOL)frontCameraAvailable {
+    return self.supported && [self cameraForPosition:AVCaptureDevicePositionFront] != nil;
+}
+
+- (BOOL)rearCameraAvailable {
+    return self.supported && [self cameraForPosition:AVCaptureDevicePositionBack] != nil;
+}
+
+- (BOOL)multiCamSupported {
+    if (@available(iOS 13.0, *)) {
+        return self.frontCameraAvailable && self.rearCameraAvailable &&
+               [AVCaptureMultiCamSession isMultiCamSupported];
+    }
+    return NO;
+}
+
+- (BOOL)useRearCamera { return self.cameraMode == HAStreamingCameraModeRear; }
+
+- (BOOL)setFeatureEnabled:(BOOL)enabled error:(NSError **)error {
+    if (enabled && !self.supported) {
+        if (error) *error = [self error:@"Local camera streaming requires iOS 10.3.3 or newer."];
+        return NO;
+    }
+    self.featureEnabled = enabled;
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults setBool:enabled forKey:kHAStreamingEnabledKey];
+    [defaults synchronize];
+    CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
+    if (!enabled) {
+        [[HACameraRegistrationManager sharedManager] cancelRegistration];
+        [self stopWithTrigger:HAStreamingStopTriggerFeatureDisabled error:nil];
+    }
+    [self post:nil];
+    return YES;
+}
+
+- (BOOL)setCameraMode:(HAStreamingCameraMode)cameraMode error:(NSError **)error {
+    HAStreamingCameraMode validated = [self validatedCameraMode:cameraMode];
+    if (validated != cameraMode) {
+        NSString *description = cameraMode == HAStreamingCameraModeBoth
+            ? @"This device cannot capture its front and rear cameras simultaneously."
+            : @"The selected camera is not available on this device.";
+        if (error) *error = [self error:description];
+        return NO;
+    }
+    if (self.cameraMode == cameraMode) return YES;
+
+    BOOL shouldRearm = self.featureEnabled && self.streaming;
+    if (shouldRearm) [self stopWithTrigger:HAStreamingStopTriggerUser error:nil];
+    self.cameraMode = cameraMode;
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults setInteger:cameraMode forKey:kHAStreamingCameraModeKey];
+    [defaults setBool:(cameraMode == HAStreamingCameraModeRear) forKey:kHAStreamingLegacyRearCameraKey];
+    [defaults synchronize];
+    CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
+    [self post:nil];
+    if (shouldRearm) [self armLocalStreamWithCompletion:nil];
+    return YES;
+}
+
+- (void)setUseRearCamera:(BOOL)useRearCamera {
+    [self setCameraMode:useRearCamera ? HAStreamingCameraModeRear : HAStreamingCameraModeFront error:nil];
+}
+
+- (BOOL)setQualityScale:(float)qualityScale error:(NSError **)error {
+    if (!isfinite(qualityScale)) {
+        if (error) *error = [self error:@"The selected stream quality is invalid."];
+        return NO;
+    }
+    float clampedScale = MIN(1.0f, MAX(0.0f, qualityScale));
+    if (fabsf(self.qualityScale - clampedScale) < 0.001f) return YES;
+
+    BOOL shouldRestartCapture = self.isCapturing && self.streamClientCount > 0;
+    self.qualityScale = clampedScale;
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults setFloat:clampedScale forKey:kHAStreamingQualityScaleKey];
+    [defaults synchronize];
+    CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
+    [self post:nil];
+    if (shouldRestartCapture) [self restartCapturePreservingClients];
+    return YES;
+}
+
+- (void)clearLocalStreamConfiguration {
+    [self setFeatureEnabled:NO error:nil];
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults removeObjectForKey:kHAStreamingCameraModeKey];
+    [defaults removeObjectForKey:kHAStreamingQualityScaleKey];
+    [defaults removeObjectForKey:kHAStreamingLegacyQualityPresetKey];
+    [defaults removeObjectForKey:kHAStreamingLegacyRearCameraKey];
+    [defaults synchronize];
+
+    self.cameraMode = self.rearCameraAvailable
+        ? HAStreamingCameraModeRear : HAStreamingCameraModeFront;
+    self.qualityScale = [self defaultQualityScale];
+    NSError *credentialError = nil;
+    if (![[HARTSPCredentialManager sharedManager] deleteCredentialsWithError:&credentialError]) {
+        HALogW(@"localstream", @"Protected stream credential reset failed: %@",
+               credentialError.localizedDescription);
+    }
+    [self post:nil];
+}
+
+#pragma mark - Permissions and arming
+
+- (void)permission:(NSString *)mediaType done:(void (^)(BOOL granted))done {
+    AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:mediaType];
+    if (status == AVAuthorizationStatusAuthorized) {
+        done(YES);
+    } else if (status == AVAuthorizationStatusNotDetermined) {
+        [AVCaptureDevice requestAccessForMediaType:mediaType completionHandler:^(BOOL granted) {
+            dispatch_async(dispatch_get_main_queue(), ^{ done(granted); });
+        }];
+    } else {
+        done(NO);
+    }
+}
+
+- (void)armLocalStreamWithCompletion:(void (^)(BOOL, NSError *))completion {
+    if (!self.supported) {
+        [self finish:completion ok:NO error:[self error:@"Local camera streaming requires iOS 10.3.3 or newer."]];
+        return;
+    }
+    if ([UIApplication sharedApplication].applicationState != UIApplicationStateActive) {
+        [self finish:completion ok:NO error:[self error:@"Start Local Stream while HA Dashboard is in the foreground."]];
+        return;
+    }
+    if (!self.featureEnabled) {
+        [self finish:completion ok:NO error:[self error:@"Enable Local Camera Stream before arming its listener."]];
+        return;
+    }
+    if (self.streaming) {
+        [self finish:completion ok:YES error:nil];
+        return;
+    }
+
+    __weak typeof(self) weakSelf = self;
+    [self permission:AVMediaTypeVideo done:^(BOOL cameraGranted) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        if (!cameraGranted) {
+            [strongSelf finish:completion ok:NO error:[strongSelf error:@"Camera permission is required."]];
+            return;
+        }
+        if (![strongSelf canContinueArming]) {
+            [strongSelf finish:completion ok:NO error:[strongSelf error:@"Local Camera Stream was disabled or left the foreground while requesting permission."]];
+            return;
+        }
+        [strongSelf permission:AVMediaTypeAudio done:^(BOOL microphoneGranted) {
+            typeof(self) innerSelf = weakSelf;
+            if (!innerSelf) return;
+            if (!microphoneGranted) {
+                [innerSelf finish:completion ok:NO error:[innerSelf error:@"Microphone permission is required."]];
+                return;
+            }
+            if (![innerSelf canContinueArming]) {
+                [innerSelf finish:completion ok:NO error:[innerSelf error:@"Local Camera Stream was disabled or left the foreground while requesting permission."]];
+                return;
+            }
+            [innerSelf startRTSPWithCompletion:completion];
+        }];
+    }];
+}
+
+- (void)startRTSPWithCompletion:(void (^)(BOOL, NSError *))completion {
+    if (![self canContinueArming]) {
+        [self finish:completion ok:NO error:[self error:@"Local Camera Stream must remain enabled in the foreground while arming."]];
+        return;
+    }
+    NSString *host = [self localIPv4];
+    if (!host.length) {
+        [self finish:completion ok:NO error:[self error:@"Connect this device to a private local network on its primary interface before starting its stream."]];
+        return;
+    }
+
+    NSError *credentialError = nil;
+    HARTSPCredentials *credentials = [[HARTSPCredentialManager sharedManager]
+        credentialsWithError:&credentialError];
+    if (!credentials) {
+        [self finish:completion ok:NO error:credentialError ?: [self error:@"Protected stream credentials are unavailable."]];
+        return;
+    }
+
+    HARTSPServer *primary = [[HARTSPServer alloc] initWithHost:host port:8554
+        username:credentials.username password:credentials.password];
+    primary.delegate = self;
+    NSError *serverError = nil;
+    if (![primary start:&serverError]) {
+        HALogE(@"localstream", @"Primary RTSP listener failed: %@", serverError.localizedDescription);
+        [self finish:completion ok:NO error:serverError];
+        return;
+    }
+
+    HARTSPServer *secondary = nil;
+    if (self.cameraMode == HAStreamingCameraModeBoth) {
+        secondary = [[HARTSPServer alloc] initWithHost:host port:8555
+            username:credentials.username password:credentials.password];
+        secondary.delegate = self;
+        if (![secondary start:&serverError]) {
+            [primary stop];
+            HALogE(@"localstream", @"Secondary RTSP listener failed: %@", serverError.localizedDescription);
+            [self finish:completion ok:NO error:serverError];
+            return;
+        }
+    }
+
+    self.primaryRTSPServer = primary;
+    self.secondaryRTSPServer = secondary;
+    self.streaming = YES;
+    HALogI(@"localstream", @"RTSP listener armed at %@%@", primary.streamURL,
+           secondary ? [NSString stringWithFormat:@" and %@", secondary.streamURL] : @"");
+    [self post:nil];
+    [self finish:completion ok:YES error:nil];
+
+    if ([HADeviceIntegrationManager sharedManager].enabled) {
+        [[HACameraRegistrationManager sharedManager]
+            ensureCameraEntriesForStreamURLs:self.streamURLs
+            deviceName:[HADeviceRegistration sharedManager].deviceName
+            username:credentials.username
+            password:credentials.password
+            credentialRevision:credentials.revision
+            framesPerSecond:self.targetFrameRate
+            completion:^(BOOL success, NSError *registrationError) {
+                if (!success) {
+                    HALogW(@"localstream", @"Home Assistant camera registration skipped: %@",
+                           registrationError.localizedDescription);
+                }
+            }];
+    }
+}
+
+- (BOOL)canContinueArming {
+    return self.featureEnabled &&
+           [UIApplication sharedApplication].applicationState == UIApplicationStateActive;
+}
+
+- (void)rotateStreamCredentialWithCompletion:(void (^)(BOOL, NSError *))completion {
+    if (![self canContinueArming]) {
+        [self finish:completion ok:NO error:[self error:@"Rotate the stream password only while Local Camera Stream is enabled in the foreground."]];
+        return;
+    }
+    NSError *credentialError = nil;
+    HARTSPCredentials *credentials = [[HARTSPCredentialManager sharedManager]
+        rotateCredentialsWithError:&credentialError];
+    if (!credentials) {
+        [self finish:completion ok:NO error:credentialError];
+        return;
+    }
+    if ([HADeviceIntegrationManager sharedManager].enabled) {
+        HALogI(@"localstream", @"Protected stream credential rotated; disconnecting viewers; Home Assistant entry reconciliation will start asynchronously after the listener re-arms");
+    } else {
+        HALogI(@"localstream", @"Protected stream credential rotated; disconnecting viewers; manual clients require the new credential");
+    }
+    if (self.streaming || self.isCapturing || self.configuringCapture) {
+        [self stopWithTrigger:HAStreamingStopTriggerUser error:nil];
+    }
+    [self armLocalStreamWithCompletion:completion];
+}
+
+#pragma mark - Capture configuration
+
+- (void)configureCaptureWithCompletion:(void (^)(BOOL, NSError *))completion {
+    if (self.captureSession || self.configuringCapture) {
+        [self finish:completion ok:YES error:nil];
+        return;
+    }
+    self.configuringCapture = YES;
+
+    NSError *audioError = nil;
+    AVAudioSession *audioSession = [AVAudioSession sharedInstance];
+    [audioSession setPreferredSampleRate:48000 error:nil];
+    [audioSession setPreferredIOBufferDuration:0.01 error:nil];
+    if (![audioSession setCategory:AVAudioSessionCategoryPlayAndRecord error:&audioError] ||
+        ![audioSession setActive:YES error:&audioError]) {
+        self.configuringCapture = NO;
+        [self finish:completion ok:NO error:audioError ?: [self error:@"Could not activate the microphone."]];
+        return;
+    }
+
+    if (self.cameraMode == HAStreamingCameraModeBoth) {
+        [self configureMultiCamCaptureWithCompletion:completion];
+    } else {
+        [self configureSingleCameraCaptureWithCompletion:completion];
+    }
+}
+
+- (void)configureSingleCameraCaptureWithCompletion:(void (^)(BOOL, NSError *))completion {
+    AVCaptureDevicePosition position = self.cameraMode == HAStreamingCameraModeRear
+        ? AVCaptureDevicePositionBack : AVCaptureDevicePositionFront;
+    AVCaptureDevice *camera = [self cameraForPosition:position];
+    AVCaptureDevice *microphone = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
+    if (!camera || !microphone) {
+        self.configuringCapture = NO;
+        [self finish:completion ok:NO error:[self error:@"Camera or microphone is unavailable."]];
+        return;
+    }
+
+    NSError *inputError = nil;
+    AVCaptureDeviceInput *cameraInput = [AVCaptureDeviceInput deviceInputWithDevice:camera error:&inputError];
+    AVCaptureDeviceInput *microphoneInput = [AVCaptureDeviceInput deviceInputWithDevice:microphone error:&inputError];
+    AVCaptureSession *session = [[AVCaptureSession alloc] init];
+    [session beginConfiguration];
+    if (!cameraInput || !microphoneInput || ![session canAddInput:cameraInput] || ![session canAddInput:microphoneInput]) {
+        [session commitConfiguration];
+        self.configuringCapture = NO;
+        [self finish:completion ok:NO error:inputError ?: [self error:@"Could not open camera or microphone."]];
+        return;
+    }
+    [session addInput:cameraInput];
+    [session addInput:microphoneInput];
+    BOOL usesLegacyPreset = [[self class] usesAudioCompatiblePresetForOperatingSystemVersion:
+        [NSProcessInfo processInfo].operatingSystemVersion];
+    if (usesLegacyPreset) {
+        BOOL selectedPreset = NO;
+        for (NSString *preset in [[self class]
+                preferredLegacySessionPresetsForQualityScale:self.qualityScale]) {
+            if (![session canSetSessionPreset:preset]) continue;
+            session.sessionPreset = preset;
+            selectedPreset = YES;
+            HALogI(@"localstream", @"Using %@ capture preset to retain microphone audio on iOS 10.", preset);
+            break;
+        }
+        if (!selectedPreset) {
+            [session commitConfiguration];
+            self.configuringCapture = NO;
+            [self finish:completion ok:NO error:[self error:@"No audio-compatible camera quality is available on this device."]];
+            return;
+        }
+    } else {
+        if ([session canSetSessionPreset:AVCaptureSessionPresetInputPriority]) {
+            session.sessionPreset = AVCaptureSessionPresetInputPriority;
+        }
+        HAStreamingQualityProfile *qualityProfile = [self qualityProfileForDevice:camera scale:self.qualityScale];
+        if (![self applyQualityProfile:qualityProfile toDevice:camera error:&inputError]) {
+            [session commitConfiguration];
+            self.configuringCapture = NO;
+            [self finish:completion ok:NO error:inputError ?: [self error:@"Could not apply the selected camera quality."]];
+            return;
+        }
+    }
+
+    AVCaptureVideoDataOutput *videoOutput = [self newVideoOutput];
+    AVCaptureAudioDataOutput *audioOutput = [self newAudioOutput];
+    if (![session canAddOutput:videoOutput] || ![session canAddOutput:audioOutput]) {
+        [session commitConfiguration];
+        self.configuringCapture = NO;
+        [self finish:completion ok:NO error:[self error:@"Device cannot produce local camera and audio streams."]];
+        return;
+    }
+    [session addOutput:videoOutput];
+    [session addOutput:audioOutput];
+    [session commitConfiguration];
+
+    if (position == AVCaptureDevicePositionBack) self.rearVideoOutput = videoOutput;
+    else self.frontVideoOutput = videoOutput;
+    self.audioOutput = audioOutput;
+    [self applyVideoOrientationToOutputs];
+    [self startCaptureSession:session completion:completion];
+}
+
+- (void)configureMultiCamCaptureWithCompletion:(void (^)(BOOL, NSError *))completion {
+    if (@available(iOS 13.0, *)) {
+        if (!self.multiCamSupported) {
+            self.configuringCapture = NO;
+            [self finish:completion ok:NO error:[self error:@"This device does not support simultaneous front and rear capture."]];
+            return;
+        }
+
+        AVCaptureDevice *frontCamera = [self cameraForPosition:AVCaptureDevicePositionFront];
+        AVCaptureDevice *rearCamera = [self cameraForPosition:AVCaptureDevicePositionBack];
+        AVCaptureDevice *microphone = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
+        NSError *configurationError = nil;
+        if (![self configureMultiCamFormatForDevice:frontCamera error:&configurationError] ||
+            ![self configureMultiCamFormatForDevice:rearCamera error:&configurationError]) {
+            self.configuringCapture = NO;
+            [self finish:completion ok:NO error:configurationError];
+            return;
+        }
+
+        AVCaptureDeviceInput *frontInput = [AVCaptureDeviceInput deviceInputWithDevice:frontCamera error:&configurationError];
+        AVCaptureDeviceInput *rearInput = [AVCaptureDeviceInput deviceInputWithDevice:rearCamera error:&configurationError];
+        AVCaptureDeviceInput *audioInput = [AVCaptureDeviceInput deviceInputWithDevice:microphone error:&configurationError];
+        if (!frontInput || !rearInput || !audioInput) {
+            self.configuringCapture = NO;
+            [self finish:completion ok:NO error:configurationError ?: [self error:@"Could not open both cameras and the microphone."]];
+            return;
+        }
+
+        AVCaptureMultiCamSession *session = [[AVCaptureMultiCamSession alloc] init];
+        [session beginConfiguration];
+        NSArray<AVCaptureInput *> *inputs = @[frontInput, rearInput, audioInput];
+        for (AVCaptureInput *input in inputs) {
+            if (![session canAddInput:input]) {
+                [session commitConfiguration];
+                self.configuringCapture = NO;
+                [self finish:completion ok:NO error:[self error:@"Could not add both cameras and the microphone."]];
+                return;
+            }
+            [session addInputWithNoConnections:input];
+        }
+
+        AVCaptureVideoDataOutput *frontOutput = [self newVideoOutput];
+        AVCaptureVideoDataOutput *rearOutput = [self newVideoOutput];
+        AVCaptureAudioDataOutput *audioOutput = [self newAudioOutput];
+        NSArray<AVCaptureOutput *> *outputs = @[frontOutput, rearOutput, audioOutput];
+        for (AVCaptureOutput *output in outputs) {
+            if (![session canAddOutput:output]) {
+                [session commitConfiguration];
+                self.configuringCapture = NO;
+                [self finish:completion ok:NO error:[self error:@"Could not add both camera stream outputs."]];
+                return;
+            }
+            [session addOutputWithNoConnections:output];
+        }
+
+        AVCaptureInputPort *frontPort = [self videoPortForInput:frontInput position:AVCaptureDevicePositionFront];
+        AVCaptureInputPort *rearPort = [self videoPortForInput:rearInput position:AVCaptureDevicePositionBack];
+        AVCaptureInputPort *audioPort = [self audioPortForInput:audioInput];
+        if (![self addConnectionFromPort:frontPort output:frontOutput toSession:session] ||
+            ![self addConnectionFromPort:rearPort output:rearOutput toSession:session] ||
+            ![self addConnectionFromPort:audioPort output:audioOutput toSession:session]) {
+            [session commitConfiguration];
+            self.configuringCapture = NO;
+            [self finish:completion ok:NO error:[self error:@"Could not connect both cameras to their stream tracks."]];
+            return;
+        }
+        [session commitConfiguration];
+
+        if (@available(iOS 16.0, *)) {
+            if (session.hardwareCost > 1.0f) {
+                self.configuringCapture = NO;
+                [self finish:completion ok:NO error:[self error:@"This front and rear camera combination exceeds the device capture budget."]];
+                return;
+            }
+        }
+
+        self.frontVideoOutput = frontOutput;
+        self.rearVideoOutput = rearOutput;
+        self.audioOutput = audioOutput;
+        [self applyVideoOrientationToOutputs];
+        HALogI(@"localstream", @"Configured simultaneous front/rear MultiCam capture.");
+        [self startCaptureSession:session completion:completion];
+        return;
+    }
+
+    self.configuringCapture = NO;
+    [self finish:completion ok:NO error:[self error:@"MultiCam requires iOS 13 or newer."]];
+}
+
+- (AVCaptureVideoDataOutput *)newVideoOutput {
+    AVCaptureVideoDataOutput *output = [[AVCaptureVideoDataOutput alloc] init];
+    output.alwaysDiscardsLateVideoFrames = YES;
+    output.videoSettings = @{(id)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange)};
+    [output setSampleBufferDelegate:self queue:self.captureQueue];
+    return output;
+}
+
+- (AVCaptureAudioDataOutput *)newAudioOutput {
+    AVCaptureAudioDataOutput *output = [[AVCaptureAudioDataOutput alloc] init];
+    // Audio must not share the old-device video callback queue. On A6-era
+    // hardware, real-time H.264 submission can keep that serial queue busy
+    // enough for AVCaptureAudioDataOutput to stop delivering after its first
+    // buffer. A dedicated queue keeps full-rate microphone delivery alive.
+    [output setSampleBufferDelegate:self queue:self.audioCaptureQueue];
+    return output;
+}
+
+- (void)startCaptureSession:(AVCaptureSession *)session completion:(void (^)(BOOL, NSError *))completion {
+    self.captureSession = session;
+    self.loggedFrontVideo = NO;
+    self.loggedRearVideo = NO;
+    self.loggedAudioInput = NO;
+    self.audioInputBufferCount = 0;
+    self.loggedAudioConfiguration = NO;
+    self.loggedEncodedAudio = NO;
+    dispatch_async(self.captureQueue, ^{
+        [session startRunning];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (self.captureSession != session) return;
+            self.configuringCapture = NO;
+            self.capturing = YES;
+            [self post:nil];
+            [self finish:completion ok:YES error:nil];
+        });
+    });
+}
+
+#pragma mark - Device and MultiCam helpers
+
+- (NSArray<HAStreamingQualityProfile *> *)qualityProfilesForDevice:(AVCaptureDevice *)device
+                                                      multiCamOnly:(BOOL)multiCamOnly {
+    NSMutableDictionary<NSString *, HAStreamingQualityProfile *> *profilesBySize = [NSMutableDictionary dictionary];
+    for (AVCaptureDeviceFormat *format in device.formats) {
+        if (@available(iOS 13.0, *)) {
+            if (multiCamOnly && !format.isMultiCamSupported) continue;
+        } else if (multiCamOnly) {
+            continue;
+        }
+        CMVideoDimensions dimensions = CMVideoFormatDescriptionGetDimensions(format.formatDescription);
+        if (dimensions.width < 320 || dimensions.height < 240) continue;
+        double aspectRatio = (double)dimensions.width / (double)dimensions.height;
+        if (aspectRatio < 1.2 || aspectRatio > 2.0) continue;
+
+        Float64 maximumRate = 0;
+        for (AVFrameRateRange *range in format.videoSupportedFrameRateRanges) {
+            maximumRate = MAX(maximumRate, range.maxFrameRate);
+        }
+        NSInteger frameRate = (NSInteger)floor(MIN(maximumRate, multiCamOnly ? 15.0 : 30.0));
+        if (frameRate < 10) continue;
+
+        NSString *key = [NSString stringWithFormat:@"%dx%d", dimensions.width, dimensions.height];
+        HAStreamingQualityProfile *existing = profilesBySize[key];
+        if (existing && existing.frameRate >= frameRate) continue;
+
+        HAStreamingQualityProfile *profile = [[HAStreamingQualityProfile alloc] init];
+        profile.format = format;
+        profile.dimensions = dimensions;
+        profile.frameRate = frameRate;
+        double bitsPerSecond = (double)dimensions.width * dimensions.height * frameRate * 0.10;
+        if (multiCamOnly) bitsPerSecond *= 0.75;
+        profile.bitRate = (NSInteger)MIN(8000000.0, MAX(180000.0, bitsPerSecond));
+        profilesBySize[key] = profile;
+    }
+
+    NSArray *profiles = profilesBySize.allValues;
+    return [profiles sortedArrayUsingComparator:^NSComparisonResult(HAStreamingQualityProfile *left,
+                                                                    HAStreamingQualityProfile *right) {
+        uint64_t leftArea = (uint64_t)left.dimensions.width * left.dimensions.height;
+        uint64_t rightArea = (uint64_t)right.dimensions.width * right.dimensions.height;
+        if (leftArea < rightArea) return NSOrderedAscending;
+        if (leftArea > rightArea) return NSOrderedDescending;
+        return NSOrderedSame;
+    }];
+}
+
+- (HAStreamingQualityProfile *)profileFromProfiles:(NSArray<HAStreamingQualityProfile *> *)profiles
+                                              scale:(float)scale {
+    if (profiles.count == 0) return nil;
+    NSUInteger index = (NSUInteger)lroundf(MIN(1.0f, MAX(0.0f, scale)) * (profiles.count - 1));
+    return profiles[index];
+}
+
+- (float)defaultQualityScale {
+    if (!self.supported) return 0.5f;
+    AVCaptureDevicePosition position = self.cameraMode == HAStreamingCameraModeRear
+        ? AVCaptureDevicePositionBack : AVCaptureDevicePositionFront;
+    AVCaptureDevice *device = [self cameraForPosition:position];
+    NSArray<HAStreamingQualityProfile *> *profiles =
+        [self qualityProfilesForDevice:device multiCamOnly:self.cameraMode == HAStreamingCameraModeBoth];
+    if (profiles.count <= 1) return 0.0f;
+    uint64_t targetArea = 640ULL * 480ULL;
+    NSUInteger closestIndex = 0;
+    uint64_t closestDistance = UINT64_MAX;
+    for (NSUInteger index = 0; index < profiles.count; index++) {
+        CMVideoDimensions dimensions = profiles[index].dimensions;
+        uint64_t area = (uint64_t)dimensions.width * dimensions.height;
+        uint64_t distance = area > targetArea ? area - targetArea : targetArea - area;
+        if (distance < closestDistance) { closestDistance = distance; closestIndex = index; }
+    }
+    return (float)closestIndex / (float)(profiles.count - 1);
+}
+
+- (HAStreamingQualityProfile *)qualityProfileForDevice:(AVCaptureDevice *)device scale:(float)scale {
+    BOOL multiCam = self.cameraMode == HAStreamingCameraModeBoth;
+    NSArray<HAStreamingQualityProfile *> *profiles = [self qualityProfilesForDevice:device multiCamOnly:multiCam];
+    if (!multiCam) return [self profileFromProfiles:profiles scale:scale];
+
+    AVCaptureDevicePosition otherPosition = device.position == AVCaptureDevicePositionFront
+        ? AVCaptureDevicePositionBack : AVCaptureDevicePositionFront;
+    AVCaptureDevice *otherDevice = [self cameraForPosition:otherPosition];
+    NSArray<HAStreamingQualityProfile *> *otherProfiles =
+        [self qualityProfilesForDevice:otherDevice multiCamOnly:YES];
+    NSMutableSet<NSString *> *otherSizes = [NSMutableSet set];
+    for (HAStreamingQualityProfile *profile in otherProfiles) {
+        [otherSizes addObject:[NSString stringWithFormat:@"%dx%d", profile.dimensions.width, profile.dimensions.height]];
+    }
+    NSMutableArray<HAStreamingQualityProfile *> *commonProfiles = [NSMutableArray array];
+    for (HAStreamingQualityProfile *profile in profiles) {
+        NSString *key = [NSString stringWithFormat:@"%dx%d", profile.dimensions.width, profile.dimensions.height];
+        if ([otherSizes containsObject:key]) [commonProfiles addObject:profile];
+    }
+    return [self profileFromProfiles:commonProfiles.count ? commonProfiles : profiles scale:scale];
+}
+
+- (HAStreamingQualityProfile *)currentQualityProfile {
+    AVCaptureDevicePosition position = self.cameraMode == HAStreamingCameraModeRear
+        ? AVCaptureDevicePositionBack : AVCaptureDevicePositionFront;
+    return [self qualityProfileForDevice:[self cameraForPosition:position] scale:self.qualityScale];
+}
+
+- (NSInteger)targetFrameRate {
+    return [self currentQualityProfile].frameRate ?: 15;
+}
+
+- (NSInteger)targetBitRate {
+    return [self currentQualityProfile].bitRate ?: 600000;
+}
+
+- (NSString *)qualityDescription {
+    return [self qualityDescriptionForScale:self.qualityScale];
+}
+
+- (NSString *)qualityDescriptionForScale:(float)qualityScale {
+    if (!self.supported) return @"Requires iOS 10.3.3 or newer";
+    AVCaptureDevicePosition position = self.cameraMode == HAStreamingCameraModeRear
+        ? AVCaptureDevicePositionBack : AVCaptureDevicePositionFront;
+    HAStreamingQualityProfile *profile =
+        [self qualityProfileForDevice:[self cameraForPosition:position] scale:qualityScale];
+    if (!profile) return @"No compatible camera format";
+    double megabits = profile.bitRate / 1000000.0;
+    NSString *base = [NSString stringWithFormat:@"%d×%d · %ld fps · %.1f Mbps",
+        profile.dimensions.width, profile.dimensions.height, (long)profile.frameRate, megabits];
+    return self.cameraMode == HAStreamingCameraModeBoth
+        ? [base stringByAppendingString:@" per camera"] : base;
+}
+
+- (AVCaptureDevice *)cameraForPosition:(AVCaptureDevicePosition)position {
+    NSArray<AVCaptureDevice *> *devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+    for (AVCaptureDevice *device in devices) {
+        if (device.position == position) return device;
+    }
+    if (position == AVCaptureDevicePositionFront) {
+        AVCaptureDevice *defaultDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
+        if (defaultDevice && defaultDevice.position != AVCaptureDevicePositionBack) return defaultDevice;
+    }
+    return nil;
+}
+
+- (HAStreamingCameraMode)validatedCameraMode:(HAStreamingCameraMode)mode {
+    if (!self.supported) return HAStreamingCameraModeFront;
+    if (mode == HAStreamingCameraModeBoth && self.multiCamSupported) return mode;
+    if (mode == HAStreamingCameraModeRear && self.rearCameraAvailable) return mode;
+    if (mode == HAStreamingCameraModeFront && self.frontCameraAvailable) return mode;
+    if (self.rearCameraAvailable) return HAStreamingCameraModeRear;
+    return HAStreamingCameraModeFront;
+}
+
++ (BOOL)usesAudioCompatiblePresetForOperatingSystemVersion:(NSOperatingSystemVersion)version {
+    // AVFoundation documents that before iOS 11, selecting a photo-equivalent
+    // activeFormat makes the AVCaptureAudioDataOutput connection inactive.
+    // Video session presets retain the microphone connection on iOS 10.
+    return version.majorVersion < 11;
+}
+
++ (NSArray<NSString *> *)preferredLegacySessionPresetsForQualityScale:(float)qualityScale {
+    float scale = MIN(1.0f, MAX(0.0f, qualityScale));
+    if (scale < 0.34f) {
+        return @[AVCaptureSessionPreset640x480,
+                 AVCaptureSessionPreset1280x720,
+                 AVCaptureSessionPresetHigh];
+    }
+    if (scale < 0.67f) {
+        return @[AVCaptureSessionPreset1280x720,
+                 AVCaptureSessionPresetHigh,
+                 AVCaptureSessionPreset640x480];
+    }
+    return @[AVCaptureSessionPreset1920x1080,
+             AVCaptureSessionPreset1280x720,
+             AVCaptureSessionPresetHigh,
+             AVCaptureSessionPreset640x480];
+}
+
+- (BOOL)configureMultiCamFormatForDevice:(AVCaptureDevice *)device error:(NSError **)error {
+    if (@available(iOS 13.0, *)) {
+        HAStreamingQualityProfile *profile = [self qualityProfileForDevice:device scale:self.qualityScale];
+        return [self applyQualityProfile:profile toDevice:device error:error];
+    }
+    if (error) *error = [self error:@"MultiCam requires iOS 13 or newer."];
+    return NO;
+}
+
+- (BOOL)applyQualityProfile:(HAStreamingQualityProfile *)profile
+                    toDevice:(AVCaptureDevice *)device
+                       error:(NSError **)error {
+    if (!profile || !device) {
+        if (error) *error = [self error:@"No compatible camera quality is available."];
+        return NO;
+    }
+    NSError *lockError = nil;
+    if (![device lockForConfiguration:&lockError]) {
+        if (error) *error = lockError;
+        return NO;
+    }
+    device.activeFormat = profile.format;
+    CMTime duration = CMTimeMake(1, (int32_t)profile.frameRate);
+    device.activeVideoMinFrameDuration = duration;
+    device.activeVideoMaxFrameDuration = duration;
+    [device unlockForConfiguration];
+    return YES;
+}
+
+- (AVCaptureInputPort *)videoPortForInput:(AVCaptureDeviceInput *)input
+                                  position:(AVCaptureDevicePosition)position API_AVAILABLE(ios(13.0)) {
+    AVCaptureInputPort *port = [input portsWithMediaType:AVMediaTypeVideo
+                                        sourceDeviceType:input.device.deviceType
+                                     sourceDevicePosition:position].firstObject;
+    if (port) return port;
+    for (AVCaptureInputPort *candidate in input.ports) {
+        if ([candidate.mediaType isEqualToString:AVMediaTypeVideo]) return candidate;
+    }
+    return nil;
+}
+
+- (AVCaptureInputPort *)audioPortForInput:(AVCaptureDeviceInput *)input API_AVAILABLE(ios(13.0)) {
+    AVCaptureInputPort *port = [input portsWithMediaType:AVMediaTypeAudio
+                                        sourceDeviceType:nil
+                                     sourceDevicePosition:AVCaptureDevicePositionUnspecified].firstObject;
+    if (port) return port;
+    for (AVCaptureInputPort *candidate in input.ports) {
+        if ([candidate.mediaType isEqualToString:AVMediaTypeAudio]) return candidate;
+    }
+    return nil;
+}
+
+- (BOOL)addConnectionFromPort:(AVCaptureInputPort *)port
+                        output:(AVCaptureOutput *)output
+                     toSession:(AVCaptureSession *)session API_AVAILABLE(ios(13.0)) {
+    if (!port) return NO;
+    AVCaptureConnection *connection = [AVCaptureConnection connectionWithInputPorts:@[port] output:output];
+    if (![session canAddConnection:connection]) return NO;
+    [session addConnection:connection];
+    return YES;
+}
+
+#pragma mark - Encoding
+
+- (void)captureOutput:(AVCaptureOutput *)output
+ didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
+       fromConnection:(AVCaptureConnection *)connection {
+    (void)connection;
+    if (!self.captureSession) return;
+    if (output == self.frontVideoOutput || output == self.rearVideoOutput) {
+        [self encodeVideo:sampleBuffer output:(AVCaptureVideoDataOutput *)output];
+    } else if (output == self.audioOutput && self.streaming) {
+        [self encodeAudio:sampleBuffer];
+    }
+}
+
+- (void)encodeVideo:(CMSampleBufferRef)sampleBuffer output:(AVCaptureVideoDataOutput *)output {
+    CVImageBufferRef imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
+    if (!imageBuffer) return;
+
+    BOOL isFront = output == self.frontVideoOutput;
+    VTCompressionSessionRef session = isFront ? self.frontCompressionSession : self.rearCompressionSession;
+    if (!session) {
+        CMVideoDimensions dimensions = CMVideoFormatDescriptionGetDimensions(CMSampleBufferGetFormatDescription(sampleBuffer));
+        OSStatus status = VTCompressionSessionCreate(kCFAllocatorDefault, dimensions.width, dimensions.height,
+            kCMVideoCodecType_H264, NULL, NULL, NULL, HAStreamingCompressionOutput,
+            (__bridge void *)self, &session);
+        if (status != noErr || !session) {
+            [self captureError:@"Could not create H.264 encoder."];
+            return;
+        }
+        NSInteger frameRate = [self targetFrameRate];
+        NSNumber *expectedRate = @(frameRate);
+        VTSessionSetProperty(session, kVTCompressionPropertyKey_RealTime, kCFBooleanTrue);
+        VTSessionSetProperty(session, kVTCompressionPropertyKey_ProfileLevel, kVTProfileLevel_H264_Baseline_AutoLevel);
+        VTSessionSetProperty(session, kVTCompressionPropertyKey_AllowFrameReordering, kCFBooleanFalse);
+        VTSessionSetProperty(session, kVTCompressionPropertyKey_ExpectedFrameRate, (__bridge CFTypeRef)expectedRate);
+        VTSessionSetProperty(session, kVTCompressionPropertyKey_AverageBitRate, (__bridge CFTypeRef)@([self targetBitRate]));
+        VTSessionSetProperty(session, kVTCompressionPropertyKey_MaxKeyFrameInterval, (__bridge CFTypeRef)@(MAX(1, frameRate / 2)));
+        VTSessionSetProperty(session, kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration, (__bridge CFTypeRef)@0.5);
+        if (@available(iOS 14.0, *)) {
+            VTSessionSetProperty(session, kVTCompressionPropertyKey_PrioritizeEncodingSpeedOverQuality, kCFBooleanTrue);
+        }
+        VTCompressionSessionPrepareToEncodeFrames(session);
+        if (isFront) self.frontCompressionSession = session;
+        else self.rearCompressionSession = session;
+    }
+
+    BOOL forceKeyFrame = isFront ? self.forceFrontKeyFrame : self.forceRearKeyFrame;
+    if (isFront) self.forceFrontKeyFrame = NO;
+    else self.forceRearKeyFrame = NO;
+    CFDictionaryRef options = forceKeyFrame
+        ? (__bridge CFDictionaryRef)@{(__bridge id)kVTEncodeFrameOptionKey_ForceKeyFrame: @YES}
+        : NULL;
+    OSStatus status = VTCompressionSessionEncodeFrame(session, imageBuffer,
+        CMSampleBufferGetPresentationTimeStamp(sampleBuffer), kCMTimeInvalid, options,
+        (__bridge void *)output, NULL);
+    if (status != noErr) [self captureError:@"H.264 encoder stopped accepting frames."];
+}
+
+- (void)handleCompressedVideoSample:(CMSampleBufferRef)sampleBuffer
+                             status:(OSStatus)status
+                             output:(AVCaptureVideoDataOutput *)output {
+    if (output != self.frontVideoOutput && output != self.rearVideoOutput) return;
+    if (status != noErr || !sampleBuffer || !CMSampleBufferDataIsReady(sampleBuffer)) {
+        [self captureError:@"H.264 encoding failed."];
+        return;
+    }
+
+    CMVideoFormatDescriptionRef format = (CMVideoFormatDescriptionRef)CMSampleBufferGetFormatDescription(sampleBuffer);
+    const uint8_t *sps = NULL, *pps = NULL;
+    size_t spsLength = 0, ppsLength = 0, parameterCount = 0;
+    if (CMVideoFormatDescriptionGetH264ParameterSetAtIndex(format, 0, &sps, &spsLength, &parameterCount, NULL) != noErr ||
+        CMVideoFormatDescriptionGetH264ParameterSetAtIndex(format, 1, &pps, &ppsLength, NULL, NULL) != noErr ||
+        spsLength < 4) {
+        [self captureError:@"H.264 stream configuration is invalid."];
+        return;
+    }
+
+    NSMutableData *configuration = [NSMutableData data];
+    uint8_t header[6] = {1, sps[1], sps[2], sps[3], 0xFF, 0xE1};
+    [configuration appendBytes:header length:sizeof(header)];
+    uint16_t length = CFSwapInt16HostToBig((uint16_t)spsLength);
+    [configuration appendBytes:&length length:sizeof(length)];
+    [configuration appendBytes:sps length:spsLength];
+    uint8_t one = 1;
+    [configuration appendBytes:&one length:1];
+    length = CFSwapInt16HostToBig((uint16_t)ppsLength);
+    [configuration appendBytes:&length length:sizeof(length)];
+    [configuration appendBytes:pps length:ppsLength];
+
+    CMBlockBufferRef block = CMSampleBufferGetDataBuffer(sampleBuffer);
+    size_t contiguousLength = 0, totalLength = 0;
+    char *bytes = NULL;
+    if (CMBlockBufferGetDataPointer(block, 0, &contiguousLength, &totalLength, &bytes) != noErr || !bytes) return;
+    NSData *nalUnits = nil;
+    if (contiguousLength >= totalLength) {
+        nalUnits = [NSData dataWithBytes:bytes length:totalLength];
+    } else {
+        NSMutableData *copy = [NSMutableData dataWithLength:totalLength];
+        if (CMBlockBufferCopyDataBytes(block, 0, totalLength, copy.mutableBytes) != noErr) return;
+        nalUnits = copy;
+    }
+    CFArrayRef attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, false);
+    BOOL keyFrame = !(attachments && CFArrayGetCount(attachments) &&
+                      CFDictionaryContainsKey(CFArrayGetValueAtIndex(attachments, 0), kCMSampleAttachmentKey_NotSync));
+    BOOL isFront = output == self.frontVideoOutput;
+    if (isFront) {
+        self.publishedFrontConfiguration = configuration;
+        if (!self.loggedFrontVideo) { self.loggedFrontVideo = YES; HALogI(@"localstream", @"Encoded first front-camera H.264 frame."); }
+    } else {
+        self.publishedRearConfiguration = configuration;
+        if (!self.loggedRearVideo) { self.loggedRearVideo = YES; HALogI(@"localstream", @"Encoded first rear-camera H.264 frame."); }
+    }
+    uint32_t timestamp = [self timestamp:CMSampleBufferGetPresentationTimeStamp(sampleBuffer)];
+    HARTSPServer *server = [self serverForVideoOutput:output];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (!self.streaming || !server.running) return;
+        [server setVideoConfiguration:configuration];
+        [server sendVideoSample:nalUnits keyFrame:keyFrame timestamp:timestamp];
+    });
+}
+
+- (void)encodeAudio:(CMSampleBufferRef)sampleBuffer {
+    self.audioInputBufferCount++;
+    NSError *encodingError = nil;
+    CMAudioFormatDescriptionRef inputFormat =
+        (CMAudioFormatDescriptionRef)CMSampleBufferGetFormatDescription(sampleBuffer);
+    if (!inputFormat) {
+        [self captureError:@"The microphone audio format is unavailable."];
+        return;
+    }
+    const AudioStreamBasicDescription *description =
+        CMAudioFormatDescriptionGetStreamBasicDescription(inputFormat);
+    if (!description) {
+        [self captureError:@"The microphone audio format is unavailable."];
+        return;
+    }
+    if (!self.loggedAudioInput) {
+        self.loggedAudioInput = YES;
+        HALogI(@"localstream", @"Received first microphone PCM buffer (%ld frames, %lu Hz, %lu channel%@).",
+               (long)CMSampleBufferGetNumSamples(sampleBuffer),
+               (unsigned long)description->mSampleRate,
+               (unsigned long)description->mChannelsPerFrame,
+               description->mChannelsPerFrame == 1 ? @"" : @"s");
+    } else if (self.audioInputBufferCount == 10) {
+        HALogI(@"localstream", @"Microphone PCM delivery is sustained.");
+    }
+    if (!self.audioEncoder) {
+        self.audioEncoder = [[HAAACEncoder alloc] initWithInputFormat:inputFormat
+                                                               error:&encodingError];
+    }
+    if (!self.audioEncoder) {
+        [self captureError:encodingError.localizedDescription ?: @"Could not create AAC encoder."];
+        return;
+    }
+
+    NSData *configuration = self.audioEncoder.audioSpecificConfig;
+    NSUInteger channels = self.audioEncoder.channelCount;
+    NSUInteger sampleRate = (NSUInteger)description->mSampleRate;
+    BOOL configurationChanged =
+        ![self.publishedAudioConfiguration isEqualToData:configuration] ||
+        self.publishedAudioChannels != channels ||
+        self.publishedAudioSampleRate != sampleRate;
+    self.publishedAudioConfiguration = configuration;
+    self.publishedAudioChannels = channels;
+    self.publishedAudioSampleRate = sampleRate;
+    if (configurationChanged) {
+        if (!self.loggedAudioConfiguration) {
+            self.loggedAudioConfiguration = YES;
+            HALogI(@"localstream", @"AAC stream configuration is ready (%lu Hz, %lu channel%@); publishing before the first encoded frame.",
+                   (unsigned long)sampleRate, (unsigned long)channels,
+                   channels == 1 ? @"" : @"s");
+        }
+        NSArray<HARTSPServer *> *servers = [self activeServers];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (!self.streaming) return;
+            for (HARTSPServer *server in servers) {
+                if (!server.running) continue;
+                [server setAudioConfiguration:configuration channels:channels sampleRate:sampleRate];
+            }
+        });
+    }
+
+    NSData *aac = [self.audioEncoder encodeSampleBuffer:sampleBuffer error:&encodingError];
+    if (encodingError) {
+        [self captureError:encodingError.localizedDescription];
+        return;
+    }
+    if (!aac) return;
+    if (!self.loggedEncodedAudio) {
+        self.loggedEncodedAudio = YES;
+        HALogI(@"localstream", @"Encoded first shared AAC frame.");
+    }
+
+    uint32_t timestamp = [self timestamp:CMSampleBufferGetPresentationTimeStamp(sampleBuffer)];
+    NSArray<HARTSPServer *> *servers = [self activeServers];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (!self.streaming) return;
+        for (HARTSPServer *server in servers) {
+            if (!server.running) continue;
+            [server sendAudioSample:aac timestamp:timestamp];
+        }
+    });
+}
+
+- (HARTSPServer *)serverForVideoOutput:(AVCaptureVideoDataOutput *)output {
+    if (self.cameraMode == HAStreamingCameraModeBoth && output == self.rearVideoOutput) {
+        return self.secondaryRTSPServer;
+    }
+    return self.primaryRTSPServer;
+}
+
+- (uint32_t)timestamp:(CMTime)time {
+    @synchronized (self) {
+        if (!CMTIME_IS_VALID(self.mediaStartTime)) self.mediaStartTime = time;
+        Float64 milliseconds = CMTimeGetSeconds(CMTimeSubtract(time, self.mediaStartTime)) * 1000.0;
+        return milliseconds > 0 ? (uint32_t)MIN(milliseconds, UINT32_MAX) : 0;
+    }
+}
+
+#pragma mark - RTSP delegate
+
+- (void)rtspServerDidChangeClientCount:(HARTSPServer *)server {
+    (void)server;
+    if (self.streamClientCount == 0) [self stopCaptureKeepListeners];
+    [self post:nil];
+}
+
+- (void)rtspServerNeedsVideoKeyFrame:(HARTSPServer *)server {
+    dispatch_async(self.captureQueue, ^{
+        if (server == self.secondaryRTSPServer) self.forceRearKeyFrame = YES;
+        else if (self.cameraMode == HAStreamingCameraModeRear) self.forceRearKeyFrame = YES;
+        else self.forceFrontKeyFrame = YES;
+    });
+}
+
+- (void)rtspServerNeedsMediaConfiguration:(HARTSPServer *)server {
+    if (server != self.primaryRTSPServer && server != self.secondaryRTSPServer) return;
+    if (self.captureSession || self.configuringCapture) return;
+    HALogI(@"localstream", @"RTSP client requested %@ media; starting capture.",
+           server == self.secondaryRTSPServer ? @"rear-camera" : @"primary-camera");
+    [self configureCaptureWithCompletion:^(BOOL success, NSError *error) {
+        if (!success) [self stopWithTrigger:HAStreamingStopTriggerCaptureInterrupted error:error];
+    }];
+}
+
+- (void)rtspServer:(HARTSPServer *)server didFailWithError:(NSError *)error {
+    if (server == self.primaryRTSPServer || server == self.secondaryRTSPServer) {
+        [self stopWithTrigger:HAStreamingStopTriggerServerFailure error:error];
+    }
+}
+
+#pragma mark - Stop and lifecycle
+
+- (void)restartCapturePreservingClients {
+    AVCaptureSession *session = self.captureSession;
+    if (!session || !self.streaming || self.streamClientCount == 0) return;
+
+    HALogI(@"localstream", @"Applying %@ without closing RTSP clients.", self.qualityDescription);
+    self.captureSession = nil;
+    self.configuringCapture = YES;
+    self.capturing = NO;
+    self.frontVideoOutput = nil;
+    self.rearVideoOutput = nil;
+    self.audioOutput = nil;
+    self.publishedFrontConfiguration = nil;
+    self.publishedRearConfiguration = nil;
+    [self clearAudioMediaStateSynchronously];
+    self.forceFrontKeyFrame = YES;
+    self.forceRearKeyFrame = YES;
+
+    VTCompressionSessionRef front = self.frontCompressionSession;
+    VTCompressionSessionRef rear = self.rearCompressionSession;
+    self.frontCompressionSession = NULL;
+    self.rearCompressionSession = NULL;
+    dispatch_async(self.captureQueue, ^{
+        [self invalidateCompressionSession:front];
+        [self invalidateCompressionSession:rear];
+        [session stopRunning];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            self.configuringCapture = NO;
+            if (!self.streaming || self.streamClientCount == 0) return;
+            [self configureCaptureWithCompletion:^(BOOL success, NSError *error) {
+                if (!success) [self stopWithTrigger:HAStreamingStopTriggerCaptureInterrupted error:error];
+            }];
+        });
+    });
+}
+
+- (void)stopCaptureKeepListeners {
+    if (!self.captureSession && !self.configuringCapture) return;
+    HALogI(@"localstream", @"Last RTSP client left; stopping all camera and microphone capture.");
+    AVCaptureSession *session = self.captureSession;
+    self.captureSession = nil;
+    self.configuringCapture = NO;
+    self.frontVideoOutput = nil;
+    self.rearVideoOutput = nil;
+    self.audioOutput = nil;
+    self.capturing = NO;
+    [self clearMediaState];
+    [self.primaryRTSPServer clearMediaConfiguration];
+    [self.secondaryRTSPServer clearMediaConfiguration];
+
+    VTCompressionSessionRef front = self.frontCompressionSession;
+    VTCompressionSessionRef rear = self.rearCompressionSession;
+    self.frontCompressionSession = NULL;
+    self.rearCompressionSession = NULL;
+    dispatch_async(self.captureQueue, ^{
+        [self invalidateCompressionSession:front];
+        [self invalidateCompressionSession:rear];
+        [session stopRunning];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[AVAudioSession sharedInstance] setActive:NO
+                                           withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
+                                                 error:nil];
+        });
+    });
+}
+
+- (void)stopWithTrigger:(HAStreamingStopTrigger)trigger error:(NSError *)error {
+    (void)trigger;
+    HARTSPServer *primary = self.primaryRTSPServer;
+    HARTSPServer *secondary = self.secondaryRTSPServer;
+    self.primaryRTSPServer = nil;
+    self.secondaryRTSPServer = nil;
+    [primary stop];
+    [secondary stop];
+    BOOL wasActive = self.streaming || self.captureSession || self.configuringCapture;
+    self.streaming = NO;
+    [self stopCaptureKeepListeners];
+    if (wasActive || error) [self post:error];
+}
+
+- (void)clearMediaState {
+    [self clearAudioMediaStateSynchronously];
+    self.publishedFrontConfiguration = nil;
+    self.publishedRearConfiguration = nil;
+    self.mediaStartTime = kCMTimeInvalid;
+    self.forceFrontKeyFrame = NO;
+    self.forceRearKeyFrame = NO;
+}
+
+- (void)clearAudioMediaStateSynchronously {
+    // Audio callbacks run independently of the video/capture queue on old
+    // devices. Once captureSession/audioOutput are cleared, drain every callback
+    // that already passed the delegate guard before resetting shared AAC state.
+    // This prevents a late callback from repopulating configuration after stop
+    // and causing the next listener to miss setAudioConfiguration:.
+    dispatch_block_t clear = ^{
+        self.audioEncoder = nil;
+        self.audioInputBufferCount = 0;
+        self.publishedAudioConfiguration = nil;
+        self.publishedAudioChannels = 0;
+        self.publishedAudioSampleRate = 0;
+    };
+    if (dispatch_get_specific(&HAStreamingAudioCaptureQueueKey)) clear();
+    else dispatch_sync(self.audioCaptureQueue, clear);
+}
+
+- (void)invalidateCompressionSession:(VTCompressionSessionRef)session {
+    if (!session) return;
+    VTCompressionSessionCompleteFrames(session, kCMTimeInvalid);
+    VTCompressionSessionInvalidate(session);
+    CFRelease(session);
+}
+
+- (NSArray<HARTSPServer *> *)activeServers {
+    NSMutableArray<HARTSPServer *> *servers = [NSMutableArray array];
+    if (self.primaryRTSPServer) [servers addObject:self.primaryRTSPServer];
+    if (self.secondaryRTSPServer) [servers addObject:self.secondaryRTSPServer];
+    return servers;
+}
+
++ (BOOL)shouldStopForTrigger:(HAStreamingStopTrigger)trigger {
+    return trigger >= HAStreamingStopTriggerUser && trigger <= HAStreamingStopTriggerCaptureInterrupted;
+}
+
+- (void)resign:(NSNotification *)notification { (void)notification; [self stopWithTrigger:HAStreamingStopTriggerAppWillResignActive error:nil]; }
+- (void)background:(NSNotification *)notification { (void)notification; [self stopWithTrigger:HAStreamingStopTriggerAppDidEnterBackground error:nil]; }
+- (void)active:(NSNotification *)notification {
+    (void)notification;
+    if ((self.isCapturing || self.streaming) && ![self authorized]) {
+        [self stopWithTrigger:HAStreamingStopTriggerPermissionLost error:[self error:@"Camera or microphone permission was removed."]];
+    }
+}
+- (void)auth:(NSNotification *)notification {
+    (void)notification;
+    HAAuthManager *auth = [HAAuthManager sharedManager];
+    BOOL identityChanged = auth.authenticationRevision != self.observedAuthenticationRevision ||
+                           auth.isDemoMode != self.observedDemoMode;
+    self.observedAuthenticationRevision = auth.authenticationRevision;
+    self.observedDemoMode = auth.isDemoMode;
+    if (!auth.isConfigured) {
+        [[HACameraRegistrationManager sharedManager] cancelRegistration];
+        [self stopWithTrigger:HAStreamingStopTriggerLogout error:nil];
+        return;
+    }
+    if (auth.isDemoMode) {
+        [[HACameraRegistrationManager sharedManager] cancelRegistration];
+        return;
+    }
+    if (!identityChanged) return;
+
+    [[HACameraRegistrationManager sharedManager] cancelRegistration];
+    if (!self.streaming || ![HADeviceIntegrationManager sharedManager].enabled) return;
+
+    NSError *credentialError = nil;
+    HARTSPCredentials *credentials = [[HARTSPCredentialManager sharedManager]
+        credentialsWithError:&credentialError];
+    if (!credentials) {
+        HALogW(@"localstream", @"Camera registration did not restart after the Home Assistant account changed: %@",
+               credentialError.localizedDescription);
+        return;
+    }
+    [[HACameraRegistrationManager sharedManager]
+        ensureCameraEntriesForStreamURLs:self.streamURLs
+        deviceName:[HADeviceRegistration sharedManager].deviceName
+        username:credentials.username
+        password:credentials.password
+        credentialRevision:credentials.revision
+        framesPerSecond:self.targetFrameRate
+        completion:^(BOOL success, NSError *error) {
+            if (!success) {
+                HALogW(@"localstream", @"Camera registration after the Home Assistant account changed was skipped: %@",
+                       error.localizedDescription);
+            }
+        }];
+}
+- (void)interrupted:(NSNotification *)notification {
+    if (notification.object == self.captureSession) {
+        [self stopWithTrigger:HAStreamingStopTriggerCaptureInterrupted error:[self error:@"Camera or microphone capture was interrupted."]];
+    }
+}
+- (BOOL)authorized {
+    return [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo] == AVAuthorizationStatusAuthorized &&
+           [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio] == AVAuthorizationStatusAuthorized;
+}
+
+- (AVCaptureVideoOrientation)currentVideoOrientation {
+    UIInterfaceOrientation interfaceOrientation = UIInterfaceOrientationUnknown;
+    if (@available(iOS 13.0, *)) {
+        for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+            if (![scene isKindOfClass:[UIWindowScene class]]) continue;
+            if (scene.activationState != UISceneActivationStateForegroundActive) continue;
+            interfaceOrientation = ((UIWindowScene *)scene).interfaceOrientation;
+            break;
+        }
+    }
+    if (interfaceOrientation == UIInterfaceOrientationUnknown) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        interfaceOrientation = [UIApplication sharedApplication].statusBarOrientation;
+#pragma clang diagnostic pop
+    }
+    switch (interfaceOrientation) {
+        case UIInterfaceOrientationPortrait: return AVCaptureVideoOrientationPortrait;
+        case UIInterfaceOrientationPortraitUpsideDown: return AVCaptureVideoOrientationPortraitUpsideDown;
+        case UIInterfaceOrientationLandscapeLeft: return AVCaptureVideoOrientationLandscapeLeft;
+        case UIInterfaceOrientationLandscapeRight: return AVCaptureVideoOrientationLandscapeRight;
+        default: return self.captureOrientation ?: AVCaptureVideoOrientationPortrait;
+    }
+}
+
+- (void)applyVideoOrientationToOutputs {
+    self.captureOrientation = [self currentVideoOrientation];
+    NSArray<AVCaptureVideoDataOutput *> *outputs = @[
+        self.frontVideoOutput ?: (id)[NSNull null],
+        self.rearVideoOutput ?: (id)[NSNull null],
+    ];
+    for (id candidate in outputs) {
+        if (candidate == [NSNull null]) continue;
+        AVCaptureConnection *connection = [(AVCaptureVideoDataOutput *)candidate connectionWithMediaType:AVMediaTypeVideo];
+        if (connection.isVideoOrientationSupported) connection.videoOrientation = self.captureOrientation;
+    }
+}
+
+- (void)orientationChanged:(NSNotification *)notification {
+    (void)notification;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSUInteger generation = ++self.orientationChangeGeneration;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            if (generation != self.orientationChangeGeneration) return;
+            AVCaptureVideoOrientation orientation = [self currentVideoOrientation];
+            if (orientation == self.captureOrientation) return;
+            self.captureOrientation = orientation;
+            if (self.isCapturing && self.streamClientCount > 0) {
+                [self restartCapturePreservingClients];
+            } else {
+                [self applyVideoOrientationToOutputs];
+            }
+        });
+    });
+}
+
+#pragma mark - Network address
+
+- (NSString *)localIPv4 {
+    struct ifaddrs *list = NULL;
+    if (getifaddrs(&list) != 0) return nil;
+    NSString *wifiAddress = nil;
+    for (struct ifaddrs *interface = list; interface; interface = interface->ifa_next) {
+        if (!interface->ifa_addr || interface->ifa_addr->sa_family != AF_INET) continue;
+        if ((interface->ifa_flags & IFF_LOOPBACK) || !(interface->ifa_flags & IFF_UP)) continue;
+        struct sockaddr_in *socketAddress = (struct sockaddr_in *)interface->ifa_addr;
+        uint32_t address = ntohl(socketAddress->sin_addr.s_addr);
+        if (address == INADDR_ANY || (address & 0xFFFF0000) == 0xA9FE0000) continue;
+        char host[INET_ADDRSTRLEN];
+        if (!inet_ntop(AF_INET, &socketAddress->sin_addr, host, sizeof(host))) continue;
+        NSString *value = [NSString stringWithUTF8String:host];
+        NSString *name = interface->ifa_name ? [NSString stringWithUTF8String:interface->ifa_name] : @"";
+        BOOL isPrivate = (address & 0xFF000000) == 0x0A000000 ||
+                         (address & 0xFFF00000) == 0xAC100000 ||
+                         (address & 0xFFFF0000) == 0xC0A80000;
+        if ([name isEqualToString:@"en0"] && isPrivate) { wifiAddress = value; break; }
+    }
+    freeifaddrs(list);
+    // Do not fall back to cellular, VPN, CoreDevice, USB, or other host-side
+    // adapters. The user can act on the displayed URL only when en0 is local.
+    NSString *selected = wifiAddress;
+    if (selected.length) HALogI(@"localstream", @"Selected LAN address %@ for the RTSP listener.", selected);
+    return selected;
+}
+
+#pragma mark - Errors and notifications
+
+- (void)captureError:(NSString *)description {
+    HALogE(@"localstream", @"%@", description);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self stopWithTrigger:HAStreamingStopTriggerCaptureInterrupted error:[self error:description]];
+    });
+}
+
+- (NSError *)error:(NSString *)description {
+    return [NSError errorWithDomain:HAStreamingManagerErrorDomain code:1
+                           userInfo:@{NSLocalizedDescriptionKey: description}];
+}
+
+- (void)finish:(void (^)(BOOL, NSError *))completion ok:(BOOL)ok error:(NSError *)error {
+    if (completion) completion(ok, error);
+}
+
+- (void)post:(NSError *)error {
+    NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
+    if (error) userInfo[HAStreamingManagerErrorKey] = error;
+    [[NSNotificationCenter defaultCenter] postNotificationName:HAStreamingManagerStateDidChangeNotification
+                                                        object:self userInfo:userInfo];
+}
+
+@end

--- a/HADashboard/Views/Cells/HACameraEntityCell.m
+++ b/HADashboard/Views/Cells/HACameraEntityCell.m
@@ -887,8 +887,7 @@ static HACameraStreamMode currentStreamMode(void) {
         return;
     }
 
-    HALogD(@"cam", @"fetchSnapshot: %@ token=%@...", url,
-          [auth.accessToken substringToIndex:MIN(10, auth.accessToken.length)]);
+    HALogD(@"cam", @"fetchSnapshot: %@ (authorization header redacted)", url);
 
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     [request setValue:[NSString stringWithFormat:@"Bearer %@", auth.accessToken] forHTTPHeaderField:@"Authorization"];

--- a/HADashboard/Views/Cells/HALogbookCardCell.m
+++ b/HADashboard/Views/Cells/HALogbookCardCell.m
@@ -48,7 +48,11 @@ static const NSInteger kMaxEntries = 10;
         self.emptyLabel.hidden = YES;
         [self.contentView addSubview:self.emptyLabel];
 
-        self.spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
+        UIActivityIndicatorViewStyle spinnerStyle = UIActivityIndicatorViewStyleGray;
+        if (@available(iOS 13.0, *)) {
+            spinnerStyle = UIActivityIndicatorViewStyleMedium;
+        }
+        self.spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:spinnerStyle];
         self.spinner.translatesAutoresizingMaskIntoConstraints = NO;
         self.spinner.hidesWhenStopped = YES;
         [self.contentView addSubview:self.spinner];

--- a/HADashboard/Views/HAGraphView.m
+++ b/HADashboard/Views/HAGraphView.m
@@ -516,13 +516,20 @@ static NSDateFormatter *sCachedTimeFmt(void) {
             segLayer.frame = CGRectMake(barAreaX + segX, y, segW, barHeight);
             segLayer.backgroundColor = color.CGColor;
             // Round corners only on first/last segments
-            if (segX <= 0.5) {
+            BOOL roundLeading = segX <= 0.5;
+            BOOL roundTrailing = segEndX >= barAreaW - 0.5;
+            if (roundLeading || roundTrailing) {
                 segLayer.cornerRadius = 3.0;
-                segLayer.maskedCorners = kCALayerMinXMinYCorner | kCALayerMinXMaxYCorner;
-            }
-            if (segEndX >= barAreaW - 0.5) {
-                segLayer.cornerRadius = 3.0;
-                segLayer.maskedCorners |= kCALayerMaxXMinYCorner | kCALayerMaxXMaxYCorner;
+                if (@available(iOS 11.0, *)) {
+                    CACornerMask corners = 0;
+                    if (roundLeading) {
+                        corners |= kCALayerMinXMinYCorner | kCALayerMinXMaxYCorner;
+                    }
+                    if (roundTrailing) {
+                        corners |= kCALayerMaxXMinYCorner | kCALayerMaxXMaxYCorner;
+                    }
+                    segLayer.maskedCorners = corners;
+                }
             }
             segLayer.masksToBounds = YES;
             [self.layer addSublayer:segLayer];

--- a/HADashboardTests/HADeviceIntegrationTests.m
+++ b/HADashboardTests/HADeviceIntegrationTests.m
@@ -3,6 +3,7 @@
 #import "HASensorReporter.h"
 #import "HARemoteCommandHandler.h"
 #import "HADeviceIntegrationManager.h"
+#import "HAConnectionManager.h"
 #import "HANotificationPresenter.h"
 #import "HATheme.h"
 #import "HAAuthManager.h"
@@ -15,6 +16,7 @@
 
 @interface HADeviceRegistration (TestAccess)
 - (NSDictionary *)registrationBody;
+- (NSDictionary *)registrationUpdateBody;
 @end
 
 @implementation HADeviceRegistrationTests
@@ -34,6 +36,20 @@
 - (void)testRegistrationExplicitlyAdvertisesWebSocketPush {
     NSDictionary *appData = [[HADeviceRegistration sharedManager] registrationBody][@"app_data"];
     XCTAssertEqualObjects(appData[@"push_websocket_channel"], @YES);
+    XCTAssertNil(appData[@"push_url"]);
+    XCTAssertNil(appData[@"push_token"]);
+    XCTAssertEqual(appData.count, (NSUInteger)1);
+}
+
+- (void)testRegistrationMetadataUpdateIsCompleteAndWebSocketOnly {
+    NSDictionary *body = [[HADeviceRegistration sharedManager] registrationUpdateBody];
+    XCTAssertTrue([body[@"app_version"] length] > 0);
+    XCTAssertTrue([body[@"device_name"] length] > 0);
+    XCTAssertEqualObjects(body[@"manufacturer"], @"Apple");
+    XCTAssertTrue([body[@"model"] length] > 0);
+    XCTAssertTrue([body[@"os_version"] length] > 0);
+    NSDictionary *appData = body[@"app_data"];
+    XCTAssertEqualObjects(appData, (@{@"push_websocket_channel": @YES}));
 }
 
 - (void)testIsRegisteredReturnsFalseBeforeRegistration {
@@ -313,6 +329,10 @@
 - (void)handleNotificationEvent:(NSDictionary *)eventData;
 @end
 
+@interface HAConnectionManager (SubscriptionTestAccess)
+- (void)webSocketClient:(id)client didReceiveMessage:(NSDictionary *)message;
+@end
+
 @interface HARemoteCommandHandlerTests : XCTestCase
 @property (nonatomic, strong) HARemoteCommandHandler *handler;
 @end
@@ -336,7 +356,30 @@
     XCTAssertNoThrow([self.handler dispatchCommand:@"set_brightness" data:@{@"level": @50}]);
     XCTAssertNoThrow([self.handler dispatchCommand:@"set_brightness" data:@{@"brightness": @128}]);
     XCTAssertNoThrow([self.handler dispatchCommand:@"command_screen_brightness_level"
-                                              data:@{@"command_screen_brightness_level": @255}]);
+                                              data:@{@"command": @255}]);
+}
+
+- (void)testCompanionBrightnessUsesOfficialCommandFieldAndByteScale {
+    HAAuthManager *auth = [HAAuthManager sharedManager];
+    BOOL oldKiosk = auth.isKioskMode;
+    BOOL oldWake = auth.proximityWakeEnabled;
+    [auth setKioskMode:YES];
+    [auth setProximityWakeEnabled:YES];
+
+    XCTestExpectation *exp = [self expectationWithDescription:@"companion brightness request"];
+    id observer = [[NSNotificationCenter defaultCenter]
+        addObserverForName:HAProximityWakeSetBrightnessNotification object:nil queue:nil
+                usingBlock:^(NSNotification *note) {
+        XCTAssertEqualWithAccuracy([note.userInfo[@"brightness"] doubleValue],
+                                   128.0 / 255.0, 0.001);
+        [exp fulfill];
+    }];
+    [self.handler dispatchCommand:@"command_screen_brightness_level"
+                             data:@{@"command": @128}];
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:observer];
+    [auth setProximityWakeEnabled:oldWake];
+    [auth setKioskMode:oldKiosk];
 }
 
 - (void)testBrightnessCommandPostsGenericNotification {
@@ -449,6 +492,51 @@
     [[NSNotificationCenter defaultCenter] removeObserver:observer];
 }
 
+- (void)testCommandNavigateAliasPostsNotification {
+    XCTestExpectation *exp = [self expectationWithDescription:@"navigate alias notification"];
+    id observer = [[NSNotificationCenter defaultCenter]
+        addObserverForName:@"HAActionNavigateNotification" object:nil queue:nil
+                usingBlock:^(NSNotification *note) {
+        XCTAssertEqualObjects(note.userInfo[@"path"], @"security");
+        [exp fulfill];
+    }];
+
+    [self.handler dispatchCommand:@"command_navigate" data:@{@"path": @"security"}];
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:observer];
+}
+
+- (void)testSwitchDashboardPersistsSelection {
+    HAAuthManager *auth = [HAAuthManager sharedManager];
+    NSString *before = auth.selectedDashboardPath;
+    [self.handler dispatchCommand:@"switch_dashboard"
+                             data:@{@"dashboard": @"release-test-dashboard"}];
+    XCTAssertEqualObjects(auth.selectedDashboardPath, @"release-test-dashboard");
+    [auth saveSelectedDashboardPath:before ?: @""];
+}
+
+- (void)testGradientPresetCommand {
+    BOOL oldEnabled = [HATheme isGradientEnabled];
+    HAGradientPreset oldPreset = [HATheme gradientPreset];
+    [self.handler dispatchCommand:@"set_gradient" data:@{@"preset": @"ocean_blue"}];
+    XCTAssertTrue([HATheme isGradientEnabled]);
+    XCTAssertEqual([HATheme gradientPreset], HAGradientPresetOceanBlue);
+    [HATheme setGradientPreset:oldPreset];
+    [HATheme setGradientEnabled:oldEnabled];
+}
+
+- (void)testReloadCommandPostsReloadNotification {
+    XCTestExpectation *exp = [self expectationWithDescription:@"reload notification"];
+    id observer = [[NSNotificationCenter defaultCenter]
+        addObserverForName:HARemoteCommandReloadNotification object:nil queue:nil
+                usingBlock:^(NSNotification *note) {
+        [exp fulfill];
+    }];
+    [self.handler dispatchCommand:@"reload" data:@{}];
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:observer];
+}
+
 - (void)testUnknownCommandDoesNotCrash {
     XCTAssertNoThrow([self.handler dispatchCommand:@"totally_unknown_command" data:@{@"foo": @"bar"}],
                      @"Unknown command should log but not crash");
@@ -491,6 +579,29 @@
 
     [self waitForExpectationsWithTimeout:2 handler:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:observer];
+}
+
+- (void)testMobilePushSubscriptionPreservesMessageAndConfirmationFields {
+    HAConnectionManager *manager = [[HAConnectionManager alloc] init];
+    NSMutableDictionary *handlers = [manager valueForKey:@"eventHandlers"];
+    XCTestExpectation *exp = [self expectationWithDescription:@"raw push event"];
+    handlers[@42] = ^(NSDictionary *event) {
+        XCTAssertEqualObjects(event[@"message"], @"command_screen_on");
+        XCTAssertEqualObjects(event[@"hass_confirm_id"], @"confirm-42");
+        XCTAssertEqualObjects(event[@"data"], @{});
+        [exp fulfill];
+    };
+
+    [manager webSocketClient:nil didReceiveMessage:@{
+        @"id": @42,
+        @"type": @"event",
+        @"event": @{
+            @"message": @"command_screen_on",
+            @"data": @{},
+            @"hass_confirm_id": @"confirm-42",
+        },
+    }];
+    [self waitForExpectationsWithTimeout:2 handler:nil];
 }
 
 - (void)testHandleNotificationEventHADictStyle {

--- a/HADashboardTests/HARTSPCredentialManagerTests.m
+++ b/HADashboardTests/HARTSPCredentialManagerTests.m
@@ -1,0 +1,195 @@
+#import <XCTest/XCTest.h>
+#import <Security/Security.h>
+
+#import "HARTSPCredentialManager.h"
+
+@interface HARTSPCredentialManagerTests : XCTestCase
+
+@property (nonatomic, copy) NSString *serviceIdentifier;
+@property (nonatomic, strong) HARTSPCredentialManager *manager;
+
+@end
+
+@implementation HARTSPCredentialManagerTests
+
+- (void)setUp {
+    [super setUp];
+    self.serviceIdentifier = [@"com.hadashboard.app.tests.rtsp-credentials."
+                              stringByAppendingString:[NSUUID UUID].UUIDString];
+    self.manager = [[HARTSPCredentialManager alloc]
+                    initWithServiceIdentifier:self.serviceIdentifier];
+
+    NSDictionary *probe = @{
+        (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrService: self.serviceIdentifier,
+        (__bridge id)kSecAttrAccount: @"entitlement-probe",
+        (__bridge id)kSecValueData: [@"probe" dataUsingEncoding:NSUTF8StringEncoding],
+        (__bridge id)kSecAttrAccessible:
+            (__bridge id)kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+    };
+    OSStatus probeStatus = SecItemAdd((__bridge CFDictionaryRef)probe, NULL);
+    if (probeStatus == errSecSuccess) {
+        SecItemDelete((__bridge CFDictionaryRef)probe);
+    }
+    XCTSkipIf(probeStatus == errSecMissingEntitlement,
+              @"The unsigned CI Catalyst host has no Keychain access group; signed local/device runs execute this suite.");
+    XCTAssertEqual(probeStatus, errSecSuccess);
+}
+
+- (void)tearDown {
+    [self.manager deleteCredentialsWithError:nil];
+    self.manager = nil;
+    self.serviceIdentifier = nil;
+    [super tearDown];
+}
+
+- (void)testGeneratedCredentialHasExpectedEntropyAndPersists {
+    NSError *error = nil;
+    HARTSPCredentials *first = [self.manager credentialsWithError:&error];
+    XCTAssertNotNil(first);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(first.username, @"hadashboard");
+    XCTAssertEqual([self decodedByteCountForURLSafeToken:first.password], (NSUInteger)24);
+    XCTAssertEqual(first.password.length, (NSUInteger)32);
+    XCTAssertEqual([self decodedByteCountForURLSafeToken:first.revision], (NSUInteger)16);
+
+    HARTSPCredentialManager *secondManager = [[HARTSPCredentialManager alloc]
+                                              initWithServiceIdentifier:self.serviceIdentifier];
+    HARTSPCredentials *second = [secondManager credentialsWithError:&error];
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(second.password, first.password);
+    XCTAssertEqualObjects(second.revision, first.revision);
+    XCTAssertFalse([[first description] containsString:first.password]);
+    XCTAssertFalse([[first debugDescription] containsString:first.password]);
+}
+
+- (void)testCredentialUsesDeviceOnlyWhenUnlockedAccessibility {
+    NSError *error = nil;
+    XCTAssertNotNil([self.manager credentialsWithError:&error]);
+    XCTAssertNil(error);
+
+    NSDictionary *query = @{
+        (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrService: self.serviceIdentifier,
+        (__bridge id)kSecAttrAccount: HARTSPCredentialUsername,
+        (__bridge id)kSecReturnAttributes: @YES,
+        (__bridge id)kSecMatchLimit: (__bridge id)kSecMatchLimitOne,
+    };
+    CFTypeRef rawResult = NULL;
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &rawResult);
+    XCTAssertEqual(status, errSecSuccess);
+
+    NSDictionary *attributes = CFBridgingRelease(rawResult);
+    XCTAssertEqualObjects(attributes[(__bridge id)kSecAttrAccessible],
+                          (__bridge id)kSecAttrAccessibleWhenUnlockedThisDeviceOnly);
+}
+
+- (void)testRotationChangesPasswordAndNonSecretRevision {
+    NSError *error = nil;
+    HARTSPCredentials *before = [self.manager credentialsWithError:&error];
+    HARTSPCredentials *after = [self.manager rotateCredentialsWithError:&error];
+    XCTAssertNil(error);
+    XCTAssertNotEqualObjects(after.password, before.password);
+    XCTAssertNotEqualObjects(after.revision, before.revision);
+    XCTAssertEqualObjects(after.username, before.username);
+
+    HARTSPCredentials *stored = [self.manager credentialsWithError:&error];
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(stored.password, after.password);
+    XCTAssertEqualObjects(stored.revision, after.revision);
+}
+
+- (void)testDeleteIsIdempotentAndNextAccessGeneratesFreshValues {
+    NSError *error = nil;
+    HARTSPCredentials *before = [self.manager credentialsWithError:&error];
+    XCTAssertTrue([self.manager deleteCredentialsWithError:&error]);
+    XCTAssertNil(error);
+    XCTAssertTrue([self.manager deleteCredentialsWithError:&error]);
+    XCTAssertNil(error);
+
+    HARTSPCredentials *after = [self.manager credentialsWithError:&error];
+    XCTAssertNil(error);
+    XCTAssertNotEqualObjects(after.password, before.password);
+    XCTAssertNotEqualObjects(after.revision, before.revision);
+}
+
+- (void)testMalformedStoredCredentialIsAtomicallyReplaced {
+    [self.manager deleteCredentialsWithError:nil];
+    NSDictionary *item = @{
+        (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrService: self.serviceIdentifier,
+        (__bridge id)kSecAttrAccount: HARTSPCredentialUsername,
+        (__bridge id)kSecValueData: [@"invalid" dataUsingEncoding:NSUTF8StringEncoding],
+        (__bridge id)kSecAttrGeneric: [@"invalid" dataUsingEncoding:NSUTF8StringEncoding],
+        (__bridge id)kSecAttrAccessible:
+            (__bridge id)kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+    };
+    XCTAssertEqual(SecItemAdd((__bridge CFDictionaryRef)item, NULL), errSecSuccess);
+
+    NSError *error = nil;
+    HARTSPCredentials *repaired = [self.manager credentialsWithError:&error];
+    XCTAssertNotNil(repaired);
+    XCTAssertNil(error);
+    XCTAssertEqual([self decodedByteCountForURLSafeToken:repaired.password], (NSUInteger)24);
+    XCTAssertEqual([self decodedByteCountForURLSafeToken:repaired.revision], (NSUInteger)16);
+
+    HARTSPCredentials *reread = [self.manager credentialsWithError:&error];
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(reread.password, repaired.password);
+    XCTAssertEqualObjects(reread.revision, repaired.revision);
+}
+
+- (void)testMissingRevisionMigrationPreservesPassword {
+    NSError *error = nil;
+    HARTSPCredentials *before = [self.manager credentialsWithError:&error];
+    XCTAssertNotNil(before);
+    XCTAssertNil(error);
+
+    NSDictionary *query = @{
+        (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrService: self.serviceIdentifier,
+        (__bridge id)kSecAttrAccount: HARTSPCredentialUsername,
+    };
+    NSDictionary *emptyRevision = @{
+        (__bridge id)kSecAttrGeneric: [NSData data],
+    };
+    XCTAssertEqual(SecItemUpdate((__bridge CFDictionaryRef)query,
+                                 (__bridge CFDictionaryRef)emptyRevision), errSecSuccess);
+
+    HARTSPCredentials *migrated = [self.manager credentialsWithError:&error];
+    XCTAssertNotNil(migrated);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(migrated.password, before.password);
+    XCTAssertEqual([self decodedByteCountForURLSafeToken:migrated.revision], (NSUInteger)16);
+}
+
+- (void)testRotationCreatesCredentialWhenNoneExists {
+    XCTAssertTrue([self.manager deleteCredentialsWithError:nil]);
+    NSError *error = nil;
+    HARTSPCredentials *rotated = [self.manager rotateCredentialsWithError:&error];
+    XCTAssertNotNil(rotated);
+    XCTAssertNil(error);
+
+    HARTSPCredentials *stored = [self.manager credentialsWithError:&error];
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(stored.password, rotated.password);
+    XCTAssertEqualObjects(stored.revision, rotated.revision);
+}
+
+- (NSUInteger)decodedByteCountForURLSafeToken:(NSString *)token {
+    NSCharacterSet *invalidCharacters =
+        [[NSCharacterSet characterSetWithCharactersInString:
+          @"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"] invertedSet];
+    XCTAssertEqual([token rangeOfCharacterFromSet:invalidCharacters].location, NSNotFound);
+
+    NSString *base64 = [token stringByReplacingOccurrencesOfString:@"-" withString:@"+"];
+    base64 = [base64 stringByReplacingOccurrencesOfString:@"_" withString:@"/"];
+    while (base64.length % 4 != 0) {
+        base64 = [base64 stringByAppendingString:@"="];
+    }
+    NSData *decoded = [[NSData alloc] initWithBase64EncodedString:base64 options:0];
+    XCTAssertNotNil(decoded);
+    return decoded.length;
+}
+
+@end

--- a/HADashboardTests/HAStreamingTests.m
+++ b/HADashboardTests/HAStreamingTests.m
@@ -1,0 +1,1892 @@
+#import <XCTest/XCTest.h>
+#import <AVFoundation/AVFoundation.h>
+#import <AudioToolbox/AudioToolbox.h>
+#import <CommonCrypto/CommonDigest.h>
+#import <CoreMedia/CoreMedia.h>
+#import <arpa/inet.h>
+#import <errno.h>
+#import <netinet/in.h>
+#import <sys/socket.h>
+#import <unistd.h>
+#import "HAStreamingManager.h"
+#import "HAAACEncoder.h"
+#import "HARTSPServer.h"
+#import "HAAPIClient.h"
+#import "HACameraRegistrationManager.h"
+#import "HAURLSessionRedirectGuard.h"
+
+static const NSTimeInterval HARTSPTestSocketTimeout = 3.0;
+
+static CMSampleBufferRef HAStreamingCreateMonoPCMBuffer(UInt32 frameCount) {
+    AudioStreamBasicDescription format = {0};
+    format.mSampleRate = 48000;
+    format.mFormatID = kAudioFormatLinearPCM;
+    format.mFormatFlags = kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked;
+    format.mBytesPerPacket = sizeof(int16_t);
+    format.mFramesPerPacket = 1;
+    format.mBytesPerFrame = sizeof(int16_t);
+    format.mChannelsPerFrame = 1;
+    format.mBitsPerChannel = 16;
+
+    CMAudioFormatDescriptionRef formatDescription = NULL;
+    if (CMAudioFormatDescriptionCreate(kCFAllocatorDefault, &format, 0, NULL, 0, NULL, NULL,
+                                       &formatDescription) != noErr) return NULL;
+
+    size_t byteCount = (size_t)frameCount * format.mBytesPerFrame;
+    CMBlockBufferRef blockBuffer = NULL;
+    OSStatus status = CMBlockBufferCreateWithMemoryBlock(kCFAllocatorDefault, NULL, byteCount,
+        kCFAllocatorDefault, NULL, 0, byteCount, 0, &blockBuffer);
+    if (status == noErr) status = CMBlockBufferFillDataBytes(0, blockBuffer, 0, byteCount);
+
+    CMSampleBufferRef sampleBuffer = NULL;
+    if (status == noErr) {
+        status = CMAudioSampleBufferCreateReadyWithPacketDescriptions(kCFAllocatorDefault,
+            blockBuffer, formatDescription, frameCount, CMTimeMake(0, 48000), NULL, &sampleBuffer);
+    }
+    if (blockBuffer) CFRelease(blockBuffer);
+    CFRelease(formatDescription);
+    return status == noErr ? sampleBuffer : NULL;
+}
+
+static uint16_t HARTSPAvailableLoopbackPort(void) {
+    int socketDescriptor = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (socketDescriptor < 0) return 0;
+
+    struct sockaddr_in address;
+    memset(&address, 0, sizeof(address));
+    address.sin_len = sizeof(address);
+    address.sin_family = AF_INET;
+    address.sin_port = 0;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (bind(socketDescriptor, (struct sockaddr *)&address, sizeof(address)) != 0) {
+        close(socketDescriptor);
+        return 0;
+    }
+
+    socklen_t addressLength = sizeof(address);
+    if (getsockname(socketDescriptor, (struct sockaddr *)&address, &addressLength) != 0) {
+        close(socketDescriptor);
+        return 0;
+    }
+    uint16_t port = ntohs(address.sin_port);
+    close(socketDescriptor);
+    return port;
+}
+
+static int HARTSPConnectToLoopback(uint16_t port) {
+    int socketDescriptor = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (socketDescriptor < 0) return -1;
+
+#ifdef SO_NOSIGPIPE
+    int noSignal = 1;
+    setsockopt(socketDescriptor, SOL_SOCKET, SO_NOSIGPIPE, &noSignal, sizeof(noSignal));
+#endif
+    struct timeval timeout;
+    timeout.tv_sec = (int)HARTSPTestSocketTimeout;
+    timeout.tv_usec = 0;
+    setsockopt(socketDescriptor, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+    setsockopt(socketDescriptor, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+
+    struct sockaddr_in address;
+    memset(&address, 0, sizeof(address));
+    address.sin_len = sizeof(address);
+    address.sin_family = AF_INET;
+    address.sin_port = htons(port);
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (connect(socketDescriptor, (struct sockaddr *)&address, sizeof(address)) != 0) {
+        close(socketDescriptor);
+        return -1;
+    }
+    return socketDescriptor;
+}
+
+static BOOL HARTSPWriteString(int socketDescriptor, NSString *value) {
+    NSData *data = [value dataUsingEncoding:NSUTF8StringEncoding];
+    const uint8_t *bytes = data.bytes;
+    NSUInteger offset = 0;
+    while (offset < data.length) {
+        ssize_t sent = send(socketDescriptor, bytes + offset, data.length - offset, 0);
+        if (sent > 0) {
+            offset += (NSUInteger)sent;
+            continue;
+        }
+        if (sent < 0 && errno == EINTR) continue;
+        return NO;
+    }
+    return YES;
+}
+
+static NSUInteger HARTSPContentLength(NSString *responseHead) {
+    for (NSString *line in [responseHead componentsSeparatedByString:@"\r\n"]) {
+        NSRange separator = [line rangeOfString:@":"];
+        if (separator.location == NSNotFound) continue;
+        NSString *key = [[line substringToIndex:separator.location]
+                         stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        if ([key caseInsensitiveCompare:@"Content-Length"] != NSOrderedSame) continue;
+        NSString *value = [[line substringFromIndex:separator.location + 1]
+                           stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        return (NSUInteger)value.longLongValue;
+    }
+    return 0;
+}
+
+static NSString *HARTSPReadResponse(int socketDescriptor) {
+    NSMutableData *response = [NSMutableData data];
+    NSData *headerTerminator = [@"\r\n\r\n" dataUsingEncoding:NSUTF8StringEncoding];
+    NSUInteger expectedLength = NSNotFound;
+    uint8_t buffer[4096];
+    while (response.length < 64 * 1024) {
+        ssize_t received = recv(socketDescriptor, buffer, sizeof(buffer), 0);
+        if (received > 0) {
+            [response appendBytes:buffer length:(NSUInteger)received];
+            if (expectedLength == NSNotFound) {
+                NSRange end = [response rangeOfData:headerTerminator
+                                           options:0
+                                             range:NSMakeRange(0, response.length)];
+                if (end.location != NSNotFound) {
+                    NSUInteger headerLength = end.location + end.length;
+                    NSData *headData = [response subdataWithRange:NSMakeRange(0, headerLength)];
+                    NSString *head = [[NSString alloc] initWithData:headData encoding:NSUTF8StringEncoding];
+                    if (!head) return nil;
+                    expectedLength = headerLength + HARTSPContentLength(head);
+                }
+            }
+            if (expectedLength != NSNotFound && response.length >= expectedLength) {
+                NSData *completeResponse = [response subdataWithRange:NSMakeRange(0, expectedLength)];
+                return [[NSString alloc] initWithData:completeResponse encoding:NSUTF8StringEncoding];
+            }
+            continue;
+        }
+        if (received < 0 && errno == EINTR) continue;
+        return nil;
+    }
+    return nil;
+}
+
+static NSData *HARTSPReadExactBytes(int socketDescriptor, NSUInteger length) {
+    NSMutableData *data = [NSMutableData dataWithLength:length];
+    uint8_t *bytes = data.mutableBytes;
+    NSUInteger offset = 0;
+    while (offset < length) {
+        ssize_t received = recv(socketDescriptor, bytes + offset, length - offset, 0);
+        if (received > 0) {
+            offset += (NSUInteger)received;
+            continue;
+        }
+        if (received < 0 && errno == EINTR) continue;
+        return nil;
+    }
+    return data;
+}
+
+static NSData *HARTSPReadInterleavedFrame(int socketDescriptor, uint8_t *channelOut) {
+    NSData *header = HARTSPReadExactBytes(socketDescriptor, 4);
+    if (header.length != 4) return nil;
+    const uint8_t *bytes = header.bytes;
+    if (bytes[0] != '$') return nil;
+    NSUInteger length = ((NSUInteger)bytes[2] << 8) | bytes[3];
+    if (channelOut) *channelOut = bytes[1];
+    return HARTSPReadExactBytes(socketDescriptor, length);
+}
+
+static NSString *HARTSPHeaderValue(NSString *response, NSString *headerName) {
+    if (!response.length || !headerName.length) return nil;
+    NSRange headEnd = [response rangeOfString:@"\r\n\r\n"];
+    NSString *head = headEnd.location == NSNotFound ? response : [response substringToIndex:headEnd.location];
+    for (NSString *line in [head componentsSeparatedByString:@"\r\n"]) {
+        NSRange separator = [line rangeOfString:@":"];
+        if (separator.location == NSNotFound) continue;
+        NSString *key = [[line substringToIndex:separator.location]
+                         stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        if ([key caseInsensitiveCompare:headerName] != NSOrderedSame) continue;
+        return [[line substringFromIndex:separator.location + 1]
+                stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    }
+    return nil;
+}
+
+static NSString *HARTSPQuotedChallengeValue(NSString *challenge, NSString *name) {
+    if (!challenge.length || !name.length) return nil;
+    NSString *prefix = [NSString stringWithFormat:@"%@=\"", name];
+    NSRange start = [challenge rangeOfString:prefix options:NSCaseInsensitiveSearch];
+    if (start.location == NSNotFound) return nil;
+    NSUInteger valueStart = NSMaxRange(start);
+    NSRange end = [challenge rangeOfString:@"\""
+                                  options:0
+                                    range:NSMakeRange(valueStart, challenge.length - valueStart)];
+    if (end.location == NSNotFound) return nil;
+    return [challenge substringWithRange:NSMakeRange(valueStart, end.location - valueStart)];
+}
+
+static NSString *HARTSPTestMD5Hex(NSString *value) {
+    NSData *data = [value dataUsingEncoding:NSUTF8StringEncoding];
+    unsigned char digest[CC_MD5_DIGEST_LENGTH];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    CC_MD5(data.bytes, (CC_LONG)data.length, digest);
+#pragma clang diagnostic pop
+    NSMutableString *hex = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
+    for (NSUInteger index = 0; index < CC_MD5_DIGEST_LENGTH; index++) {
+        [hex appendFormat:@"%02x", digest[index]];
+    }
+    return hex;
+}
+
+static NSString *HARTSPDigestAuthorization(NSString *method,
+                                            NSString *URI,
+                                            NSString *username,
+                                            NSString *password,
+                                            NSString *nonce) {
+    NSString *realm = @"HA Dashboard";
+    NSString *HA1 = HARTSPTestMD5Hex([NSString stringWithFormat:@"%@:%@:%@", username, realm, password]);
+    NSString *HA2 = HARTSPTestMD5Hex([NSString stringWithFormat:@"%@:%@", method, URI]);
+    NSString *response = HARTSPTestMD5Hex([NSString stringWithFormat:@"%@:%@:%@", HA1, nonce, HA2]);
+    return [NSString stringWithFormat:
+            @"Digest username=\"%@\", realm=\"%@\", nonce=\"%@\", uri=\"%@\", response=\"%@\", algorithm=MD5",
+            username, realm, nonce, URI, response];
+}
+
+static BOOL HARTSPStartAuthenticatedVLCPlayback(int socketDescriptor,
+                                                NSString *streamURL,
+                                                NSString *username,
+                                                NSString *password) {
+    NSString *request = [NSString stringWithFormat:
+        @"DESCRIBE %@ RTSP/1.0\r\nCSeq: 1\r\nAccept: application/sdp\r\n\r\n",
+        streamURL];
+    if (!HARTSPWriteString(socketDescriptor, request)) return NO;
+    NSString *challengeResponse = HARTSPReadResponse(socketDescriptor);
+    NSString *challenge = HARTSPHeaderValue(challengeResponse, @"WWW-Authenticate");
+    NSString *nonce = HARTSPQuotedChallengeValue(challenge, @"nonce") ?: @"";
+    if (!nonce.length) return NO;
+
+    NSString *cachedAuthorization = HARTSPDigestAuthorization(
+        @"DESCRIBE", streamURL, username, password, nonce);
+    request = [NSString stringWithFormat:
+        @"DESCRIBE %@ RTSP/1.0\r\nCSeq: 2\r\nAccept: application/sdp\r\nAuthorization: %@\r\n\r\n",
+        streamURL, cachedAuthorization];
+    if (!HARTSPWriteString(socketDescriptor, request) ||
+        ![HARTSPReadResponse(socketDescriptor) hasPrefix:@"RTSP/1.0 200 OK"]) return NO;
+
+    NSString *videoURL = [streamURL stringByAppendingString:@"/trackID=0"];
+    request = [NSString stringWithFormat:
+        @"SETUP %@ RTSP/1.0\r\nCSeq: 3\r\nTransport: RTP/AVP/TCP;unicast;interleaved=0-1\r\nAuthorization: %@\r\n\r\n",
+        videoURL, cachedAuthorization];
+    if (!HARTSPWriteString(socketDescriptor, request)) return NO;
+    NSString *setupResponse = HARTSPReadResponse(socketDescriptor);
+    if (![setupResponse hasPrefix:@"RTSP/1.0 200 OK"]) return NO;
+    NSString *session = HARTSPHeaderValue(setupResponse, @"Session") ?: @"";
+    if (!session.length) return NO;
+
+    NSString *audioURL = [streamURL stringByAppendingString:@"/trackID=1"];
+    request = [NSString stringWithFormat:
+        @"SETUP %@ RTSP/1.0\r\nCSeq: 4\r\nSession: %@\r\nTransport: RTP/AVP/TCP;unicast;interleaved=2-3\r\nAuthorization: %@\r\n\r\n",
+        audioURL, session, cachedAuthorization];
+    if (!HARTSPWriteString(socketDescriptor, request) ||
+        ![HARTSPReadResponse(socketDescriptor) hasPrefix:@"RTSP/1.0 200 OK"]) return NO;
+
+    request = [NSString stringWithFormat:
+        @"PLAY %@ RTSP/1.0\r\nCSeq: 5\r\nSession: %@\r\nAuthorization: %@\r\n\r\n",
+        streamURL, session, cachedAuthorization];
+    return HARTSPWriteString(socketDescriptor, request) &&
+        [HARTSPReadResponse(socketDescriptor) hasPrefix:@"RTSP/1.0 200 OK"];
+}
+
+@interface HARTSPServerDelegateSpy : NSObject <HARTSPServerDelegate>
+@property (nonatomic, assign) BOOL suppliesMediaConfiguration;
+@property (nonatomic, assign) NSUInteger mediaConfigurationRequestCount;
+@property (nonatomic, assign) NSUInteger keyFrameRequestCount;
+@property (nonatomic, assign) NSUInteger maximumMediaClientCount;
+@property (nonatomic, strong) NSError *serverError;
+@end
+
+@implementation HARTSPServerDelegateSpy
+
+- (void)rtspServerDidChangeClientCount:(HARTSPServer *)server {
+    self.maximumMediaClientCount = MAX(self.maximumMediaClientCount, server.clientCount);
+}
+
+- (void)rtspServerNeedsVideoKeyFrame:(HARTSPServer *)server {
+    (void)server;
+    self.keyFrameRequestCount++;
+}
+
+- (void)rtspServerNeedsMediaConfiguration:(HARTSPServer *)server {
+    self.mediaConfigurationRequestCount++;
+    if (!self.suppliesMediaConfiguration) return;
+
+    const uint8_t avcConfiguration[] = {
+        0x01, 0x42, 0x00, 0x1e, 0xff, 0xe1, 0x00, 0x04,
+        0x67, 0x42, 0x00, 0x1e, 0x01, 0x00, 0x02, 0x68, 0xce,
+    };
+    const uint8_t audioConfiguration[] = {0x12, 0x10};
+    [server setVideoConfiguration:[NSData dataWithBytes:avcConfiguration
+                                                 length:sizeof(avcConfiguration)]];
+    [server setAudioConfiguration:[NSData dataWithBytes:audioConfiguration
+                                                 length:sizeof(audioConfiguration)]
+                          channels:2
+                        sampleRate:44100];
+}
+
+- (void)rtspServer:(HARTSPServer *)server didFailWithError:(NSError *)error {
+    (void)server;
+    self.serverError = error;
+}
+
+@end
+
+@interface HAStreamingManager (CompatibilityTesting)
++ (BOOL)supportsOperatingSystemVersion:(NSOperatingSystemVersion)version;
++ (BOOL)usesAudioCompatiblePresetForOperatingSystemVersion:(NSOperatingSystemVersion)version;
++ (NSArray<NSString *> *)preferredLegacySessionPresetsForQualityScale:(float)qualityScale;
+- (void)encodeAudio:(CMSampleBufferRef)sampleBuffer;
+@end
+
+@interface HAStreamingManager (AudioQueueTesting)
+@property (nonatomic, strong) dispatch_queue_t audioCaptureQueue;
+@property (nonatomic, strong) HAAACEncoder *audioEncoder;
+@property (nonatomic, strong) NSData *publishedAudioConfiguration;
+- (void)clearMediaState;
+@end
+
+@interface HARTSPAudioConfigurationSpy : HARTSPServer
+@property (nonatomic, strong) XCTestExpectation *configurationExpectation;
+@property (nonatomic, copy) NSData *audioConfiguration;
+@property (nonatomic, assign) NSUInteger audioChannels;
+@property (nonatomic, assign) NSUInteger audioSampleRate;
+@property (nonatomic, assign) NSUInteger audioSampleCount;
+@end
+
+@implementation HARTSPAudioConfigurationSpy
+- (BOOL)isRunning { return YES; }
+- (void)setAudioConfiguration:(NSData *)configuration
+                     channels:(NSUInteger)channels
+                   sampleRate:(NSUInteger)sampleRate {
+    self.audioConfiguration = configuration;
+    self.audioChannels = channels;
+    self.audioSampleRate = sampleRate;
+    [self.configurationExpectation fulfill];
+}
+- (void)sendAudioSample:(NSData *)aacRaw timestamp:(uint32_t)milliseconds {
+    (void)aacRaw;
+    (void)milliseconds;
+    self.audioSampleCount++;
+}
+@end
+
+typedef ssize_t (^HARTSPTestSendFunction)(CFSocketNativeHandle socket,
+                                          const void *bytes,
+                                          size_t length,
+                                          int *errorOut);
+
+@interface HARTSPServer (BackpressureTesting)
+@property (nonatomic, copy) HARTSPTestSendFunction sendFunctionForTesting;
+@property (nonatomic, assign) NSUInteger maximumPendingOutputBytes;
+- (NSUInteger)pendingOutputByteCountForTesting;
+- (void)flushPendingClientWritesForTesting;
+@end
+
+@interface HAUnsupportedStreamingManager : HAStreamingManager
+@end
+
+@implementation HAUnsupportedStreamingManager
+- (BOOL)supported { return NO; }
+@end
+
+@interface HACameraRegistrationManager (RegistrationTesting)
+- (NSDictionary *)cameraConfigurationInputForURL:(NSString *)url
+                                      optionsFlow:(BOOL)optionsFlow;
+- (NSError *)cameraCredentialTransportErrorForURL:(NSURL *)URL;
+- (void)processCurrentURL;
+- (BOOL)ensureActiveAuthenticationOrCancel;
+- (void)updateEntry:(NSString *)entryID forURL:(NSString *)url;
+- (void)acceptEntry:(NSString *)entryID forURL:(NSString *)url;
+- (void)createEntryForURL:(NSString *)url;
+@end
+
+@interface HACameraRegistrationRouteSpy : HACameraRegistrationManager
+@property (nonatomic, copy) NSString *updatedEntryID;
+@property (nonatomic, copy) NSString *acceptedEntryID;
+@property (nonatomic, assign) BOOL createdEntry;
+@end
+
+@implementation HACameraRegistrationRouteSpy
+- (BOOL)ensureActiveAuthenticationOrCancel { return YES; }
+- (void)updateEntry:(NSString *)entryID forURL:(NSString *)url {
+    (void)url;
+    self.updatedEntryID = entryID;
+}
+- (void)acceptEntry:(NSString *)entryID forURL:(NSString *)url {
+    (void)url;
+    self.acceptedEntryID = entryID;
+}
+- (void)createEntryForURL:(NSString *)url {
+    (void)url;
+    self.createdEntry = YES;
+}
+@end
+
+typedef HAAPIClient *(^HACameraRegistrationTestAPIClientFactory)(NSURL *baseURL,
+                                                                  NSString *token,
+                                                                  NSTimeInterval requestTimeout,
+                                                                  NSTimeInterval resourceTimeout);
+typedef id (^HACameraRegistrationTestRetryScheduler)(NSTimeInterval delay,
+                                                      dispatch_block_t block);
+typedef void (^HACameraRegistrationTestRetryCanceller)(id token);
+
+@interface HACameraRegistrationManager (RetryTesting)
+- (instancetype)initWithAPIClientFactory:(HACameraRegistrationTestAPIClientFactory)apiClientFactory
+                            scheduleRetry:(HACameraRegistrationTestRetryScheduler)retryScheduler
+                     cancelScheduledRetry:(HACameraRegistrationTestRetryCanceller)retryCanceller;
+- (NSError *)registrationPreflightError;
+- (NSString *)currentServerOriginToken;
+- (void)beginRegistrationAttempt;
+- (void)streamingStateDidChange:(NSNotification *)notification;
+@end
+
+@interface HACameraRegistrationRetryTestClient : HAAPIClient
+@property (nonatomic, assign, getter=isCancelledForTesting) BOOL cancelledForTesting;
+@property (nonatomic, assign) NSUInteger getCount;
+@property (nonatomic, assign) NSUInteger postCount;
+@property (nonatomic, assign) NSUInteger deleteCount;
+@property (nonatomic, copy) NSString *deletedPath;
+@end
+
+@implementation HACameraRegistrationRetryTestClient
+
+- (void)getJSONAtPath:(NSString *)path completion:(HAAPIResponseBlock)completion {
+    (void)path;
+    self.getCount++;
+    if (completion) completion(@[], nil);
+}
+
+- (void)postJSONAtPath:(NSString *)path body:(NSDictionary *)body completion:(HAAPIResponseBlock)completion {
+    (void)body;
+    self.postCount++;
+    if ([path isEqualToString:@"config/config_entries/flow"]) {
+        if (completion) completion(@{@"flow_id": @"test-camera-flow"}, nil);
+        return;
+    }
+    NSError *timeout = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorTimedOut
+        userInfo:@{NSLocalizedDescriptionKey: @"The request timed out."}];
+    if (completion) completion(nil, timeout);
+}
+
+- (void)deleteJSONAtPath:(NSString *)path completion:(HAAPIResponseBlock)completion {
+    self.deleteCount++;
+    self.deletedPath = path;
+    if (completion) completion(@{}, nil);
+}
+
+- (void)cancelAllRequests {
+    self.cancelledForTesting = YES;
+}
+
+@end
+
+
+@interface HACameraRegistrationRetryTestManager : HACameraRegistrationManager
+@property (nonatomic, assign) BOOL allowRegistrationToContinue;
+@property (nonatomic, assign) BOOL streamListenerArmedForTesting;
+@end
+
+@implementation HACameraRegistrationRetryTestManager
+- (NSError *)registrationPreflightError { return nil; }
+- (NSString *)currentServerOriginToken { return @"https|test.home-assistant.invalid|443"; }
+- (BOOL)registrationCanContinue {
+    return self.isRegistering && self.allowRegistrationToContinue;
+}
+- (BOOL)ensureActiveAuthenticationOrCancel {
+    if ([self registrationCanContinue]) return YES;
+    [self cancelRegistration];
+    return NO;
+}
+- (BOOL)streamListenerIsArmedForPendingURLs {
+    return self.streamListenerArmedForTesting;
+}
+@end
+
+@interface HAStreamingTests : XCTestCase
+@end
+
+@implementation HAStreamingTests
+
+- (void)testRTSPServerBindsTheAdvertisedAddress {
+    HARTSPServer *server = [[HARTSPServer alloc] initWithHost:@"127.0.0.1" port:18554
+        username:@"hadashboard" password:@"test-password"];
+    XCTAssertNil(server.streamURL);
+    NSError *error = nil;
+    XCTAssertTrue([server start:&error]);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(server.streamURL, @"rtsp://127.0.0.1:18554/live");
+    [server stop];
+    XCTAssertNil(server.streamURL);
+}
+
+- (void)testRTSPServerRejectsAnInvalidAdvertisedAddress {
+    HARTSPServer *server = [[HARTSPServer alloc] initWithHost:@"not-an-address" port:18554
+        username:@"hadashboard" password:@"test-password"];
+    NSError *error = nil;
+    XCTAssertFalse([server start:&error]);
+    XCTAssertNotNil(error);
+}
+
+- (void)testRTSPDigestRejectsMissingAndWrongCredentialsWithoutMediaDemand {
+    uint16_t port = HARTSPAvailableLoopbackPort();
+    XCTAssertNotEqual(port, (uint16_t)0);
+    HARTSPServerDelegateSpy *delegate = [[HARTSPServerDelegateSpy alloc] init];
+    HARTSPServer *server = [[HARTSPServer alloc] initWithHost:@"127.0.0.1"
+                                                        port:port
+                                                    username:@"hadashboard"
+                                                    password:@"correct-password"];
+    server.delegate = delegate;
+    NSError *startError = nil;
+    XCTAssertTrue([server start:&startError]);
+    XCTAssertNil(startError);
+
+    NSString *streamURL = server.streamURL;
+    XCTestExpectation *responsesReceived = [self expectationWithDescription:@"Unauthorized responses received"];
+    XCTestExpectation *clientClosed = [self expectationWithDescription:@"Unauthorized client closed"];
+    dispatch_semaphore_t closeGate = dispatch_semaphore_create(0);
+    __block BOOL connected = NO;
+    __block NSString *missingCredentialResponse = nil;
+    __block NSString *wrongCredentialResponse = nil;
+
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        @autoreleasepool {
+            int socketDescriptor = HARTSPConnectToLoopback(port);
+            NSString *missingResponse = nil;
+            NSString *wrongResponse = nil;
+            if (socketDescriptor >= 0) {
+                NSString *request = [NSString stringWithFormat:
+                                     @"DESCRIBE %@ RTSP/1.0\r\nCSeq: 1\r\nAccept: application/sdp\r\n\r\n",
+                                     streamURL];
+                if (HARTSPWriteString(socketDescriptor, request)) {
+                    missingResponse = HARTSPReadResponse(socketDescriptor);
+                    NSString *challenge = HARTSPHeaderValue(missingResponse, @"WWW-Authenticate");
+                    NSString *nonce = HARTSPQuotedChallengeValue(challenge, @"nonce") ?: @"";
+                    NSString *authorization = HARTSPDigestAuthorization(@"DESCRIBE", streamURL,
+                                                                         @"hadashboard", @"wrong-password",
+                                                                         nonce);
+                    request = [NSString stringWithFormat:
+                               @"DESCRIBE %@ RTSP/1.0\r\nCSeq: 2\r\nAccept: application/sdp\r\nAuthorization: %@\r\n\r\n",
+                               streamURL, authorization];
+                    if (HARTSPWriteString(socketDescriptor, request)) {
+                        wrongResponse = HARTSPReadResponse(socketDescriptor);
+                    }
+                }
+            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                connected = socketDescriptor >= 0;
+                missingCredentialResponse = missingResponse;
+                wrongCredentialResponse = wrongResponse;
+                [responsesReceived fulfill];
+            });
+            dispatch_semaphore_wait(closeGate,
+                                    dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)));
+            if (socketDescriptor >= 0) close(socketDescriptor);
+            dispatch_async(dispatch_get_main_queue(), ^{ [clientClosed fulfill]; });
+        }
+    });
+
+    [self waitForExpectations:@[responsesReceived] timeout:5.0];
+    XCTAssertTrue(connected);
+    XCTAssertTrue([missingCredentialResponse hasPrefix:@"RTSP/1.0 401 Unauthorized"]);
+    NSString *challenge = [HARTSPHeaderValue(missingCredentialResponse, @"WWW-Authenticate") lowercaseString];
+    XCTAssertTrue([challenge containsString:@"algorithm=md5"]);
+    XCTAssertFalse([challenge containsString:@"qop="]);
+    XCTAssertTrue([wrongCredentialResponse hasPrefix:@"RTSP/1.0 401 Unauthorized"]);
+    XCTAssertEqual(server.connectionCount, (NSUInteger)1);
+    XCTAssertEqual(server.clientCount, (NSUInteger)0);
+    XCTAssertEqual(server.playingClientCount, (NSUInteger)0);
+    XCTAssertEqual(delegate.maximumMediaClientCount, (NSUInteger)0);
+    XCTAssertEqual(delegate.mediaConfigurationRequestCount, (NSUInteger)0);
+    XCTAssertEqual(delegate.keyFrameRequestCount, (NSUInteger)0);
+    XCTAssertNil(delegate.serverError);
+
+    dispatch_semaphore_signal(closeGate);
+    [self waitForExpectations:@[clientClosed] timeout:5.0];
+    [server stop];
+}
+
+- (void)testRTSPDigestStartsMediaDemandOnlyAfterAuthenticatedDescribeSetupAndPlay {
+    uint16_t port = HARTSPAvailableLoopbackPort();
+    XCTAssertNotEqual(port, (uint16_t)0);
+    HARTSPServerDelegateSpy *delegate = [[HARTSPServerDelegateSpy alloc] init];
+    delegate.suppliesMediaConfiguration = YES;
+    NSString *username = @"hadashboard";
+    NSString *password = @"correct-password";
+    HARTSPServer *server = [[HARTSPServer alloc] initWithHost:@"127.0.0.1"
+                                                        port:port
+                                                    username:username
+                                                    password:password];
+    server.delegate = delegate;
+    NSError *startError = nil;
+    XCTAssertTrue([server start:&startError]);
+    XCTAssertNil(startError);
+
+    NSString *streamURL = server.streamURL;
+    NSString *videoTrackURL = [streamURL stringByAppendingString:@"/trackID=0"];
+    XCTestExpectation *challengeReceived = [self expectationWithDescription:@"Digest challenge received"];
+    XCTestExpectation *playing = [self expectationWithDescription:@"Authenticated PLAY completed"];
+    XCTestExpectation *clientClosed = [self expectationWithDescription:@"Authenticated client closed"];
+    dispatch_semaphore_t authenticationGate = dispatch_semaphore_create(0);
+    dispatch_semaphore_t closeGate = dispatch_semaphore_create(0);
+    __block BOOL connected = NO;
+    __block NSString *challengeResponse = nil;
+    __block NSString *describeResponse = nil;
+    __block NSString *setupResponse = nil;
+    __block NSString *playResponse = nil;
+
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        @autoreleasepool {
+            int socketDescriptor = HARTSPConnectToLoopback(port);
+            NSString *localChallengeResponse = nil;
+            NSString *nonce = @"";
+            if (socketDescriptor >= 0) {
+                NSString *request = [NSString stringWithFormat:
+                                     @"DESCRIBE %@ RTSP/1.0\r\nCSeq: 1\r\nAccept: application/sdp\r\n\r\n",
+                                     streamURL];
+                if (HARTSPWriteString(socketDescriptor, request)) {
+                    localChallengeResponse = HARTSPReadResponse(socketDescriptor);
+                    NSString *challenge = HARTSPHeaderValue(localChallengeResponse, @"WWW-Authenticate");
+                    nonce = HARTSPQuotedChallengeValue(challenge, @"nonce") ?: @"";
+                }
+            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                connected = socketDescriptor >= 0;
+                challengeResponse = localChallengeResponse;
+                [challengeReceived fulfill];
+            });
+
+            dispatch_semaphore_wait(authenticationGate,
+                                    dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)));
+            NSString *localDescribeResponse = nil;
+            NSString *localSetupResponse = nil;
+            NSString *localPlayResponse = nil;
+            if (socketDescriptor >= 0 && nonce.length) {
+                NSString *authorization = HARTSPDigestAuthorization(@"DESCRIBE", streamURL,
+                                                                     username, password, nonce);
+                NSString *request = [NSString stringWithFormat:
+                                     @"DESCRIBE %@ RTSP/1.0\r\nCSeq: 2\r\nAccept: application/sdp\r\nAuthorization: %@\r\n\r\n",
+                                     streamURL, authorization];
+                if (HARTSPWriteString(socketDescriptor, request)) {
+                    localDescribeResponse = HARTSPReadResponse(socketDescriptor);
+                }
+
+                authorization = HARTSPDigestAuthorization(@"SETUP", videoTrackURL,
+                                                           username, password, nonce);
+                request = [NSString stringWithFormat:
+                           @"SETUP %@ RTSP/1.0\r\nCSeq: 3\r\nTransport: RTP/AVP/TCP;unicast;interleaved=0-1\r\nAuthorization: %@\r\n\r\n",
+                           videoTrackURL, authorization];
+                if (HARTSPWriteString(socketDescriptor, request)) {
+                    localSetupResponse = HARTSPReadResponse(socketDescriptor);
+                }
+
+                NSString *session = HARTSPHeaderValue(localSetupResponse, @"Session") ?: @"";
+                authorization = HARTSPDigestAuthorization(@"PLAY", streamURL,
+                                                           username, password, nonce);
+                request = [NSString stringWithFormat:
+                           @"PLAY %@ RTSP/1.0\r\nCSeq: 4\r\nSession: %@\r\nAuthorization: %@\r\n\r\n",
+                           streamURL, session, authorization];
+                if (HARTSPWriteString(socketDescriptor, request)) {
+                    localPlayResponse = HARTSPReadResponse(socketDescriptor);
+                }
+            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                describeResponse = localDescribeResponse;
+                setupResponse = localSetupResponse;
+                playResponse = localPlayResponse;
+                [playing fulfill];
+            });
+
+            dispatch_semaphore_wait(closeGate,
+                                    dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)));
+            if (socketDescriptor >= 0) close(socketDescriptor);
+            dispatch_async(dispatch_get_main_queue(), ^{ [clientClosed fulfill]; });
+        }
+    });
+
+    [self waitForExpectations:@[challengeReceived] timeout:5.0];
+    XCTAssertTrue(connected);
+    XCTAssertTrue([challengeResponse hasPrefix:@"RTSP/1.0 401 Unauthorized"]);
+    NSString *challenge = [HARTSPHeaderValue(challengeResponse, @"WWW-Authenticate") lowercaseString];
+    XCTAssertTrue([challenge containsString:@"algorithm=md5"]);
+    XCTAssertFalse([challenge containsString:@"qop="]);
+    XCTAssertEqual(server.connectionCount, (NSUInteger)1);
+    XCTAssertEqual(server.clientCount, (NSUInteger)0);
+    XCTAssertEqual(server.playingClientCount, (NSUInteger)0);
+    XCTAssertEqual(delegate.maximumMediaClientCount, (NSUInteger)0);
+    XCTAssertEqual(delegate.mediaConfigurationRequestCount, (NSUInteger)0);
+    XCTAssertEqual(delegate.keyFrameRequestCount, (NSUInteger)0);
+
+    dispatch_semaphore_signal(authenticationGate);
+    [self waitForExpectations:@[playing] timeout:5.0];
+    XCTAssertTrue([describeResponse hasPrefix:@"RTSP/1.0 200 OK"]);
+    XCTAssertTrue([describeResponse containsString:@"m=video 0 RTP/AVP 96"]);
+    XCTAssertTrue([describeResponse containsString:@"m=audio 0 RTP/AVP 97"]);
+    XCTAssertTrue([setupResponse hasPrefix:@"RTSP/1.0 200 OK"]);
+    XCTAssertGreaterThan(HARTSPHeaderValue(setupResponse, @"Session").length, (NSUInteger)0);
+    XCTAssertTrue([playResponse hasPrefix:@"RTSP/1.0 200 OK"]);
+    XCTAssertEqual(server.clientCount, (NSUInteger)1);
+    XCTAssertEqual(server.playingClientCount, (NSUInteger)1);
+    XCTAssertEqual(delegate.maximumMediaClientCount, (NSUInteger)1);
+    XCTAssertEqual(delegate.mediaConfigurationRequestCount, (NSUInteger)1);
+    XCTAssertEqual(delegate.keyFrameRequestCount, (NSUInteger)1);
+    XCTAssertNil(delegate.serverError);
+
+    dispatch_semaphore_signal(closeGate);
+    [self waitForExpectations:@[clientClosed] timeout:5.0];
+    [server stop];
+}
+
+- (void)testRTSPDigestAcceptsVLCCachedDescribeAuthorizationOnSameConnection {
+    uint16_t port = HARTSPAvailableLoopbackPort();
+    XCTAssertNotEqual(port, (uint16_t)0);
+    HARTSPServerDelegateSpy *delegate = [[HARTSPServerDelegateSpy alloc] init];
+    delegate.suppliesMediaConfiguration = YES;
+    NSString *username = @"hadashboard";
+    NSString *password = @"correct-password";
+    HARTSPServer *server = [[HARTSPServer alloc] initWithHost:@"127.0.0.1"
+                                                        port:port
+                                                    username:username
+                                                    password:password];
+    server.delegate = delegate;
+    NSError *startError = nil;
+    XCTAssertTrue([server start:&startError]);
+    XCTAssertNil(startError);
+
+    NSString *streamURL = server.streamURL;
+    NSString *videoTrackURL = [streamURL stringByAppendingString:@"/trackID=0"];
+    NSString *audioTrackURL = [streamURL stringByAppendingString:@"/trackID=1"];
+    XCTestExpectation *requestsCompleted = [self expectationWithDescription:
+        @"VLC-style cached Digest requests completed"];
+    XCTestExpectation *clientClosed = [self expectationWithDescription:
+        @"VLC-style client closed"];
+    dispatch_semaphore_t closeGate = dispatch_semaphore_create(0);
+    __block BOOL connected = NO;
+    __block NSString *challengeResponse = nil;
+    __block NSString *describeResponse = nil;
+    __block NSString *videoSetupResponse = nil;
+    __block NSString *audioSetupResponse = nil;
+    __block NSString *wrongSessionPlayResponse = nil;
+    __block NSString *playResponse = nil;
+
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        @autoreleasepool {
+            int socketDescriptor = HARTSPConnectToLoopback(port);
+            NSString *localChallengeResponse = nil;
+            NSString *localDescribeResponse = nil;
+            NSString *localVideoSetupResponse = nil;
+            NSString *localAudioSetupResponse = nil;
+            NSString *localWrongSessionPlayResponse = nil;
+            NSString *localPlayResponse = nil;
+            if (socketDescriptor >= 0) {
+                NSString *request = [NSString stringWithFormat:
+                    @"DESCRIBE %@ RTSP/1.0\r\nCSeq: 1\r\nAccept: application/sdp\r\n\r\n",
+                    streamURL];
+                if (HARTSPWriteString(socketDescriptor, request)) {
+                    localChallengeResponse = HARTSPReadResponse(socketDescriptor);
+                }
+
+                NSString *challenge = HARTSPHeaderValue(localChallengeResponse,
+                                                         @"WWW-Authenticate");
+                NSString *nonce = HARTSPQuotedChallengeValue(challenge, @"nonce") ?: @"";
+                NSString *cachedDescribeAuthorization = HARTSPDigestAuthorization(
+                    @"DESCRIBE", streamURL, username, password, nonce);
+
+                request = [NSString stringWithFormat:
+                    @"DESCRIBE %@ RTSP/1.0\r\nCSeq: 2\r\nAccept: application/sdp\r\nAuthorization: %@\r\n\r\n",
+                    streamURL, cachedDescribeAuthorization];
+                if (HARTSPWriteString(socketDescriptor, request)) {
+                    localDescribeResponse = HARTSPReadResponse(socketDescriptor);
+                }
+
+                // VLC 3.0.21 sends this exact DESCRIBE digest again: its URI and
+                // response are not recomputed for either SETUP track or PLAY.
+                request = [NSString stringWithFormat:
+                    @"SETUP %@ RTSP/1.0\r\nCSeq: 3\r\nTransport: RTP/AVP/TCP;unicast;interleaved=0-1\r\nAuthorization: %@\r\n\r\n",
+                    videoTrackURL, cachedDescribeAuthorization];
+                if (HARTSPWriteString(socketDescriptor, request)) {
+                    localVideoSetupResponse = HARTSPReadResponse(socketDescriptor);
+                }
+
+                NSString *session = HARTSPHeaderValue(localVideoSetupResponse, @"Session") ?: @"";
+                request = [NSString stringWithFormat:
+                    @"SETUP %@ RTSP/1.0\r\nCSeq: 4\r\nSession: %@\r\nTransport: RTP/AVP/TCP;unicast;interleaved=2-3\r\nAuthorization: %@\r\n\r\n",
+                    audioTrackURL, session, cachedDescribeAuthorization];
+                if (HARTSPWriteString(socketDescriptor, request)) {
+                    localAudioSetupResponse = HARTSPReadResponse(socketDescriptor);
+                }
+
+                request = [NSString stringWithFormat:
+                    @"PLAY %@ RTSP/1.0\r\nCSeq: 5\r\nSession: %@\r\nAuthorization: %@\r\n\r\n",
+                    streamURL, @"not-the-negotiated-session", cachedDescribeAuthorization];
+                if (HARTSPWriteString(socketDescriptor, request)) {
+                    localWrongSessionPlayResponse = HARTSPReadResponse(socketDescriptor);
+                }
+
+                request = [NSString stringWithFormat:
+                    @"PLAY %@ RTSP/1.0\r\nCSeq: 6\r\nSession: %@\r\nAuthorization: %@\r\n\r\n",
+                    streamURL, session, cachedDescribeAuthorization];
+                if (HARTSPWriteString(socketDescriptor, request)) {
+                    localPlayResponse = HARTSPReadResponse(socketDescriptor);
+                }
+            }
+
+            dispatch_async(dispatch_get_main_queue(), ^{
+                connected = socketDescriptor >= 0;
+                challengeResponse = localChallengeResponse;
+                describeResponse = localDescribeResponse;
+                videoSetupResponse = localVideoSetupResponse;
+                audioSetupResponse = localAudioSetupResponse;
+                wrongSessionPlayResponse = localWrongSessionPlayResponse;
+                playResponse = localPlayResponse;
+                [requestsCompleted fulfill];
+            });
+
+            dispatch_semaphore_wait(closeGate,
+                dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)));
+            if (socketDescriptor >= 0) close(socketDescriptor);
+            dispatch_async(dispatch_get_main_queue(), ^{ [clientClosed fulfill]; });
+        }
+    });
+
+    [self waitForExpectations:@[requestsCompleted] timeout:8.0];
+    XCTAssertTrue(connected);
+    XCTAssertTrue([challengeResponse hasPrefix:@"RTSP/1.0 401 Unauthorized"]);
+    XCTAssertTrue([describeResponse hasPrefix:@"RTSP/1.0 200 OK"]);
+    XCTAssertTrue([videoSetupResponse hasPrefix:@"RTSP/1.0 200 OK"]);
+    XCTAssertGreaterThan(HARTSPHeaderValue(videoSetupResponse, @"Session").length,
+                         (NSUInteger)0);
+    XCTAssertTrue([audioSetupResponse hasPrefix:@"RTSP/1.0 200 OK"]);
+    XCTAssertTrue([wrongSessionPlayResponse hasPrefix:@"RTSP/1.0 454 Session Not Found"]);
+    XCTAssertTrue([playResponse hasPrefix:@"RTSP/1.0 200 OK"]);
+    XCTAssertEqual(server.connectionCount, (NSUInteger)1);
+    XCTAssertEqual(server.clientCount, (NSUInteger)1);
+    XCTAssertEqual(server.playingClientCount, (NSUInteger)1);
+    XCTAssertEqual(delegate.mediaConfigurationRequestCount, (NSUInteger)1);
+    XCTAssertEqual(delegate.keyFrameRequestCount, (NSUInteger)1);
+    XCTAssertNil(delegate.serverError);
+
+    dispatch_semaphore_signal(closeGate);
+    [self waitForExpectations:@[clientClosed] timeout:5.0];
+    [server stop];
+}
+
+- (void)testRTSPTransientWriteBackpressureBuffersAndFlushesRTPInOrder {
+    uint16_t port = HARTSPAvailableLoopbackPort();
+    XCTAssertNotEqual(port, (uint16_t)0);
+    HARTSPServerDelegateSpy *delegate = [[HARTSPServerDelegateSpy alloc] init];
+    delegate.suppliesMediaConfiguration = YES;
+    HARTSPServer *server = [[HARTSPServer alloc] initWithHost:@"127.0.0.1"
+                                                        port:port
+                                                    username:@"hadashboard"
+                                                    password:@"correct-password"];
+    server.delegate = delegate;
+    NSError *startError = nil;
+    XCTAssertTrue([server start:&startError]);
+    XCTAssertNil(startError);
+
+    XCTestExpectation *playbackReady = [self expectationWithDescription:@"Slow VLC playback ready"];
+    XCTestExpectation *framesRead = [self expectationWithDescription:@"Buffered RTP frames read"];
+    XCTestExpectation *clientClosed = [self expectationWithDescription:@"Slow VLC client closed"];
+    dispatch_semaphore_t readGate = dispatch_semaphore_create(0);
+    dispatch_semaphore_t closeGate = dispatch_semaphore_create(0);
+    __block BOOL playbackStarted = NO;
+    __block NSArray<NSData *> *receivedFrames = nil;
+    __block NSArray<NSNumber *> *receivedChannels = nil;
+    NSString *streamURL = server.streamURL;
+
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        @autoreleasepool {
+            int socketDescriptor = HARTSPConnectToLoopback(port);
+            BOOL started = socketDescriptor >= 0 && HARTSPStartAuthenticatedVLCPlayback(
+                socketDescriptor, streamURL, @"hadashboard", @"correct-password");
+            dispatch_async(dispatch_get_main_queue(), ^{
+                playbackStarted = started;
+                [playbackReady fulfill];
+            });
+
+            dispatch_semaphore_wait(readGate,
+                dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)));
+            NSMutableArray<NSData *> *frames = [NSMutableArray array];
+            NSMutableArray<NSNumber *> *channels = [NSMutableArray array];
+            if (started) {
+                for (NSUInteger index = 0; index < 3; index++) {
+                    uint8_t channel = UINT8_MAX;
+                    NSData *frame = HARTSPReadInterleavedFrame(socketDescriptor, &channel);
+                    if (!frame) break;
+                    [frames addObject:frame];
+                    [channels addObject:@(channel)];
+                }
+            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                receivedFrames = [frames copy];
+                receivedChannels = [channels copy];
+                [framesRead fulfill];
+            });
+
+            dispatch_semaphore_wait(closeGate,
+                dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)));
+            if (socketDescriptor >= 0) close(socketDescriptor);
+            dispatch_async(dispatch_get_main_queue(), ^{ [clientClosed fulfill]; });
+        }
+    });
+
+    [self waitForExpectations:@[playbackReady] timeout:8.0];
+    XCTAssertTrue(playbackStarted);
+    XCTAssertEqual(server.connectionCount, (NSUInteger)1);
+    XCTAssertEqual(server.playingClientCount, (NSUInteger)1);
+
+    __block BOOL blockWrites = YES;
+    __block BOOL partialWriteCompleted = NO;
+    server.sendFunctionForTesting = ^ssize_t(CFSocketNativeHandle socket,
+                                              const void *bytes,
+                                              size_t length,
+                                              int *errorOut) {
+        if (errorOut) *errorOut = 0;
+        if (blockWrites) {
+            if (!partialWriteCompleted) {
+                partialWriteCompleted = YES;
+                ssize_t sent = send(socket, bytes, MIN((size_t)7, length), 0);
+                if (sent < 0 && errorOut) *errorOut = errno;
+                return sent;
+            }
+            if (errorOut) *errorOut = EAGAIN;
+            return -1;
+        }
+        ssize_t sent = send(socket, bytes, length, 0);
+        if (sent < 0 && errorOut) *errorOut = errno;
+        return sent;
+    };
+
+    const uint8_t firstVideoBytes[] = {0, 0, 0, 3, 0x41, 0x11, 0x12};
+    const uint8_t audioBytes[] = {0x31, 0x32, 0x33};
+    const uint8_t secondVideoBytes[] = {0, 0, 0, 3, 0x41, 0x21, 0x22};
+    NSData *firstVideo = [NSData dataWithBytes:firstVideoBytes length:sizeof(firstVideoBytes)];
+    NSData *audio = [NSData dataWithBytes:audioBytes length:sizeof(audioBytes)];
+    NSData *secondVideo = [NSData dataWithBytes:secondVideoBytes length:sizeof(secondVideoBytes)];
+    [server sendVideoSample:firstVideo keyFrame:NO timestamp:0];
+    [server sendAudioSample:audio timestamp:0];
+    [server sendVideoSample:secondVideo keyFrame:NO timestamp:33];
+
+    XCTAssertTrue(partialWriteCompleted);
+    XCTAssertGreaterThan([server pendingOutputByteCountForTesting], (NSUInteger)0);
+    XCTAssertEqual(server.connectionCount, (NSUInteger)1);
+    XCTAssertEqual(server.clientCount, (NSUInteger)1);
+    XCTAssertEqual(server.playingClientCount, (NSUInteger)1);
+
+    blockWrites = NO;
+    [server flushPendingClientWritesForTesting];
+    XCTAssertEqual([server pendingOutputByteCountForTesting], (NSUInteger)0);
+    dispatch_semaphore_signal(readGate);
+    [self waitForExpectations:@[framesRead] timeout:5.0];
+
+    XCTAssertEqualObjects(receivedChannels, (@[@0, @2, @0]));
+    XCTAssertEqual(receivedFrames.count, (NSUInteger)3);
+    if (receivedFrames.count == 3) {
+        NSData *firstPayload = [receivedFrames[0] subdataWithRange:
+            NSMakeRange(12, receivedFrames[0].length - 12)];
+        NSData *audioPayload = [receivedFrames[1] subdataWithRange:
+            NSMakeRange(16, receivedFrames[1].length - 16)];
+        NSData *secondPayload = [receivedFrames[2] subdataWithRange:
+            NSMakeRange(12, receivedFrames[2].length - 12)];
+        XCTAssertEqualObjects(firstPayload,
+            [NSData dataWithBytes:firstVideoBytes + 4 length:sizeof(firstVideoBytes) - 4]);
+        XCTAssertEqualObjects(audioPayload, audio);
+        XCTAssertEqualObjects(secondPayload,
+            [NSData dataWithBytes:secondVideoBytes + 4 length:sizeof(secondVideoBytes) - 4]);
+        const uint8_t *firstRTP = receivedFrames[0].bytes;
+        const uint8_t *secondRTP = receivedFrames[2].bytes;
+        uint16_t firstSequence = ((uint16_t)firstRTP[2] << 8) | firstRTP[3];
+        uint16_t secondSequence = ((uint16_t)secondRTP[2] << 8) | secondRTP[3];
+        XCTAssertEqual(secondSequence, (uint16_t)(firstSequence + 1));
+    }
+
+    server.sendFunctionForTesting = nil;
+    dispatch_semaphore_signal(closeGate);
+    [self waitForExpectations:@[clientClosed] timeout:5.0];
+    [server stop];
+}
+
+- (void)testRTSPSlowClientClosesOnlyAfterPendingOutputLimit {
+    uint16_t port = HARTSPAvailableLoopbackPort();
+    XCTAssertNotEqual(port, (uint16_t)0);
+    HARTSPServerDelegateSpy *delegate = [[HARTSPServerDelegateSpy alloc] init];
+    delegate.suppliesMediaConfiguration = YES;
+    HARTSPServer *server = [[HARTSPServer alloc] initWithHost:@"127.0.0.1"
+                                                        port:port
+                                                    username:@"hadashboard"
+                                                    password:@"correct-password"];
+    server.delegate = delegate;
+    NSError *startError = nil;
+    XCTAssertTrue([server start:&startError]);
+    XCTAssertNil(startError);
+
+    XCTestExpectation *playbackReady = [self expectationWithDescription:@"Bounded client ready"];
+    XCTestExpectation *workerClosed = [self expectationWithDescription:@"Bounded client worker closed"];
+    dispatch_semaphore_t closeGate = dispatch_semaphore_create(0);
+    __block BOOL playbackStarted = NO;
+    NSString *streamURL = server.streamURL;
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        @autoreleasepool {
+            int socketDescriptor = HARTSPConnectToLoopback(port);
+            BOOL started = socketDescriptor >= 0 && HARTSPStartAuthenticatedVLCPlayback(
+                socketDescriptor, streamURL, @"hadashboard", @"correct-password");
+            dispatch_async(dispatch_get_main_queue(), ^{
+                playbackStarted = started;
+                [playbackReady fulfill];
+            });
+            dispatch_semaphore_wait(closeGate,
+                dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)));
+            if (socketDescriptor >= 0) close(socketDescriptor);
+            dispatch_async(dispatch_get_main_queue(), ^{ [workerClosed fulfill]; });
+        }
+    });
+
+    [self waitForExpectations:@[playbackReady] timeout:8.0];
+    XCTAssertTrue(playbackStarted);
+    server.maximumPendingOutputBytes = 40;
+    server.sendFunctionForTesting = ^ssize_t(CFSocketNativeHandle socket,
+                                              const void *bytes,
+                                              size_t length,
+                                              int *errorOut) {
+        (void)socket; (void)bytes; (void)length;
+        if (errorOut) *errorOut = EAGAIN;
+        return -1;
+    };
+
+    const uint8_t videoBytes[] = {0, 0, 0, 3, 0x41, 0x01, 0x02};
+    const uint8_t audioBytes[] = {0x03, 0x04, 0x05};
+    [server sendVideoSample:[NSData dataWithBytes:videoBytes length:sizeof(videoBytes)]
+                   keyFrame:NO timestamp:0];
+    XCTAssertGreaterThan([server pendingOutputByteCountForTesting], (NSUInteger)0);
+    XCTAssertEqual(server.connectionCount, (NSUInteger)1);
+    [server sendAudioSample:[NSData dataWithBytes:audioBytes length:sizeof(audioBytes)]
+                   timestamp:0];
+
+    XCTAssertEqual(server.connectionCount, (NSUInteger)0);
+    XCTAssertEqual(server.clientCount, (NSUInteger)0);
+    XCTAssertEqual(server.playingClientCount, (NSUInteger)0);
+    XCTAssertEqual([server pendingOutputByteCountForTesting], (NSUInteger)0);
+    XCTAssertTrue(server.running);
+
+    server.sendFunctionForTesting = nil;
+    dispatch_semaphore_signal(closeGate);
+    [self waitForExpectations:@[workerClosed] timeout:5.0];
+    [server stop];
+}
+
+- (void)testRTSPReconnectWithVerifiedStaleNonceReceivesFreshChallenge {
+    uint16_t port = HARTSPAvailableLoopbackPort();
+    XCTAssertNotEqual(port, (uint16_t)0);
+    HARTSPServerDelegateSpy *delegate = [[HARTSPServerDelegateSpy alloc] init];
+    delegate.suppliesMediaConfiguration = YES;
+    NSString *username = @"hadashboard";
+    NSString *password = @"correct-password";
+    HARTSPServer *server = [[HARTSPServer alloc] initWithHost:@"127.0.0.1"
+                                                        port:port
+                                                    username:username
+                                                    password:password];
+    server.delegate = delegate;
+    NSError *startError = nil;
+    XCTAssertTrue([server start:&startError]);
+    XCTAssertNil(startError);
+
+    NSString *streamURL = server.streamURL;
+    XCTestExpectation *staleChallengeReceived = [self expectationWithDescription:@"Fresh nonce challenge received"];
+    XCTestExpectation *retryAuthenticated = [self expectationWithDescription:@"Fresh nonce retry authenticated"];
+    XCTestExpectation *clientClosed = [self expectationWithDescription:@"Reconnect client closed"];
+    dispatch_semaphore_t retryGate = dispatch_semaphore_create(0);
+    dispatch_semaphore_t closeGate = dispatch_semaphore_create(0);
+    __block BOOL firstConnectionAuthenticated = NO;
+    __block NSString *staleResponse = nil;
+    __block NSString *firstNonce = nil;
+    __block NSString *freshNonce = nil;
+    __block NSString *retryResponse = nil;
+
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        @autoreleasepool {
+            int firstSocket = HARTSPConnectToLoopback(port);
+            NSString *request = [NSString stringWithFormat:
+                @"DESCRIBE %@ RTSP/1.0\r\nCSeq: 1\r\nAccept: application/sdp\r\n\r\n", streamURL];
+            NSString *challengeResponse = nil;
+            NSString *authenticatedResponse = nil;
+            if (firstSocket >= 0 && HARTSPWriteString(firstSocket, request)) {
+                challengeResponse = HARTSPReadResponse(firstSocket);
+                NSString *challenge = HARTSPHeaderValue(challengeResponse, @"WWW-Authenticate");
+                firstNonce = HARTSPQuotedChallengeValue(challenge, @"nonce");
+                NSString *authorization = HARTSPDigestAuthorization(
+                    @"DESCRIBE", streamURL, username, password, firstNonce ?: @"");
+                request = [NSString stringWithFormat:
+                    @"DESCRIBE %@ RTSP/1.0\r\nCSeq: 2\r\nAccept: application/sdp\r\nAuthorization: %@\r\n\r\n",
+                    streamURL, authorization];
+                if (HARTSPWriteString(firstSocket, request)) {
+                    authenticatedResponse = HARTSPReadResponse(firstSocket);
+                }
+            }
+            firstConnectionAuthenticated = [authenticatedResponse hasPrefix:@"RTSP/1.0 200 OK"];
+            if (firstSocket >= 0) close(firstSocket);
+
+            int reconnectSocket = HARTSPConnectToLoopback(port);
+            NSString *cachedAuthorization = HARTSPDigestAuthorization(
+                @"DESCRIBE", streamURL, username, password, firstNonce ?: @"");
+            request = [NSString stringWithFormat:
+                @"DESCRIBE %@ RTSP/1.0\r\nCSeq: 1\r\nAccept: application/sdp\r\nAuthorization: %@\r\n\r\n",
+                streamURL, cachedAuthorization];
+            NSString *localStaleResponse = nil;
+            if (reconnectSocket >= 0 && HARTSPWriteString(reconnectSocket, request)) {
+                localStaleResponse = HARTSPReadResponse(reconnectSocket);
+            }
+            NSString *freshChallenge = HARTSPHeaderValue(localStaleResponse, @"WWW-Authenticate");
+            NSString *localFreshNonce = HARTSPQuotedChallengeValue(freshChallenge, @"nonce");
+            dispatch_async(dispatch_get_main_queue(), ^{
+                staleResponse = localStaleResponse;
+                freshNonce = localFreshNonce;
+                [staleChallengeReceived fulfill];
+            });
+
+            dispatch_semaphore_wait(retryGate,
+                dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)));
+            NSString *localRetryResponse = nil;
+            if (reconnectSocket >= 0 && localFreshNonce.length) {
+                NSString *freshAuthorization = HARTSPDigestAuthorization(
+                    @"DESCRIBE", streamURL, username, password, localFreshNonce);
+                request = [NSString stringWithFormat:
+                    @"DESCRIBE %@ RTSP/1.0\r\nCSeq: 2\r\nAccept: application/sdp\r\nAuthorization: %@\r\n\r\n",
+                    streamURL, freshAuthorization];
+                if (HARTSPWriteString(reconnectSocket, request)) {
+                    localRetryResponse = HARTSPReadResponse(reconnectSocket);
+                }
+            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                retryResponse = localRetryResponse;
+                [retryAuthenticated fulfill];
+            });
+
+            dispatch_semaphore_wait(closeGate,
+                dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)));
+            if (reconnectSocket >= 0) close(reconnectSocket);
+            dispatch_async(dispatch_get_main_queue(), ^{ [clientClosed fulfill]; });
+        }
+    });
+
+    [self waitForExpectations:@[staleChallengeReceived] timeout:8.0];
+    XCTAssertTrue(firstConnectionAuthenticated);
+    XCTAssertTrue([staleResponse hasPrefix:@"RTSP/1.0 401 Unauthorized"]);
+    NSString *challenge = [HARTSPHeaderValue(staleResponse, @"WWW-Authenticate") lowercaseString];
+    XCTAssertTrue([challenge containsString:@"stale=true"]);
+    XCTAssertGreaterThan(freshNonce.length, (NSUInteger)0);
+    XCTAssertNotEqualObjects(freshNonce, firstNonce);
+    XCTAssertEqual(server.clientCount, (NSUInteger)0);
+    XCTAssertEqual(delegate.mediaConfigurationRequestCount, (NSUInteger)1);
+
+    dispatch_semaphore_signal(retryGate);
+    [self waitForExpectations:@[retryAuthenticated] timeout:5.0];
+    XCTAssertTrue([retryResponse hasPrefix:@"RTSP/1.0 200 OK"]);
+    XCTAssertEqual(server.clientCount, (NSUInteger)1);
+    XCTAssertEqual(delegate.mediaConfigurationRequestCount, (NSUInteger)1);
+
+    dispatch_semaphore_signal(closeGate);
+    [self waitForExpectations:@[clientClosed] timeout:5.0];
+    [server stop];
+}
+
+- (void)testRTSPMalformedAndOversizedRequestsFailClosedWithoutMediaDemand {
+    uint16_t port = HARTSPAvailableLoopbackPort();
+    XCTAssertNotEqual(port, (uint16_t)0);
+    HARTSPServerDelegateSpy *delegate = [[HARTSPServerDelegateSpy alloc] init];
+    HARTSPServer *server = [[HARTSPServer alloc] initWithHost:@"127.0.0.1"
+                                                        port:port
+                                                    username:@"hadashboard"
+                                                    password:@"correct-password"];
+    server.delegate = delegate;
+    NSError *startError = nil;
+    XCTAssertTrue([server start:&startError]);
+    XCTAssertNil(startError);
+
+    NSString *streamURL = server.streamURL;
+    XCTestExpectation *responsesReceived = [self expectationWithDescription:@"Rejected request responses received"];
+    __block BOOL malformedClientConnected = NO;
+    __block BOOL oversizedClientConnected = NO;
+    __block NSString *malformedResponse = nil;
+    __block NSString *oversizedResponse = nil;
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        @autoreleasepool {
+            int malformedSocket = HARTSPConnectToLoopback(port);
+            NSString *localMalformedResponse = nil;
+            if (malformedSocket >= 0) {
+                NSString *request = [NSString stringWithFormat:
+                                     @"DESCRIBE %@ RTSP/1.0\r\nAccept: application/sdp\r\n\r\n", streamURL];
+                if (HARTSPWriteString(malformedSocket, request)) {
+                    localMalformedResponse = HARTSPReadResponse(malformedSocket);
+                }
+                close(malformedSocket);
+            }
+
+            int oversizedSocket = HARTSPConnectToLoopback(port);
+            NSString *localOversizedResponse = nil;
+            if (oversizedSocket >= 0) {
+                NSMutableString *request = [NSMutableString stringWithFormat:
+                                            @"DESCRIBE %@ RTSP/1.0\r\nCSeq: 1\r\nX-Fill: ", streamURL];
+                [request appendString:[@"x" stringByPaddingToLength:(17 * 1024)
+                                                           withString:@"x"
+                                                      startingAtIndex:0]];
+                [request appendString:@"\r\n\r\n"];
+                HARTSPWriteString(oversizedSocket, request);
+                localOversizedResponse = HARTSPReadResponse(oversizedSocket);
+                close(oversizedSocket);
+            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                malformedClientConnected = malformedSocket >= 0;
+                oversizedClientConnected = oversizedSocket >= 0;
+                malformedResponse = localMalformedResponse;
+                oversizedResponse = localOversizedResponse;
+                [responsesReceived fulfill];
+            });
+        }
+    });
+
+    [self waitForExpectations:@[responsesReceived] timeout:8.0];
+    XCTAssertTrue(malformedClientConnected);
+    XCTAssertTrue(oversizedClientConnected);
+    XCTAssertTrue([malformedResponse hasPrefix:@"RTSP/1.0 400 Bad Request"]);
+    XCTAssertTrue([oversizedResponse hasPrefix:@"RTSP/1.0 413 Request Entity Too Large"]);
+    XCTAssertEqual(server.clientCount, (NSUInteger)0);
+    XCTAssertEqual(server.playingClientCount, (NSUInteger)0);
+    XCTAssertEqual(delegate.maximumMediaClientCount, (NSUInteger)0);
+    XCTAssertEqual(delegate.mediaConfigurationRequestCount, (NSUInteger)0);
+    XCTAssertEqual(delegate.keyFrameRequestCount, (NSUInteger)0);
+    XCTAssertNil(delegate.serverError);
+    [server stop];
+}
+
+- (void)testUnauthenticatedOptionsCannotExtendAuthenticationDeadline {
+    uint16_t port = HARTSPAvailableLoopbackPort();
+    XCTAssertNotEqual(port, (uint16_t)0);
+    HARTSPServerDelegateSpy *delegate = [[HARTSPServerDelegateSpy alloc] init];
+    HARTSPServer *server = [[HARTSPServer alloc] initWithHost:@"127.0.0.1"
+                                                        port:port
+                                                    username:@"hadashboard"
+                                                    password:@"correct-password"];
+    server.delegate = delegate;
+    NSError *startError = nil;
+    XCTAssertTrue([server start:&startError]);
+    XCTAssertNil(startError);
+
+    NSString *streamURL = server.streamURL;
+    XCTestExpectation *deadlineReached = [self expectationWithDescription:
+        @"Unauthenticated connection closed despite OPTIONS activity"];
+    __block NSUInteger successfulOptions = 0;
+    __block BOOL connectionClosed = NO;
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        @autoreleasepool {
+            int socketDescriptor = HARTSPConnectToLoopback(port);
+            if (socketDescriptor >= 0) {
+                for (NSUInteger index = 1; index <= 8; index++) {
+                    NSString *request = [NSString stringWithFormat:
+                        @"OPTIONS %@ RTSP/1.0\r\nCSeq: %lu\r\n\r\n",
+                        streamURL, (unsigned long)index];
+                    if (!HARTSPWriteString(socketDescriptor, request)) {
+                        connectionClosed = YES;
+                        break;
+                    }
+                    NSString *response = HARTSPReadResponse(socketDescriptor);
+                    if (![response hasPrefix:@"RTSP/1.0 200 OK"]) {
+                        connectionClosed = YES;
+                        break;
+                    }
+                    successfulOptions++;
+                    [NSThread sleepForTimeInterval:1.0];
+                }
+                close(socketDescriptor);
+            }
+            dispatch_async(dispatch_get_main_queue(), ^{ [deadlineReached fulfill]; });
+        }
+    });
+
+    [self waitForExpectations:@[deadlineReached] timeout:10.0];
+    XCTAssertTrue(connectionClosed);
+    XCTAssertGreaterThanOrEqual(successfulOptions, (NSUInteger)3);
+    XCTAssertLessThan(successfulOptions, (NSUInteger)8);
+    XCTAssertEqual(server.clientCount, (NSUInteger)0);
+    XCTAssertEqual(delegate.maximumMediaClientCount, (NSUInteger)0);
+    [server stop];
+}
+
+- (void)testEveryLifecycleTriggerStops {
+    for (NSInteger trigger = HAStreamingStopTriggerUser;
+         trigger <= HAStreamingStopTriggerCaptureInterrupted;
+         trigger++) {
+        XCTAssertTrue([HAStreamingManager shouldStopForTrigger:(HAStreamingStopTrigger)trigger]);
+    }
+}
+
+- (void)testAudioConfigurationIsPublishedBeforeEnoughPCMExistsForAnAACPacket {
+    HAStreamingManager *manager = [[HAStreamingManager alloc] init];
+    HARTSPAudioConfigurationSpy *server = [[HARTSPAudioConfigurationSpy alloc]
+        initWithHost:@"127.0.0.1" port:18554 username:@"hadashboard" password:@"test-password"];
+    server.configurationExpectation = [self expectationWithDescription:
+        @"AAC configuration published before first encoded packet"];
+    [manager setValue:@YES forKey:@"streaming"];
+    [manager setValue:server forKey:@"primaryRTSPServer"];
+
+    CMSampleBufferRef sampleBuffer = HAStreamingCreateMonoPCMBuffer(1);
+    XCTAssertNotEqual(sampleBuffer, NULL);
+    if (sampleBuffer) {
+        [manager encodeAudio:sampleBuffer];
+        CFRelease(sampleBuffer);
+    }
+
+    [self waitForExpectations:@[server.configurationExpectation] timeout:2.0];
+    const uint8_t expectedConfiguration[] = {0x11, 0x88};
+    XCTAssertEqualObjects(server.audioConfiguration,
+        [NSData dataWithBytes:expectedConfiguration length:sizeof(expectedConfiguration)]);
+    XCTAssertEqual(server.audioChannels, (NSUInteger)1);
+    XCTAssertEqual(server.audioSampleRate, (NSUInteger)48000);
+    XCTAssertEqual(server.audioSampleCount, (NSUInteger)0);
+
+    [manager setValue:@NO forKey:@"streaming"];
+    [manager setValue:nil forKey:@"primaryRTSPServer"];
+}
+
+- (void)testAACEncoderAccumulatesSubpacketPCMUntilOnePacketIsReady {
+    CMSampleBufferRef sampleBuffer = HAStreamingCreateMonoPCMBuffer(256);
+    XCTAssertNotEqual(sampleBuffer, NULL);
+    if (!sampleBuffer) return;
+
+    NSError *initializationError = nil;
+    HAAACEncoder *encoder = [[HAAACEncoder alloc]
+        initWithInputFormat:(CMAudioFormatDescriptionRef)CMSampleBufferGetFormatDescription(sampleBuffer)
+        error:&initializationError];
+    XCTAssertNotNil(encoder);
+    XCTAssertNil(initializationError);
+
+    NSData *encodedPacket = nil;
+    for (NSUInteger index = 0; index < 4; index++) {
+        NSError *encodingError = nil;
+        encodedPacket = [encoder encodeSampleBuffer:sampleBuffer error:&encodingError];
+        XCTAssertNil(encodingError);
+        if (index < 3) XCTAssertNil(encodedPacket);
+    }
+    XCTAssertGreaterThan(encodedPacket.length, (NSUInteger)0);
+    CFRelease(sampleBuffer);
+}
+
+- (void)testAACEncoderContinuesAfterTemporaryLiveInputExhaustion {
+    CMSampleBufferRef sampleBuffer = HAStreamingCreateMonoPCMBuffer(1024);
+    XCTAssertNotEqual(sampleBuffer, NULL);
+    if (!sampleBuffer) return;
+
+    NSError *initializationError = nil;
+    HAAACEncoder *encoder = [[HAAACEncoder alloc]
+        initWithInputFormat:(CMAudioFormatDescriptionRef)CMSampleBufferGetFormatDescription(sampleBuffer)
+        error:&initializationError];
+    XCTAssertNotNil(encoder);
+    XCTAssertNil(initializationError);
+
+    NSUInteger encodedPacketCount = 0;
+    for (NSUInteger index = 0; index < 6; index++) {
+        NSError *encodingError = nil;
+        NSData *packet = [encoder encodeSampleBuffer:sampleBuffer error:&encodingError];
+        XCTAssertNil(encodingError);
+        if (packet.length > 0) encodedPacketCount++;
+    }
+    // Returning 0/noErr from the input callback permanently finalized the
+    // converter after its first packet on iOS 10. Live exhaustion must leave
+    // it capable of producing subsequent AAC packets.
+    XCTAssertGreaterThan(encodedPacketCount, (NSUInteger)1);
+    CFRelease(sampleBuffer);
+}
+
+- (void)testStoppingDrainsAnInFlightAudioCallbackBeforeClearingAACState {
+    HAStreamingManager *manager = [[HAStreamingManager alloc] init];
+    dispatch_semaphore_t callbackStarted = dispatch_semaphore_create(0);
+    dispatch_semaphore_t allowCallbackToFinish = dispatch_semaphore_create(0);
+    dispatch_semaphore_t clearStarted = dispatch_semaphore_create(0);
+    dispatch_semaphore_t clearFinished = dispatch_semaphore_create(0);
+
+    dispatch_async(manager.audioCaptureQueue, ^{
+        dispatch_semaphore_signal(callbackStarted);
+        dispatch_semaphore_wait(allowCallbackToFinish, DISPATCH_TIME_FOREVER);
+        manager.audioEncoder = (HAAACEncoder *)[[NSObject alloc] init];
+        manager.publishedAudioConfiguration = [NSData dataWithBytes:"\x12\x10" length:2];
+    });
+    XCTAssertEqual(dispatch_semaphore_wait(callbackStarted,
+        dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC)), 0L);
+
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        dispatch_semaphore_signal(clearStarted);
+        [manager clearMediaState];
+        dispatch_semaphore_signal(clearFinished);
+    });
+    XCTAssertEqual(dispatch_semaphore_wait(clearStarted,
+        dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC)), 0L);
+    XCTAssertNotEqual(dispatch_semaphore_wait(clearFinished, DISPATCH_TIME_NOW), 0L,
+                      @"Clear must wait for the callback that already passed the capture guard");
+
+    dispatch_semaphore_signal(allowCallbackToFinish);
+    XCTAssertEqual(dispatch_semaphore_wait(clearFinished,
+        dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC)), 0L);
+    XCTAssertNil(manager.audioEncoder);
+    XCTAssertNil(manager.publishedAudioConfiguration);
+}
+
+- (void)testAuthenticatedHTTPRedirectOriginComparisonIsStrict {
+    NSURL *implicitHTTPS = [NSURL URLWithString:@"https://ha.example/api/config"];
+    NSURL *explicitHTTPS = [NSURL URLWithString:@"https://HA.EXAMPLE:443/other"];
+    NSURL *differentScheme = [NSURL URLWithString:@"http://ha.example/api/config"];
+    NSURL *differentHost = [NSURL URLWithString:@"https://other.example/api/config"];
+    NSURL *differentPort = [NSURL URLWithString:@"https://ha.example:8443/api/config"];
+
+    XCTAssertTrue([HAURLSessionRedirectGuard URL:implicitHTTPS
+                             sharesOriginWithURL:explicitHTTPS]);
+    XCTAssertFalse([HAURLSessionRedirectGuard URL:implicitHTTPS
+                              sharesOriginWithURL:differentScheme]);
+    XCTAssertFalse([HAURLSessionRedirectGuard URL:implicitHTTPS
+                              sharesOriginWithURL:differentHost]);
+    XCTAssertFalse([HAURLSessionRedirectGuard URL:implicitHTTPS
+                              sharesOriginWithURL:differentPort]);
+}
+
+- (void)testAPIClientRejectsAnInitialCrossOriginPathWithoutSendingIt {
+    HAAPIClient *client = [[HAAPIClient alloc]
+        initWithBaseURL:[NSURL URLWithString:@"https://ha.example/api"] token:@"test-token"];
+    XCTestExpectation *rejected = [self expectationWithDescription:@"Cross-origin path rejected"];
+    [client getJSONAtPath:@"https://other.example/credential-target"
+               completion:^(id response, NSError *error) {
+        XCTAssertNil(response);
+        XCTAssertNotNil(error);
+        XCTAssertEqual(error.code, (NSInteger)-5);
+        [rejected fulfill];
+    }];
+    [self waitForExpectations:@[rejected] timeout:1.0];
+    [client cancelAllRequests];
+}
+
+- (void)testCameraRegistrationUsesLongerTimeoutsAndContinuousCappedRetriesWithoutSleeping {
+    HAAPIClient *standardClient = [[HAAPIClient alloc]
+        initWithBaseURL:[NSURL URLWithString:@"https://ha.example/api"] token:@"test-token"];
+    XCTAssertEqualWithAccuracy(standardClient.requestTimeoutInterval, 15.0, 0.001);
+    XCTAssertEqualWithAccuracy(standardClient.resourceTimeoutInterval, 30.0, 0.001);
+    [standardClient cancelAllRequests];
+
+    NSMutableArray<HACameraRegistrationRetryTestClient *> *clients = [NSMutableArray array];
+    NSMutableArray<NSNumber *> *requestTimeouts = [NSMutableArray array];
+    NSMutableArray<NSNumber *> *resourceTimeouts = [NSMutableArray array];
+    NSMutableArray<NSNumber *> *retryDelays = [NSMutableArray array];
+    NSMutableArray *scheduledBlocks = [NSMutableArray array];
+    __block NSUInteger cancelledTokenCount = 0;
+
+    HACameraRegistrationTestAPIClientFactory factory =
+        ^HAAPIClient *(NSURL *baseURL, NSString *token,
+                       NSTimeInterval requestTimeout, NSTimeInterval resourceTimeout) {
+        (void)baseURL;
+        (void)token;
+        [requestTimeouts addObject:@(requestTimeout)];
+        [resourceTimeouts addObject:@(resourceTimeout)];
+        HACameraRegistrationRetryTestClient *client = [[HACameraRegistrationRetryTestClient alloc] init];
+        [clients addObject:client];
+        return client;
+    };
+    HACameraRegistrationTestRetryScheduler scheduler =
+        ^id(NSTimeInterval delay, dispatch_block_t block) {
+        NSObject *token = [[NSObject alloc] init];
+        [retryDelays addObject:@(delay)];
+        [scheduledBlocks addObject:[block copy]];
+        return token;
+    };
+    HACameraRegistrationTestRetryCanceller canceller = ^(id token) {
+        if (token) cancelledTokenCount++;
+    };
+
+    HACameraRegistrationRetryTestManager *manager =
+        [[HACameraRegistrationRetryTestManager alloc] initWithAPIClientFactory:factory
+                                                                 scheduleRetry:scheduler
+                                                          cancelScheduledRetry:canceller];
+    manager.allowRegistrationToContinue = YES;
+    [manager setValue:@YES forKey:@"registering"];
+    [manager setValue:@[@"rtsp://192.0.2.10:8554/live"] forKey:@"pendingURLs"];
+    [manager setValue:@"hadashboard" forKey:@"username"];
+    [manager setValue:@"test-password" forKey:@"password"];
+    [manager setValue:@"test-revision" forKey:@"credentialRevision"];
+    [manager setValue:@30 forKey:@"framesPerSecond"];
+
+    [manager beginRegistrationAttempt];
+    XCTAssertTrue(manager.isRegistering);
+    XCTAssertTrue(manager.isRetryScheduled);
+    XCTAssertEqual(manager.retryAttempt, (NSUInteger)1);
+    XCTAssertEqualObjects(retryDelays, (@[@2.0]));
+    XCTAssertEqual(clients.count, (NSUInteger)1);
+    XCTAssertEqual(clients.firstObject.deleteCount, (NSUInteger)1);
+    XCTAssertEqualObjects(clients.firstObject.deletedPath,
+                          @"config/config_entries/flow/test-camera-flow");
+
+    for (NSUInteger index = 0; index < 6; index++) {
+        dispatch_block_t scheduled = scheduledBlocks[index];
+        scheduled();
+    }
+
+    XCTAssertTrue(manager.isRegistering);
+    XCTAssertTrue(manager.isRetryScheduled);
+    XCTAssertEqual(manager.retryAttempt, (NSUInteger)7);
+    XCTAssertEqualObjects(retryDelays, (@[@2.0, @4.0, @8.0, @16.0, @32.0, @60.0, @60.0]));
+    XCTAssertEqual(clients.count, (NSUInteger)7);
+
+    // An effectively indefinite retry sequence saturates its display counter
+    // and delay instead of overflowing an exponential shift.
+    [manager setValue:@(NSUIntegerMax) forKey:@"retryAttempt"];
+    dispatch_block_t saturatedRetry = scheduledBlocks[6];
+    saturatedRetry();
+    XCTAssertEqual(manager.retryAttempt, NSUIntegerMax);
+    XCTAssertEqualObjects(retryDelays.lastObject, @60.0);
+    XCTAssertEqual(clients.count, (NSUInteger)8);
+    XCTAssertEqualObjects(requestTimeouts, (@[@75.0, @75.0, @75.0, @75.0, @75.0, @75.0, @75.0, @75.0]));
+    XCTAssertEqualObjects(resourceTimeouts, (@[@120.0, @120.0, @120.0, @120.0, @120.0, @120.0, @120.0, @120.0]));
+    XCTAssertEqualObjects(manager.lastError.domain, NSURLErrorDomain);
+    XCTAssertEqual(manager.lastError.code, (NSInteger)NSURLErrorTimedOut);
+
+    [manager cancelRegistration];
+    XCTAssertFalse(manager.isRegistering);
+    XCTAssertFalse(manager.isRetryScheduled);
+    XCTAssertEqual(manager.retryAttempt, (NSUInteger)0);
+    XCTAssertEqual(cancelledTokenCount, (NSUInteger)1);
+    for (HACameraRegistrationRetryTestClient *client in clients) {
+        XCTAssertTrue(client.isCancelledForTesting);
+        XCTAssertEqual(client.getCount, (NSUInteger)1);
+        XCTAssertEqual(client.postCount, (NSUInteger)2);
+        XCTAssertEqual(client.deleteCount, (NSUInteger)1);
+    }
+}
+
+- (void)testChangedCredentialRevisionSupersedesScheduledRetryAndInvalidatesOldTimer {
+    NSMutableArray<HACameraRegistrationRetryTestClient *> *clients = [NSMutableArray array];
+    NSMutableArray *scheduledBlocks = [NSMutableArray array];
+    NSMutableArray *scheduledTokens = [NSMutableArray array];
+    NSMutableSet *cancelledTokens = [NSMutableSet set];
+    HACameraRegistrationTestAPIClientFactory factory =
+        ^HAAPIClient *(NSURL *baseURL, NSString *token,
+                       NSTimeInterval requestTimeout, NSTimeInterval resourceTimeout) {
+        (void)baseURL; (void)token; (void)requestTimeout; (void)resourceTimeout;
+        HACameraRegistrationRetryTestClient *client = [[HACameraRegistrationRetryTestClient alloc] init];
+        [clients addObject:client];
+        return client;
+    };
+    HACameraRegistrationRetryTestManager *manager =
+        [[HACameraRegistrationRetryTestManager alloc] initWithAPIClientFactory:factory
+        scheduleRetry:^id(NSTimeInterval delay, dispatch_block_t block) {
+            (void)delay;
+            NSObject *token = [[NSObject alloc] init];
+            [scheduledBlocks addObject:[block copy]];
+            [scheduledTokens addObject:token];
+            return token;
+        } cancelScheduledRetry:^(id token) {
+            if (token) [cancelledTokens addObject:token];
+        }];
+    manager.allowRegistrationToContinue = YES;
+    manager.streamListenerArmedForTesting = YES;
+    NSArray<NSString *> *URLs = @[@"rtsp://192.0.2.10:8554/live"];
+
+    [manager ensureCameraEntriesForStreamURLs:URLs
+                                   deviceName:@"Test Device"
+                                     username:@"hadashboard"
+                                     password:@"test-password"
+                           credentialRevision:@"old-revision"
+                              framesPerSecond:30
+                                   completion:nil];
+    XCTAssertEqual(clients.count, (NSUInteger)1);
+    XCTAssertTrue(manager.isRetryScheduled);
+    dispatch_block_t oldRetry = scheduledBlocks[0];
+    id oldToken = scheduledTokens[0];
+
+    // An identical lifecycle request coalesces with the active work.
+    [manager ensureCameraEntriesForStreamURLs:URLs
+                                   deviceName:@"Test Device"
+                                     username:@"hadashboard"
+                                     password:@"test-password"
+                           credentialRevision:@"old-revision"
+                              framesPerSecond:30
+                                   completion:nil];
+    XCTAssertEqual(clients.count, (NSUInteger)1);
+
+    // Password rotation changes the revision and must replace the active
+    // generation immediately instead of sitting behind its infinite retry.
+    [manager ensureCameraEntriesForStreamURLs:URLs
+                                   deviceName:@"Test Device"
+                                     username:@"hadashboard"
+                                     password:@"new-test-password"
+                           credentialRevision:@"new-revision"
+                              framesPerSecond:30
+                                   completion:nil];
+    XCTAssertEqual(clients.count, (NSUInteger)2);
+    XCTAssertTrue(clients[0].isCancelledForTesting);
+    XCTAssertTrue([cancelledTokens containsObject:oldToken]);
+    XCTAssertEqualObjects([manager valueForKey:@"credentialRevision"], @"new-revision");
+    XCTAssertEqual(manager.retryAttempt, (NSUInteger)1);
+    dispatch_block_t newRetry = scheduledBlocks[1];
+
+    oldRetry();
+    XCTAssertEqual(clients.count, (NSUInteger)2);
+    XCTAssertEqualObjects([manager valueForKey:@"credentialRevision"], @"new-revision");
+
+    newRetry();
+    XCTAssertEqual(clients.count, (NSUInteger)3);
+    XCTAssertEqualObjects([manager valueForKey:@"credentialRevision"], @"new-revision");
+    [manager cancelRegistration];
+}
+
+- (void)testStoppingTheStreamCancelsAndInvalidatesAScheduledCameraRegistrationRetry {
+    __block NSUInteger clientCount = 0;
+    __block dispatch_block_t scheduledBlock = nil;
+    __block id scheduledToken = nil;
+    __block id cancelledToken = nil;
+    HACameraRegistrationRetryTestClient *firstClient = [[HACameraRegistrationRetryTestClient alloc] init];
+    HACameraRegistrationTestAPIClientFactory factory =
+        ^HAAPIClient *(NSURL *baseURL, NSString *token,
+                       NSTimeInterval requestTimeout, NSTimeInterval resourceTimeout) {
+        (void)baseURL; (void)token; (void)requestTimeout; (void)resourceTimeout;
+        clientCount++;
+        return firstClient;
+    };
+    HACameraRegistrationRetryTestManager *manager =
+        [[HACameraRegistrationRetryTestManager alloc] initWithAPIClientFactory:factory
+        scheduleRetry:^id(NSTimeInterval delay, dispatch_block_t block) {
+            XCTAssertEqualWithAccuracy(delay, 2.0, 0.001);
+            scheduledBlock = [block copy];
+            scheduledToken = [[NSObject alloc] init];
+            return scheduledToken;
+        } cancelScheduledRetry:^(id token) {
+            cancelledToken = token;
+        }];
+    manager.allowRegistrationToContinue = YES;
+    manager.streamListenerArmedForTesting = YES;
+    [manager setValue:@YES forKey:@"registering"];
+    [manager setValue:@[@"rtsp://192.0.2.10:8554/live"] forKey:@"pendingURLs"];
+    [manager setValue:@"hadashboard" forKey:@"username"];
+    [manager setValue:@"test-password" forKey:@"password"];
+    [manager setValue:@"test-revision" forKey:@"credentialRevision"];
+    [manager setValue:@30 forKey:@"framesPerSecond"];
+
+    [manager beginRegistrationAttempt];
+    XCTAssertTrue(manager.isRetryScheduled);
+    XCTAssertNotNil(scheduledBlock);
+    manager.streamListenerArmedForTesting = NO;
+    [manager streamingStateDidChange:nil];
+    XCTAssertEqual(cancelledToken, scheduledToken);
+    XCTAssertTrue(firstClient.isCancelledForTesting);
+    XCTAssertFalse(manager.isRegistering);
+    XCTAssertFalse(manager.isRetryScheduled);
+
+    scheduledBlock();
+    XCTAssertEqual(clientCount, (NSUInteger)1);
+    XCTAssertFalse(manager.isRegistering);
+}
+
+- (void)testCameraRegistrationPayloadUsesTheSelectedStreamFrameRate {
+    HACameraRegistrationManager *manager = [[HACameraRegistrationManager alloc] init];
+    [manager setValue:@"hadashboard" forKey:@"username"];
+    [manager setValue:@"test-stream-password" forKey:@"password"];
+    [manager setValue:@30 forKey:@"framesPerSecond"];
+
+    NSString *streamURL = @"rtsp://192.0.2.10:8554/live";
+    NSDictionary *input = [manager cameraConfigurationInputForURL:streamURL optionsFlow:YES];
+    NSDictionary *advanced = input[@"advanced"];
+
+    XCTAssertEqualObjects(input[@"stream_source"], streamURL);
+    XCTAssertEqualObjects(input[@"username"], @"hadashboard");
+    XCTAssertEqualObjects(input[@"password"], @"test-stream-password");
+    XCTAssertEqualObjects(advanced[@"authentication"], @"digest");
+    XCTAssertEqualObjects(advanced[@"rtsp_transport"], @"tcp");
+    XCTAssertEqualObjects(advanced[@"framerate"], @30);
+    XCTAssertEqualObjects(advanced[@"limit_refetch_to_url_change"], @NO);
+    XCTAssertEqualObjects(advanced[@"use_wallclock_as_timestamps"], @NO);
+}
+
+- (void)testCameraRegistrationAllowsLocalHTTPWithoutConsentState {
+    NSString *legacyConsentKey = @"ha_camera_insecure_consent_origin";
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    id previousValue = [defaults objectForKey:legacyConsentKey];
+    [defaults setObject:@"http|different.local|8123" forKey:legacyConsentKey];
+
+    @try {
+        HACameraRegistrationManager *manager = [[HACameraRegistrationManager alloc] init];
+        XCTAssertNil([defaults objectForKey:legacyConsentKey]);
+        NSArray<NSString *> *allowedURLs = @[
+            @"http://localhost:8123/api",
+            @"http://ha.local:8123/api",
+            @"http://127.0.0.1:8123/api",
+            @"http://10.20.30.40:8123/api",
+            @"http://172.16.0.1:8123/api",
+            @"http://172.31.255.254:8123/api",
+            @"http://192.168.1.2:8123/api",
+            @"http://169.254.10.20:8123/api",
+            @"http://[::1]:8123/api",
+            @"http://[fe80::1234]:8123/api",
+            @"http://[fd12:3456::1]:8123/api",
+        ];
+        for (NSString *URLString in allowedURLs) {
+            XCTAssertNil([manager cameraCredentialTransportErrorForURL:
+                [NSURL URLWithString:URLString]], @"Expected local HTTP to be allowed: %@", URLString);
+        }
+        XCTAssertNil([defaults objectForKey:legacyConsentKey]);
+    } @finally {
+        if (previousValue) [defaults setObject:previousValue forKey:legacyConsentKey];
+        else [defaults removeObjectForKey:legacyConsentKey];
+    }
+}
+
+- (void)testCameraRegistrationRefusesNonLocalHTTP {
+    HACameraRegistrationManager *manager = [[HACameraRegistrationManager alloc] init];
+    NSArray<NSString *> *blockedURLs = @[
+        @"http://example.com:8123/api",
+        @"http://8.8.8.8:8123/api",
+        @"http://172.15.255.255:8123/api",
+        @"http://172.32.0.1:8123/api",
+        @"http://192.0.2.10:8123/api",
+        @"http://[2001:db8::1]:8123/api",
+    ];
+    for (NSString *URLString in blockedURLs) {
+        NSError *error = [manager cameraCredentialTransportErrorForURL:
+            [NSURL URLWithString:URLString]];
+        XCTAssertNotNil(error, @"Expected non-local HTTP to be refused: %@", URLString);
+        XCTAssertTrue([error.localizedDescription containsString:@"must use HTTPS"]);
+    }
+}
+
+- (void)testCameraRegistrationAllowsHTTPSWithoutHostRestriction {
+    HACameraRegistrationManager *manager = [[HACameraRegistrationManager alloc] init];
+    XCTAssertNil([manager cameraCredentialTransportErrorForURL:
+        [NSURL URLWithString:@"https://ha.example:8123/api"]]);
+    XCTAssertNil([manager cameraCredentialTransportErrorForURL:
+        [NSURL URLWithString:@"https://203.0.113.10:8123/api"]]);
+}
+
+- (void)testAppOwnedCameraMissingRevisionOrFrameRateUsesOptionsFlow {
+    NSString *entryKey = @"ha_camera_primary_entry_id";
+    NSString *urlKey = @"ha_camera_primary_stream_url";
+    NSString *revisionKey = @"ha_camera_primary_credential_revision";
+    NSString *frameRateKey = @"ha_camera_primary_frames_per_second";
+    NSArray<NSString *> *keys = @[entryKey, urlKey, revisionKey, frameRateKey];
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSMutableDictionary *previousValues = [NSMutableDictionary dictionary];
+    for (NSString *key in keys) {
+        id value = [defaults objectForKey:key];
+        if (value) previousValues[key] = value;
+    }
+
+    @try {
+        NSString *entryID = @"app-owned-camera-entry";
+        NSString *streamURL = @"rtsp://192.0.2.10:8554/live";
+        NSString *revision = @"current-credential-revision";
+        HACameraRegistrationRouteSpy *manager = [[HACameraRegistrationRouteSpy alloc] init];
+        [manager setValue:@[streamURL] forKey:@"pendingURLs"];
+        [manager setValue:@[@{@"entry_id": entryID}] forKey:@"existingEntries"];
+        [manager setValue:@0 forKey:@"currentIndex"];
+        [manager setValue:revision forKey:@"credentialRevision"];
+        [manager setValue:@30 forKey:@"framesPerSecond"];
+
+        [defaults setObject:entryID forKey:entryKey];
+        [defaults setObject:streamURL forKey:urlKey];
+        [defaults removeObjectForKey:revisionKey];
+        [defaults setInteger:30 forKey:frameRateKey];
+        [manager processCurrentURL];
+        XCTAssertEqualObjects(manager.updatedEntryID, entryID);
+        XCTAssertNil(manager.acceptedEntryID);
+        XCTAssertFalse(manager.createdEntry);
+
+        manager.updatedEntryID = nil;
+        [defaults setObject:revision forKey:revisionKey];
+        [defaults removeObjectForKey:frameRateKey];
+        [manager processCurrentURL];
+        XCTAssertEqualObjects(manager.updatedEntryID, entryID);
+        XCTAssertNil(manager.acceptedEntryID);
+        XCTAssertFalse(manager.createdEntry);
+    } @finally {
+        for (NSString *key in keys) {
+            id previousValue = previousValues[key];
+            if (previousValue) [defaults setObject:previousValue forKey:key];
+            else [defaults removeObjectForKey:key];
+        }
+        [defaults synchronize];
+    }
+}
+
+- (void)testCameraRegistrationRejectsANonPositiveFrameRate {
+    HACameraRegistrationManager *manager = [[HACameraRegistrationManager alloc] init];
+    __block BOOL completed = NO;
+    [manager ensureCameraEntriesForStreamURLs:@[@"rtsp://192.0.2.10:8554/live"]
+                                   deviceName:@"Test Device"
+                                     username:@"hadashboard"
+                                     password:@"test-stream-password"
+                           credentialRevision:@"test-revision"
+                              framesPerSecond:0
+                                   completion:^(BOOL success, NSError *error) {
+        completed = YES;
+        XCTAssertFalse(success);
+        XCTAssertTrue([error.localizedDescription containsString:@"frame rate"]);
+    }];
+    XCTAssertTrue(completed);
+}
+
+- (void)testStreamingCompatibilityBoundaryIsExact {
+    NSOperatingSystemVersion iOS933 = {9, 3, 3};
+    NSOperatingSystemVersion iOS1032 = {10, 3, 2};
+    NSOperatingSystemVersion iOS1033 = {10, 3, 3};
+    NSOperatingSystemVersion iOS11 = {11, 0, 0};
+    XCTAssertFalse([HAStreamingManager supportsOperatingSystemVersion:iOS933]);
+    XCTAssertFalse([HAStreamingManager supportsOperatingSystemVersion:iOS1032]);
+    XCTAssertTrue([HAStreamingManager supportsOperatingSystemVersion:iOS1033]);
+    XCTAssertTrue([HAStreamingManager supportsOperatingSystemVersion:iOS11]);
+}
+
+- (void)testIOS10UsesAudioCompatibleVideoPresetsInsteadOfManualActiveFormat {
+    NSOperatingSystemVersion iOS1033 = {10, 3, 3};
+    NSOperatingSystemVersion iOS11 = {11, 0, 0};
+    XCTAssertTrue([HAStreamingManager usesAudioCompatiblePresetForOperatingSystemVersion:iOS1033]);
+    XCTAssertFalse([HAStreamingManager usesAudioCompatiblePresetForOperatingSystemVersion:iOS11]);
+    XCTAssertEqualObjects(
+        [HAStreamingManager preferredLegacySessionPresetsForQualityScale:0.0f].firstObject,
+        AVCaptureSessionPreset640x480);
+    XCTAssertEqualObjects(
+        [HAStreamingManager preferredLegacySessionPresetsForQualityScale:0.5f].firstObject,
+        AVCaptureSessionPreset1280x720);
+    XCTAssertEqualObjects(
+        [HAStreamingManager preferredLegacySessionPresetsForQualityScale:1.0f].firstObject,
+        AVCaptureSessionPreset1920x1080);
+}
+
+- (void)testUnsupportedPlatformCannotRestoreOrArmStreaming {
+    NSString *enabledKey = @"ha_local_camera_stream_enabled";
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    id previousValue = [defaults objectForKey:enabledKey];
+    [defaults setBool:YES forKey:enabledKey];
+
+    HAUnsupportedStreamingManager *manager = [[HAUnsupportedStreamingManager alloc] init];
+    XCTAssertFalse(manager.featureEnabled);
+    XCTAssertFalse([defaults boolForKey:enabledKey]);
+
+    __block BOOL completed = NO;
+    [manager armLocalStreamWithCompletion:^(BOOL success, NSError *error) {
+        completed = YES;
+        XCTAssertFalse(success);
+        XCTAssertNotNil(error);
+    }];
+    XCTAssertTrue(completed);
+    XCTAssertFalse(manager.streaming);
+
+    if (previousValue) [defaults setObject:previousValue forKey:enabledKey];
+    else [defaults removeObjectForKey:enabledKey];
+}
+
+- (void)testLocalFeatureCanBeDisabledWithoutRelayConfiguration {
+    HAStreamingManager *manager = HAStreamingManager.sharedManager;
+    BOOL wasEnabled = manager.featureEnabled;
+    NSError *error = nil;
+    XCTAssertTrue([manager setFeatureEnabled:NO error:&error]);
+    XCTAssertNil(error);
+    XCTAssertFalse(manager.featureEnabled);
+    XCTAssertTrue(manager.configured);
+    if (wasEnabled) XCTAssertTrue([manager setFeatureEnabled:YES error:&error]);
+}
+
+@end

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,44 +1,144 @@
 # Privacy Policy — HA Dashboard
 
-**Last updated:** February 2026
+**Last updated:** September 2026
 
-HA Dashboard is a native iOS app that connects to your self-hosted Home Assistant server. This policy explains how the app handles your data.
+HA Dashboard is a native app that connects to Home Assistant infrastructure
+chosen by the user. This policy distinguishes communication with that
+infrastructure from collection by the app developer.
 
-## Data Collection
+## Developer Data Collection
 
-HA Dashboard does **not** collect, store, or transmit any personal data to the developer or any third party. The app contains no analytics, tracking, advertising, or telemetry SDKs.
+HA Dashboard does **not** send personal data to the developer and contains no
+developer analytics, tracking, advertising, telemetry, or crash-reporting SDK.
+The developer cannot access your Home Assistant credentials, dashboard data,
+device diagnostics, or camera/microphone media through the app.
 
-## How the App Works
+## Home Assistant Communication
 
-- The app connects directly to a Home Assistant server URL that **you** configure.
-- All communication occurs between your device and your Home Assistant server.
-- No data passes through any intermediary servers.
+- The app exchanges authentication, dashboard configuration, entity state, and
+  service-call data with the Home Assistant server URL you configure.
+- If you explicitly enable **Register with Home Assistant**, the app registers
+  a mobile-app device and sends its generated device ID, device name, model,
+  operating-system/app versions, battery, brightness, app state, active
+  dashboard, network state, Wi-Fi SSID/BSSID when available, and Local Camera
+  Stream status, bare URLs, camera mode/capability, quality, transport and
+  authentication mode, and authenticated/playing/raw connection counts to your
+  Home Assistant instance. It does not send the stream password as a sensor
+  value.
+- Home Assistant may return a Home Assistant Cloud cloudhook or remote UI URL.
+  When present, optional device diagnostic webhooks may use that user-controlled
+  route. Camera and microphone media never uses a cloudhook or remote UI route.
+- Remote commands and in-app notification banners use Home Assistant's local
+  WebSocket push channel while the app is open and connected. The app does not
+  register a developer cloud-push URL/token or fall back to a developer push
+  service when that channel is unavailable.
+- Available-storage diagnostics are sent only when the selected webhook route
+  is a local-network address and only after device registration is enabled.
 
-## Credentials
+## Local Camera and Microphone Stream
 
-- Your Home Assistant access token or OAuth credentials are stored locally in the iOS Keychain on your device.
-- Credentials are never transmitted to the developer or any third party.
-- Credentials are only sent to your configured Home Assistant server for authentication.
+- Local Camera Stream is off by default and requires iOS 10.3.3 or later. It
+  requests Camera and Microphone access only after you enable the feature.
+- While the app is foregrounded, enabling the feature arms an in-process
+  H.264/AAC RTSP-over-TCP listener on the selected private primary (`en0`)
+  address. Camera and microphone capture starts only after an RTSP client
+  successfully authenticates and requests media, not merely because the toggle
+  is on or an unauthenticated client reaches the port.
+- A single selected camera uses port 8554. On supported MultiCam devices, Both
+  mode uses front on 8554 and rear on 8555.
+- Each device uses the fixed RTSP username `hadashboard` and its own
+  cryptographically generated 32-character password. The password is stored in
+  the platform Keychain as available only while the device is unlocked and is
+  not synchronised to other devices.
+- The listener requires RTSP Digest authentication, but RTSP/RTP media remains
+  plaintext and is **not encrypted on the local network**. A host with the
+  password and network access can receive live camera and microphone media.
+  Use this feature only on a trusted local network, do not forward these ports
+  or expose them through a VPN, and turn it off when it is not needed.
+- A visible **Camera + mic live** indicator appears above the dashboard,
+  including in kiosk mode, whenever authenticated viewers have activated
+  capture. Tapping it stops and disables Local Camera Stream.
+- The **Mute Camera Audio** setting affects playback of Home Assistant camera
+  cards only. Local Camera Stream includes microphone AAC whenever it is being
+  viewed; turn Local Camera Stream off to stop publishing that audio.
+- Capture stops after the final authenticated media client disconnects. The
+  listener and capture both stop when you turn the feature off, leave the
+  foreground, log out, lose permission, or encounter a listener/capture
+  failure. The app does not record media, show a hidden preview, run
+  camera/microphone capture in the background, or accept a Home Assistant
+  command that remotely enables capture.
+
+## Credentials and Local Storage
+
+- Home Assistant access and refresh tokens are stored in the platform Keychain.
+  Developer deployment arguments may bootstrap a token once; the app moves
+  valid credentials to Keychain and removes persisted bootstrap values.
+- The Local Camera Stream password remains in the device-only Keychain when the
+  stream is turned off so existing clients continue to work the next time it is
+  enabled. Rotating it disconnects current viewers and invalidates manually
+  saved URLs. **Log Out & Reset** deletes it; a new password is generated if the
+  feature is used again.
+- The stream address shown in Settings and reported as a sensor attribute does
+  not contain credentials. The explicit **Copy URL with Password** action puts
+  a sensitive connection URL on the system clipboard as a local-only item, so
+  it is not propagated through Universal Clipboard. The app gives the system a
+  60-second expiration date and also clears an unchanged expired value itself
+  while active or when it next becomes active. Other apps with clipboard access
+  may be able to read the credential before it expires. A receiving RTSP client
+  may retain a protected URL in its own history or logs; remove it there when no
+  longer needed.
+- App preferences, cached Home Assistant state, stream mode/quality, and saved
+  Home Assistant config-entry IDs and non-secret credential revisions are
+  stored in the app container.
+- If camera registration is enabled, Home Assistant stores Generic Camera
+  entries with the bare RTSP URLs, username, and password on your Home Assistant
+  server. Password rotation completes locally after the protected listener
+  re-arms and does not wait for Home Assistant. While **Register with Home
+  Assistant** remains enabled, the app then starts asynchronous reconciliation
+  of the replacement credential through Home Assistant's camera config flow. It
+  updates only entries whose IDs it saved, or creates a new entry when it has no
+  saved ID; retryable failures continue while the same stream, registration
+  setting, account, and Home Assistant origin remain active. Manually configured
+  or unowned entries must be updated manually. Home Assistant backups may
+  therefore contain the stream password; protect those backups as you would
+  other Home Assistant credentials.
+- Camera registration sends the username and password to the configured Home
+  Assistant URL using that server connection. HTTPS protects that submission in
+  transit. For a loopback, `.local`, link-local, RFC1918, or IPv6 unique-local
+  Home Assistant address, automatic registration may instead use HTTP without
+  another per-server prompt. **HTTP provides no transport encryption: another
+  host able to monitor that LAN may recover the camera username and password.**
+  Use this only on a trusted local network. Non-local HTTP is never accepted for
+  automatic camera credential registration.
+- Live camera and microphone media is not written to the app container, Photos,
+  iCloud, or a developer service.
 
 ## Local Network Access
 
-The app uses local network access (mDNS/Bonjour) to discover Home Assistant servers on your network. This requires the Local Network permission on iOS. The discovery data does not leave your device.
+The app uses Bonjour/mDNS to discover Home Assistant and may host the optional
+RTSP listener described above. iOS and iPadOS 14 or later request Local Network
+permission for this access; earlier supported releases do not show that system
+permission. Discovery results remain on the device.
 
-## Cookies and Web Tracking
+## User Controls and Retention
 
-The app does not use cookies, web views, or any form of web-based tracking.
+Turning off Register with Home Assistant stops device reporting and removes its
+local webhook credentials. **Log Out & Reset** clears local Home Assistant and
+stream credentials, registration identity, preferences, cached Home Assistant
+state/history, local logs, and stream configuration. Home Assistant devices and
+Generic Camera entries, including their saved stream credentials, are not
+deleted automatically; remove them in Home Assistant if no longer wanted.
 
-## Data Storage
+## Cookies, Tracking, and Third-Party SDKs
 
-All app data (server configuration, dashboard preferences, cached entity states) is stored locally on your device. No data is synced to cloud services.
-
-## Third-Party Services
-
-The app does not integrate with any third-party services, SDKs, or APIs beyond your own Home Assistant server.
+The app does not use cookies, advertising identifiers, tracking, or web-based
+analytics. It includes no third-party analytics or advertising SDK. Home
+Assistant and optional Home Assistant Cloud routes are services configured by
+the user, not developer data-collection services.
 
 ## Children's Privacy
 
-The app does not knowingly collect any data from anyone, including children.
+The developer does not knowingly collect data from anyone, including children.
 
 ## Changes to This Policy
 
@@ -46,4 +146,5 @@ If this policy changes, the updated version will be published at the same URL.
 
 ## Contact
 
-For questions about this privacy policy, open an issue on the GitHub repository.
+For privacy questions, open an issue on the GitHub repository. A separate
+non-GitHub support address has not yet been published.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # HA Dashboard
 
-[![Download on the App Store](https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&releaseDate=1740009600)](https://apps.apple.com/gb/app/ha-dash/id6759347912)
+[![Download on the App Store](https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83)](https://apps.apple.com/gb/app/ha-dash/id6759347912)
 
 A native iOS app that renders your [Home Assistant](https://www.home-assistant.io/) dashboards natively, achieving usable framerates on the oldest iOS devices.
 
-Built to run on everything from an iPad 2 (iOS 9.3.5, armv7) wall-mounted as a kiosk, to the latest iPhones on iOS 26.
+Built to run from armv7 and arm64 devices on iOS 9.3.3 through current iOS 27 devices, with a Mac Catalyst developer build. The optional Local Camera Stream requires iOS 10.3.3 or later.
 
 ## Features
 
@@ -14,10 +14,26 @@ Built to run on everything from an iPad 2 (iOS 9.3.5, armv7) wall-mounted as a k
 - **Themes** — Auto, Dark, Light, and Gradient modes with 5 gradient presets plus custom hex colors
 - **Kiosk mode** — hides navigation, prevents sleep, triple-tap to escape
 - **Dashboard switcher** — switch between multiple HA dashboards
+- **Local remote controls** — use Home Assistant's WebSocket notification
+  channel to wake/dim an open kiosk, set brightness, navigate, change
+  appearance/kiosk state, reload, or show an in-app banner
 - **mDNS discovery** — finds Home Assistant servers on your local network
 - **Triple auth** — trusted network support, long-lived access token, or full OAuth login flow with token refresh
-- **Universal binary** — armv7 + arm64 in a single build for legacy device support
+- **Universal binary** — armv7 + arm64 in one build, with an iOS 9.0 minimum encoded in both slices
 - **Demo mode** — Built-in dashboards with simulated entities and history
+- **Optional local camera streams** — Foreground-only, per-device password-protected H.264/AAC RTSP with front/rear selection, simultaneous MultiCam where supported, concurrent consumers, live capability-based quality/orientation, and Home Assistant Generic Camera registration (iOS 10.3.3+)
+
+Local Camera Stream requires RTSP Digest authentication with the fixed username
+`hadashboard` and a strong password generated separately on each device. Capture
+starts only for an authenticated viewer. RTSP media is still plaintext and is
+not encrypted on the LAN, so use it only on a trusted local network and do not
+forward ports 8554 or 8555. See the
+[streaming contract](docs/live-camera-streaming-v1.md).
+
+Remote commands work only while HA Dashboard is open and connected; they cannot
+unlock the device, launch a backgrounded app, or remotely enable camera capture.
+See the [support guide](https://ha-dashboard.github.io/ios-app/support.html) for
+the supported commands and payloads.
 
 ## Screenshots
 
@@ -25,8 +41,8 @@ See the [landing page](https://ha-dashboard.github.io/ios-app/) for screenshots.
 
 ## Requirements
 
-- **Xcode 26** (for modern devices and simulators)
-- **Xcode 13.2.1** (optional — only needed if targeting iPad 2 / armv7)
+- **Xcode 26 or 27** (modern compiler, devices, simulators, and Catalyst)
+- **Xcode 13.2.1 iPhoneOS SDK stubs** (full app or extracted SDK via `XCODE13_SDK_PATH`) for universal iOS 9 device linking
 - **XcodeGen** (`brew install xcodegen`)
 - A Home Assistant server with pre-configured dashboards
 
@@ -66,6 +82,11 @@ You should customise this to your needs.
 
 ```bash
 scripts/deploy.sh sim              # iPad simulator
+scripts/deploy.sh iphone           # Paired iPhone
+scripts/deploy.sh mini5            # iPad Mini 5 (CoreDevice or MobileDevice Wi-Fi)
+scripts/deploy.sh mini4            # iPad Mini 4 (MobileDevice Wi-Fi)
+scripts/deploy.sh ipad4            # Jailbroken iPad 4 over SSH
+scripts/deploy.sh mac              # Local Mac Catalyst build
 scripts/deploy.sh all --kiosk      # All targets in kiosk mode
 ```
 
@@ -74,7 +95,7 @@ See `.env.example` for the device UDIDs and credentials needed for each target.
 ## Architecture
 
 - Pure **Objective-C**
-- Programmatic Auto Layout (`NSLayoutConstraint` anchors, iOS 9+)
+- Programmatic application UI and Auto Layout (`NSLayoutConstraint` anchors, iOS 9+); `LaunchScreen.storyboard` is the sole storyboard
 - **SocketRocket** for WebSocket, **NSURLSession** for REST
 - Custom 12-column `UICollectionViewLayout` for iPad multi-column dashboards
 - Performance optimizations for older devices: deferred loading, coalesced reloads, cell rasterization, lightweight graph mode
@@ -103,7 +124,7 @@ npm run capture             # Capture HA web screenshots for comparison
 
 ## Privacy
 
-HA Dashboard does not collect, store, or transmit any personal data. All communication is directly between your device and your Home Assistant server. See [PRIVACY.md](PRIVACY.md) for the full privacy policy.
+HA Dashboard sends no personal data to the developer. Optional device diagnostics go only to the Home Assistant infrastructure you configure; camera/microphone media goes directly to authenticated RTSP clients while the app is foregrounded and never through a developer relay. See [PRIVACY.md](PRIVACY.md), the [live-streaming contract](docs/live-camera-streaming-v1.md), and the [1.2.6 release dossier](docs/releases/v1.2.6.md).
 
 ## License
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -12,12 +12,14 @@ Apple Silicon Mac required (arm64). Intel Macs won't run the arm64 simulators.
 
 | Xcode | Install Path | Required? | Purpose |
 |-------|-------------|-----------|---------|
-| **26** (latest) | `/Applications/Xcode.app` | Yes | Builds all targets: simulator, device arm64, Mac Catalyst |
-| **13.2.1** | `/Applications/Xcode-13.2.1.app` | Only for iPad 2 | Provides armv7 SDK stubs for the universal device build |
+| **26 or 27** | `/Applications/Xcode.app` or `XCODE_PATH` | Yes | Modern compiler plus simulator, bundle-template, and Mac Catalyst builds |
+| **13.2.1 iPhoneOS SDK** | Full Xcode app or `XCODE13_SDK_PATH` | Universal device builds | Link stubs used for both iOS 9 armv7 and arm64 slices |
 
-After installing Xcode 26, open it once and install the iOS simulator runtime when prompted.
+After installing the modern Xcode, open it once and install a current iOS simulator runtime when prompted.
 
-If you don't need to target iPad 2 (armv7), you can skip Xcode 13.2.1 entirely — the `sim` and `mac` build targets only use Xcode 26.
+If you only build `sim` or `mac`, you can omit the Xcode 13 SDK. `device` always needs the full Xcode 13.2.1 iPhoneOS SDK or the repository's extracted SDK stubs, because both shipped slices retain an iOS 9 minimum.
+
+Legacy x86_64 RosettaSim builds are a separate exception: they require macOS 26 and Xcode 26. Xcode 27 rejects simulator deployment targets below iOS 15, and macOS 27 cannot boot the x86-only iOS 9–14 runtimes. Physical iOS 9 device builds continue to work with Xcode 27 through the direct-clang path.
 
 ### Homebrew Dependencies
 
@@ -33,8 +35,8 @@ These are only needed if deploying to physical devices, not for simulator develo
 
 | Tool | Install | Used By |
 |------|---------|---------|
-| `pymobiledevice3` | `pip install pymobiledevice3` | iPad Mini 4 deploy |
-| `sshpass` | `brew install hudochenkov/sshpass/sshpass` | iPad 2 WiFi SSH deploy |
+| `libimobiledevice` + `ideviceinstaller` | `brew install libimobiledevice ideviceinstaller` | Mini 4/Mini 5 MobileDevice Wi-Fi fallback |
+| `sshpass` | `brew install hudochenkov/sshpass/sshpass` | Jailbroken iPad 2/3/4 Wi-Fi SSH deploy |
 
 ## Quick Start (Simulator)
 
@@ -50,7 +52,8 @@ cp .env.example .env
 Edit `.env` with at minimum:
 ```bash
 BUNDLE_ID=com.yourname.hadashboard    # Your bundle identifier
-# Apple Team ID is optional for simulator-only builds
+# Apple Team ID is optional only for simulator builds; device and Catalyst
+# builds need it for signing and the app-private Keychain access group.
 ```
 
 If you have a Home Assistant server, also set:
@@ -93,8 +96,9 @@ This launches with 3 built-in dashboards (Home, Monitoring, Media) using simulat
 |--------|---------|
 | `scripts/regen.sh` | Runs XcodeGen to generate `.xcodeproj` from `project.yml`. Run after changing project.yml or adding/removing source files. |
 | `scripts/build.sh sim` | Builds arm64 simulator binary |
-| `scripts/build.sh device` | Builds universal armv7+arm64 device binary (requires Xcode 13.2.1) |
-| `scripts/build.sh mac` | Builds Mac Catalyst binary |
+| `scripts/build.sh device` | Builds universal armv7+arm64 with iOS 9 minimum in both slices (requires Xcode 13 SDK stubs); the legacy slice uses ARM mode to avoid Xcode 27 Thumb-entry/IMP relocation loss |
+| `scripts/build.sh rosettasim` | Builds x86_64 for legacy simulators (macOS 26 + Xcode 26 only) |
+| `scripts/build.sh mac` | Builds and automatically provisions the signed Mac Catalyst binary, including its app-private Keychain access group |
 | `scripts/deploy.sh <target>` | Builds + installs + launches on a target |
 | `scripts/test-snapshots.sh` | Runs snapshot regression tests |
 | `scripts/clean.sh` | Cleans build artifacts |
@@ -111,7 +115,7 @@ If you prefer building from Xcode's UI rather than the command line:
 4. Choose a simulator destination
 5. Build and run (Cmd+R)
 
-Note: the build scripts inject the version number from git tags. Building directly from Xcode uses the `0.0.0` fallback, which is fine for development.
+Note: the build scripts inject the version number from git tags. Building directly from Xcode uses the `0.0.0` fallback and produces only the normal modern-Xcode architecture/deployment settings; use `scripts/build.sh device` for the distributable iOS 9 universal product.
 
 ## Running Tests
 
@@ -130,17 +134,14 @@ scripts/test-snapshots.sh record
 
 Version numbers come from git tags — never hardcode them:
 
-```bash
-git tag v1.2.3
-git push --tags
-```
+Create curated notes at `docs/releases/vX.Y.Z.md`, merge and verify a clean current `main`, then run `scripts/release.sh X.Y.Z`. The script refuses detached, dirty, or out-of-date trees and creates an annotated tag.
 
 The build scripts read the latest `v*` tag for `MARKETING_VERSION` and use the commit count for `CURRENT_PROJECT_VERSION`.
 
 ## Project Overview
 
-- **Language**: Pure Objective-C — no Swift, no storyboards, no XIBs
-- **UI**: All programmatic, using `NSLayoutConstraint` anchors (iOS 9+ compatible)
+- **Language**: Pure Objective-C — no Swift or application UI storyboards/XIBs; `LaunchScreen.storyboard` is the sole storyboard
+- **UI**: Application UI is programmatic and uses `NSLayoutConstraint` anchors; `LaunchScreen.storyboard` is the sole storyboard
 - **Networking**: SocketRocket (WebSocket), NSURLSession (REST)
 - **Project config**: XcodeGen (`project.yml`) — the `.xcodeproj` is generated and committed, but should be regenerated via `scripts/regen.sh` after changing `project.yml`
 
@@ -150,8 +151,10 @@ The build scripts read the latest `v*` tag for `MARKETING_VERSION` and use the c
 HADashboard/         App source code
 ├── Auth/            Authentication (OAuth, tokens, keychain)
 ├── Controllers/     View controllers (dashboard, settings)
+├── Integration/     Home Assistant device sensors and remote commands
 ├── Models/          Data models, Lovelace JSON parser
 ├── Networking/      WebSocket, REST, mDNS discovery
+├── Streaming/       Protected RTSP server, per-device Keychain credential, capture, and encoders
 ├── Theme/           Themes, icon mapping, haptics
 └── Views/           All UI — cells, layouts, helpers
 Vendor/              Third-party: SocketRocket, MDI icons, snapshot test framework
@@ -165,6 +168,10 @@ scripts/             Build, deploy, test automation
 
 **Simulator not found** — Open Xcode, go to Settings > Platforms, and install the iOS simulator runtime. The deploy script looks for "iPad Pro 11 M4" by default; set `SIM_IPAD_NAME` in `.env` to match an available simulator.
 
-**Build fails with signing errors** — For simulator builds, signing is disabled automatically. For device builds, you need `APPLE_TEAM_ID` set in `.env`.
+**Build fails with signing errors** — For simulator builds, signing is disabled automatically. Device and Mac Catalyst builds need `APPLE_TEAM_ID` in `.env`. Catalyst also needs either the App Store Connect API-key variables in `.env` or a suitable Apple account signed in to Xcode so automatic provisioning can authorize its Keychain access group.
+
+**iPad 4 accepts port 22 but SSH hangs before the banner** — The 32-bit iOS 10.3.3 h3lix jailbreak is not compatible with the normal OpenSSH daemon even though the package can install and open the port. Use a trusted armv7 Dropbear package/service for h3lix, then retry `scripts/deploy.sh ipad4`. The deploy preserves and reapplies the app's application-identifier entitlement so Keychain credentials survive upgrades.
+
+**`scripts/build.sh rosettasim` rejects Xcode 27** — This is intentional. Run legacy simulator builds on macOS 26 with Xcode 26, or validate the iOS 9 physical-device product with `scripts/build.sh device`.
 
 **Snapshot tests fail immediately** — Make sure you have the iPad (10th generation) + iOS 17.4 simulator runtime installed. Snapshot tests are pixel-exact and depend on a specific device/OS combination.

--- a/Vendor/Lottie/Private/LOTAnimatedSwitch.m
+++ b/Vendor/Lottie/Private/LOTAnimatedSwitch.m
@@ -120,7 +120,7 @@
 - (void)_toggleAndSendActions {
   if (self.isEnabled) {
     #if !TARGET_OS_TV && !TARGET_OS_MACCATALYST
-    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 10.0) {
+    if (@available(iOS 10.0, *)) {
       UIImpactFeedbackGenerator *generator = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleLight];
       [generator impactOccurred];
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -186,7 +186,7 @@
       <p>A native iOS app that renders your Home Assistant Lovelace dashboards. No web views.</p>
       <div class="app-store-section">
         <a href="https://apps.apple.com/gb/app/ha-dash/id6759347912" class="app-store-badge">
-          <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1740009600" alt="Download on the App Store">
+          <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83" alt="Download on the App Store">
         </a>
       </div>
     </div>
@@ -199,13 +199,15 @@
       <ul>
         <li><strong>Native rendering</strong> of HA Lovelace dashboards &mdash; sections, masonry, panel, and sidebar layouts</li>
         <li><strong>Real-time updates</strong> via WebSocket &mdash; entity states update live</li>
-        <li><strong>33 cell types</strong> &mdash; controls, inputs, composite cards, entity detail views</li>
+        <li><strong>Broad card coverage</strong> &mdash; controls, inputs, composite cards, and entity detail views</li>
         <li><strong>Themes</strong> &mdash; Auto, Dark, Light, and Gradient modes</li>
         <li><strong>Kiosk mode</strong> &mdash; hides navigation, prevents sleep, triple-tap top of screen to temporarily show controls</li>
         <li><strong>Demo mode</strong> &mdash; 3 built-in dashboards with simulated entities, no server needed</li>
         <li><strong>Dashboard switcher</strong> &mdash; switch between multiple HA dashboards</li>
+        <li><strong>Local remote controls</strong> &mdash; wake or dim an open kiosk, set brightness, navigate, change appearance or kiosk state, reload, and show notification banners through Home Assistant's WebSocket channel</li>
         <li><strong>mDNS discovery</strong> &mdash; finds Home Assistant servers on your local network</li>
-        <li><strong>Dual auth</strong> &mdash; long-lived access token or full OAuth login flow</li>
+        <li><strong>Three connection modes</strong> &mdash; trusted-network access, long-lived token, or full OAuth login</li>
+        <li><strong>Local camera streams</strong> &mdash; foreground-only, per-device password-protected H.264/AAC on iOS 10.3.3+, with front/rear MultiCam on supported iOS 13+ hardware, concurrent consumers, device-capability quality control, and Home Assistant camera registration</li>
       </ul>
 
       <div class="screenshots">
@@ -224,7 +226,7 @@
       <ul>
         <li>A running Home Assistant instance (local network or remote via HTTPS)</li>
         <li>At least one Lovelace dashboard configured</li>
-        <li>An iPad or iPhone running iOS 9 or later</li>
+        <li>An iPad or iPhone running iOS 9 or later (Local Camera Stream requires iOS 10.3.3+)</li>
       </ul>
       <p>No Home Assistant server? Use <strong>Demo Mode</strong> to explore the app with built-in sample dashboards.</p>
     </section>
@@ -237,7 +239,7 @@
 
     <section id="privacy">
       <h2>Privacy</h2>
-      <p>HA Dashboard does <strong>not</strong> collect, store, or transmit any personal data. The app contains no analytics, tracking, advertising, or telemetry. All communication is directly between your device and your Home Assistant server.</p>
+      <p>HA Dashboard sends no personal data to the developer and contains no analytics, tracking, advertising, or telemetry. It communicates with the Home Assistant infrastructure you configure. Optional camera/microphone streams require a unique device password and go directly to authenticated RTSP clients on your trusted local network, never through a developer relay or cloud media service. RTSP media is not encrypted on the LAN.</p>
       <p><a href="privacy.html">Read the full Privacy Policy &rarr;</a></p>
     </section>
 

--- a/docs/live-camera-streaming-v1.md
+++ b/docs/live-camera-streaming-v1.md
@@ -1,0 +1,336 @@
+# Local Camera and Audio Streaming
+
+## Compatibility boundary
+
+The HA Dashboard app targets iOS 9.0 and is intended to run on iOS 9.3.3 and
+later. Local Camera Stream is a separate optional feature that requires iOS
+10.3.3 or later. Its persisted enable flag is discarded on an unsupported OS,
+and every arm attempt checks the platform again before requesting permission.
+
+Simultaneous front/rear capture uses `AVCaptureMultiCamSession`, so Both appears
+only on compatible iOS 13-or-later hardware. A normal single-camera stream does
+not require MultiCam support. Mac Catalyst is a developer-build target rather
+than part of the iPhone/iPad App Store compatibility claim.
+
+## Media and lifecycle boundary
+
+HA Dashboard hosts its streams in-process. It uses no relay, cloud media
+service, recording service, remote publisher, or third-party media server.
+Turning on **Local Camera Stream** arms RTSP/RTP-over-TCP listeners while the
+dashboard remains visible. No in-app or hidden preview is rendered.
+
+Arming a listener does not turn on the camera or microphone. Capture begins
+only when an RTSP client successfully authenticates and sends a media request
+(`DESCRIBE`), which may occur before that client sends `PLAY`. Merely opening a
+TCP connection, sending `OPTIONS`, or failing authentication does not activate
+capture. Capture stops after the final authenticated media client leaves; the
+armed listener remains ready for the next client. Turning the feature off,
+leaving the foreground, logging out/resetting, losing permission, or a
+listener/capture failure stops listeners and capture.
+
+The enable switch, selected camera mode, and capability-based quality persist.
+Returning to the foreground re-arms a previously enabled feature. Home
+Assistant cannot remotely enable capture or change these app settings.
+
+## Addresses, cameras, and consumers
+
+- The listener binds the exact selected private IPv4 address on the primary
+  `en0` interface (normally Wi-Fi). It does not bind cellular, VPN, CoreDevice,
+  USB, or other host adapters and does not listen on every interface.
+- A single selected camera uses `rtsp://<device>:8554/live`.
+- In Both mode, front uses port 8554 and rear uses port 8555. Each stream carries
+  the same live AAC microphone source and uses the same device credential.
+- RTSP uses interleaved TCP only; UDP `SETUP` is intentionally unsupported.
+- The implementation targets two simultaneous consumers per endpoint. Earlier
+  pre-candidate builds physically demonstrated that count, but exact-candidate
+  acceptance remains pending. The server does not publish a larger contractual
+  client limit. A transiently blocked TCP receiver is protected by an ordered,
+  bounded output queue rather than being disconnected on its first nonblocking
+  `EAGAIN`; a receiver is disconnected if its pending queue reaches 1 MiB or
+  makes no write progress for two seconds.
+- Stream URLs use the device's current local address. Home Assistant must be
+  able to route to it. Use a DHCP reservation; after an address change, re-arm
+  and rerun registration so saved Generic Camera URLs are updated.
+
+## Security boundary
+
+Each device uses the fixed username `hadashboard` and one 32-character,
+unpadded base64url password generated from 24 bytes of secure random data. The
+password is stored as a device-only Keychain item that is available only while
+the device is unlocked; it is not synchronised to another device. Turning the
+stream off retains the credential so clients continue to work after re-arming.
+**Log Out & Reset** deletes it.
+
+The server requires RTSP Digest authentication (MD5 without `qop`, for legacy
+VLC/live555/FFmpeg compatibility) before a connection can run `DESCRIBE`,
+`SETUP`, `PLAY`, or `TEARDOWN`; `OPTIONS` remains public. One valid Digest
+request authenticates that TCP connection while RTSP session/state checks still
+apply to later requests. Every new connection receives a fresh nonce; a client
+that reconnects with a previously verified nonce receives `stale=true` and must
+recompute its Digest response. This access control prevents a client without
+the password from activating capture, but it is not transport encryption: RTSP
+control and interleaved RTP camera/microphone media remain
+**plaintext and unencrypted on the LAN**. A host that obtains the password and
+can reach the listener can receive live media. Use Local Camera Stream only on
+a trusted local network, never forward ports 8554/8555, avoid exposing them
+through a VPN, and turn the feature off when it is not needed.
+
+Settings displays and sensor attributes use bare addresses without
+credentials. Tapping an address copies that bare value. The explicit
+**Protected access > Copy URL with Password** action copies a sensitive value
+such as `rtsp://hadashboard:<password>@<device>:8554/live`. If the clipboard
+value has not changed, it expires after 60 seconds. The item is local-only so
+Universal Clipboard does not propagate it to another device; HA Dashboard also
+clears an unchanged expired value while active or when it next becomes active.
+This leaves enough time to switch to VLC and paste it. Other apps with clipboard
+access may be able to read the credential before it expires. Treat copied URLs
+as passwords. VLC or another receiving client may retain a protected URL in its
+own history or logs; HA Dashboard cannot clear another app's storage.
+
+**Rotate Stream Password** generates a new device password, disconnects current
+viewers, and restarts the protected listeners. The rotation operation completes
+when the local listener re-arms; it does not wait for Home Assistant. While
+**Register with Home Assistant** is enabled, the app then starts asynchronous
+reconciliation of the replacement credential with app-owned camera entries.
+Retryable failures continue while the same stream, registration setting,
+account, and Home Assistant origin remain active. Old URLs stop authenticating,
+and clients or entries added manually must be updated manually. The settings UI
+asks for confirmation before invalidating existing clients.
+
+While capture is active, an always-on-top red **Camera + mic live** indicator
+shows the authenticated media-client count above the dashboard, including in
+kiosk mode. Tapping the indicator immediately stops and disables Local Camera
+Stream. Reported sensor diagnostics separately distinguish raw connections,
+authenticated media clients, and clients that sent `PLAY`.
+
+The listener also limits each endpoint to eight concurrent sockets, caps a
+request at 16 KiB, gives an unauthenticated socket five seconds to authenticate,
+closes an idle authenticated connection after 10 seconds, and closes a
+connection after three invalid-credential attempts. An initial missing
+Authorization header and a verified stale nonce do not consume that failure
+budget. Pending output is capped at 1 MiB per client and must make progress
+within two seconds. These bounds reduce casual resource abuse but do not make
+an exposed listener safe for the public Internet.
+
+The **Mute Camera Audio** setting controls playback of Home Assistant camera
+cards. It does not remove AAC audio from Local Camera Stream; disabling Local
+Camera Stream is the way to stop publishing its microphone audio.
+
+## Capability-based quality and orientation
+
+The slider is built from formats reported by the selected camera. Its label
+shows the selected resolution, frame rate, and estimated H.264 bitrate.
+MultiCam mode uses formats supported by both cameras and caps frame rate for a
+sustainable simultaneous-capture range.
+
+Quality and orientation changes preserve connected RTSP sessions. HA Dashboard
+restarts only capture/encoders, keeps RTP timestamps monotonic, and sends new
+H.264 SPS/PPS plus an IDR so VLC/FFmpeg can reconfigure without reopening the
+listener. Video follows the current interface orientation.
+
+On iOS 10, AVFoundation deactivates `AVCaptureAudioDataOutput` when an app
+selects a photo-equivalent camera `activeFormat`. The legacy single-camera path
+therefore uses capability-checked 640x480/720p/1080p video session presets;
+iOS 11+ and MultiCam keep direct capability formats. Old-device video and
+microphone callbacks use separate serial queues. The live AAC input callback
+also distinguishes temporary exhaustion from permanent end-of-stream so one
+PCM chunk cannot finalize the reusable encoder after its first packet.
+
+VLC 3.x commonly applies about 1000 ms of client-side network cache. For
+latency testing, start VLC with `--network-caching=100 --rtsp-tcp`. Opening a
+network URL starts playback automatically; pressing VLC's play/pause control
+afterward pauses the stream.
+
+## Home Assistant registration
+
+**Register with Home Assistant** is first the opt-in mobile-app registration
+used for device sensors and commands. Once it succeeds, an already armed Local
+Camera Stream immediately starts its camera-entry flow. The app uses the
+logged-in token with Home Assistant's Generic Camera config flow; Home
+Assistant requires an administrator to create or change config entries.
+
+Only config-entry IDs previously saved by this app are reused or updated. The
+app never claims an existing Generic Camera by guessing from its title or host.
+If no saved ID exists, it creates a new entry after Home Assistant validates
+the source. In Both mode it creates named front and rear entries. Leaving Both
+mode does not delete or disable the rear entry on the Home Assistant server;
+remove it there if it is no longer wanted.
+
+The app supplies the bare RTSP source URL, username, password, Digest
+authentication mode, TCP transport, and selected 15/30 fps capture-profile rate
+as separate Generic Camera settings. It tracks a non-secret credential revision
+and the submitted frame rate so, while registration is enabled, rotating a
+password or changing the profile starts asynchronous reconciliation of saved
+entries even when the stream address has not changed. A changed credential,
+profile, camera, address, or device name supersedes an older scheduled retry
+immediately. An app-owned legacy entry missing either marker is forced through
+Home Assistant's options flow rather than accepted unchanged.
+Home Assistant therefore stores the stream credential in its config entry, and
+Home Assistant backups may contain it; protect those backups as you would other
+credentials.
+
+Credential registration uses the configured Home Assistant server URL. HTTPS
+protects the password submission in transit. Automatic registration over HTTP
+proceeds without another per-server prompt only when the configured address is
+loopback, `.local`, IPv4 link-local/RFC1918, or IPv6 link-local/unique-local.
+**HTTP provides no transport encryption: another host able to monitor that LAN
+may recover the camera username and password.** Use it only on a trusted local
+network. Non-local HTTP is never accepted for automatic camera credential
+registration. Same-origin redirect enforcement remains active for both HTTP
+and HTTPS so credentials cannot follow a redirect to another origin.
+
+Generic Camera validation uses a camera-specific 75-second request and
+120-second resource timeout without slowing normal dashboard API calls. Home
+Assistant 2026.8.3's Generic Camera flow starts a temporary HLS stream and waits
+up to its 30-second source timeout for the first HLS part. A roughly 30-second
+attempt therefore means Home Assistant did not obtain usable preview media; a
+healthy iPad 4 validation in this run completed in about 2.9 seconds. After
+each retryable failed attempt, the app waits 2, 4, 8, 16, and 32 seconds, then
+60 seconds between attempts while the same stream, integration, account, and
+Home Assistant origin remain active. These waits begin after the preceding
+attempt ends; they are not an end-to-end completion deadline. The app requests
+deletion of a known failed flow before scheduling its retry and logs cleanup
+failures.
+Disabling registration or the stream, stopping the listener, changing
+account/origin, or full reset cancels in-flight and scheduled work.
+
+If the user is not an administrator, direct RTSP continues to work and a Home
+Assistant administrator can add Generic Camera manually. Use the bare URL,
+username `hadashboard`, the password from between `hadashboard:` and `@` in the
+explicitly copied protected URL, Digest authentication, and TCP transport.
+Camera config-entry IDs, bare URLs, and non-secret credential revisions are
+stored in the app container. The password remains in the device Keychain and,
+after successful registration, the Home Assistant config entry. Camera and
+microphone media never uses the mobile-app webhook, cloudhook, or remote UI
+route.
+
+The existing mobile-app integration reports `sensor.camera_stream` state, bare
+active URLs, selected camera mode, authenticated-media/playing/raw connection
+counts, MultiCam capability, and resolved quality. It never reports the stream
+password. Other opt-in diagnostics may use a Home Assistant Cloud or remote UI
+webhook returned by the user's Home Assistant instance; see the privacy policy
+for the complete data list.
+
+## Release acceptance record
+
+Do not describe the following as release proof until it is completed against
+one exact candidate.
+
+- Candidate commit: _pending_
+- Marketing/build version: _pending_
+- Test date: _pending_
+- Artifact hashes: _pending_
+- iOS 9.3.3/9.3.5 armv7 launch, login, dashboard, Settings, reset: _pending_
+- iOS 9–14 arm64 physical launch: _pending_
+- Both armv7 and arm64 Mach-O minimum versions are 9.0: _pending_
+- Privacy manifest present in iOS and Catalyst bundle locations: _pending_
+- Catalyst H.264/AAC, permissions, login, Settings: _pending_
+- Mini 4 single-camera decode and orientation: _pending_
+- Mini 5 single-camera decode and orientation: _pending_
+- iPhone front/rear/Both concurrent decode: _pending_
+- Two consumers, disconnect capture stop, reconnect restart: _pending_
+- Missing/wrong/correct Digest authentication and no pre-auth capture: _pending_
+- Connection/request/idle/authentication-failure limits: _pending_
+- Keychain persistence, rotation, reset deletion, and clipboard expiry: _pending_
+- Kiosk-visible live indicator and tap-to-stop behavior: _pending_
+- Live quality and rotation without client reconnect: _pending_
+- Home Assistant admin/non-admin credential registration, password-rotation
+  update, and proxy image: _pending_
+- Foreground/background listener shutdown and persisted re-arm: _pending_
+
+### Pre-candidate engineering evidence
+
+On 31 August 2026, dirty development build 1.2.5 (159) produced H.264/AAC
+playback on Catalyst, iPad Mini 4, iPad Mini 5, and iPhone. Two simultaneous
+clients decoded the Mini 5 endpoint; iPhone front and rear MultiCam endpoints
+decoded concurrently; and Home Assistant loaded Catalyst, Mini 4, and iPhone
+Generic Camera entries. A later local rebuild compiled all sources separately
+for armv7 and arm64, produced minimum-iOS-9.0 load commands in both slices, and
+generated a matching two-architecture dSYM. This evidence predates the
+protected-stream implementation, guided media work only, and is **not**
+authentication or acceptance proof for the eventual 1.2.6 commit or IPA.
+
+On 1 September 2026, the later dirty protected-stream source produced a signed
+universal 1.2.5 (159) development app whose executable SHA-256 was
+`a40044432c521cde6ff135d9638a83649662e0cf683f865b3fdc459dfaf96fe7`.
+Both armv7 and arm64 slices and the bundle reported minimum iOS 9.0; the
+signature, privacy manifest, and two-architecture dSYM UUIDs verified. A signed
+Catalyst run passed 19 focused tests, including device-only Keychain behavior,
+Digest gates, strict CSeq/request limits, the fixed unauthenticated deadline,
+and cross-origin redirect/path rejection. Direct protected playback returned
+401 before authentication, then 200 for DESCRIBE, both SETUP tracks, and PLAY;
+the client received H.264 and AAC (148 video and 10 audio packets, first packets
+at 7 ms and 15 ms), the red live indicator appeared during capture, and capture
+stopped after disconnect. An earlier protected build also delivered both tracks
+to two simultaneous authenticated clients.
+
+At that stage this was still pre-candidate evidence: the tree was uncommitted
+and behind `origin/main`; the then-current build still required a separate
+local-HTTP credential exception that had not been approved, so protected HA
+registration/rotation remained pending. The exact app was running on Catalyst,
+upgraded successfully on iPad Mini 4, and installed on the connected iPad Pro;
+the locked Pro could not be launched. Mini 5 accepted the IPA and reported
+build 159, but its MobileDevice installer never returned a completion signal,
+so that upgrade remains unverified. The iPhone remained locked. The iPad 4
+was subsequently upgraded through Dropbear and remained running on iOS 10.3.3
+with normal Home Assistant startup logs and no new crash report. Its Local
+Camera Stream preference was not enabled, so protected capture/playback on that
+device remains a user-driven permission test. This is not release or complete
+physical-device acceptance.
+
+Later on 1 September, an earlier signed dirty Catalyst build passed 35 focused
+streaming/registration tests, including the then-bounded registration retry.
+The final current source passed 37 signed streaming/credential tests and 60
+isolated device-integration/remote-control tests, all with no failures or skips.
+The current suites cover VLC's same-connection
+Digest reuse, stale-nonce reconnect, partial write plus `EAGAIN`, ordered
+H.264/AAC queue drain, slow-client eviction at the output cap, protected
+app-owned Home Assistant entry updates at the selected profile's actual frame
+rate, private-LAN HTTP policy, continuous context-bound retries, immediate
+supersession by a rotated credential, iOS 10 audio-compatible presets, and
+repeated AAC output after temporary live input exhaustion. They also cover the
+audio stop/re-arm queue barrier, WebSocket-only registration migration, the raw
+mobile-push event shape, standard 0–255 brightness payloads, wake/sleep,
+navigation, appearance, kiosk and reload commands. A second Mac on a
+different local subnet deliberately stopped reading for 500 ms, then received
+11,812 H.264 and 727 AAC RTP packets through 15 seconds; both tracks were still
+arriving at the end. Home Assistant updated the existing Catalyst entry in
+place to Digest/TCP and 30 fps, validated the protected stream, and left the
+entity loaded and idle. The rebuilt armv7 and arm64 slices and bundle still
+reported minimum iOS 9.0. This remains development evidence, not an exact clean
+release-candidate result.
+
+The latest dirty fleet artifact is recorded under deploy evidence run
+`20260901T141019Z-23305`, built from rebased commit `044af4c` as build 162.
+Its universal executable SHA-256 is
+`fe58c424626473c0a9b15a2c52f173acf9ca47fbeb1e587022be59e3f87dc3f4`;
+the Catalyst executable is
+`3d7259f8dd2bd9bbda9cd59b837ed1d7009c71bbcfd10af535505b0bc1b5d042`.
+Both universal slices and the bundle report minimum iOS 9.0, and the automatic
+profile covers the five active physical targets. That exact universal bundle
+was installed on iPhone, Mini 5, Mini 4, iPad 4, and iPad Pro. Mini 4 and iPad 4
+launched; Mini 5 reported `InstallComplete`; the locked iPhone and iPad Pro are
+recorded as installed-only successes. Catalyst launched from a single 4.5 MiB
+non-mergeable main executable, so its recorded hash identifies the application
+code rather than Xcode's former 56 KiB debug launcher.
+
+On physical iOS 10.3.3, the final iPad 4 process used the iOS 10-safe 1280x720
+preset and 44.1 kHz mono audio. Home Assistant consumed HLS for 12.613 seconds:
+the master request returned 200, 2/2 playlists and 13/13 media resources
+returned HTTP 200, 7,089,608 media bytes arrived, and there were no fetch
+errors. The
+fresh device session recorded the Digest challenge followed by authenticated
+DESCRIBE 200, both SETUP responses, PLAY 200, first and sustained PCM, first
+H.264 RTP, first AAC RTP, and a graceful TEARDOWN/disconnect. Home Assistant
+still has exactly one loaded `iPad Office Camera` entry and one corresponding
+entity, so registration/relaunch created no duplicate.
+
+The same final iPad 4 build refreshed its old registration to WebSocket-only
+local push and Home Assistant explicitly accepted the channel. A live
+`notify.mobile_app_ipad_office` call delivered `command_screen_on`; the standard
+`command_screen_brightness_level` payload then restored the measured 79%
+brightness. A second brightness command delivered more than 10 seconds later,
+proving confirmations kept the local channel alive. Wake on Touch's one-minute
+state transition is separately covered by deterministic controller/handler
+tests because that option was not enabled on this iPad. This remains a dirty
+development deployment, not the merged/tagged release candidate.

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -111,47 +111,62 @@
   <main class="container">
     <a href="index.html" class="back-link">&larr; Back to HA Dashboard</a>
 
-    <p><strong>Last updated:</strong> February 2026</p>
+    <p><strong>Last updated:</strong> September 2026</p>
 
-    <p>HA Dashboard is a native iOS app that connects to your self-hosted Home Assistant server. This policy explains how the app handles your data.</p>
+    <p>HA Dashboard connects to Home Assistant infrastructure chosen by the user. This policy distinguishes that communication from collection by the app developer.</p>
 
-    <h2>Data Collection</h2>
-    <p>HA Dashboard does <strong>not</strong> collect, store, or transmit any personal data to the developer or any third party. The app contains no analytics, tracking, advertising, or telemetry SDKs.</p>
+    <h2>Developer Data Collection</h2>
+    <p>HA Dashboard does <strong>not</strong> send personal data to the developer and contains no developer analytics, tracking, advertising, telemetry, or crash-reporting SDK. The developer cannot access your Home Assistant credentials, dashboard data, device diagnostics, or camera/microphone media through the app.</p>
 
-    <h2>How the App Works</h2>
+    <h2>Home Assistant Communication</h2>
     <ul>
-      <li>The app connects directly to a Home Assistant server URL that <strong>you</strong> configure.</li>
-      <li>All communication occurs between your device and your Home Assistant server.</li>
-      <li>No data passes through any intermediary servers.</li>
+      <li>The app exchanges authentication, dashboard configuration, entity state, and service-call data with the Home Assistant server URL you configure.</li>
+      <li>If you enable <strong>Register with Home Assistant</strong>, the app sends its generated device ID, device name, model, OS/app versions, battery, brightness, app state, active dashboard, network state, Wi-Fi SSID/BSSID when available, and Local Camera Stream status, bare URLs, camera mode/capability, quality, transport and authentication mode, and authenticated/playing/raw connection counts to your Home Assistant instance. It does not send the stream password as a sensor value.</li>
+      <li>Home Assistant may return a Home Assistant Cloud cloudhook or remote UI URL. Optional diagnostic webhooks may use that user-controlled route. Camera and microphone media never uses it.</li>
+      <li>Remote commands and in-app notification banners use Home Assistant's local WebSocket push channel while the app is open and connected. The app does not register a developer cloud-push URL/token or fall back to a developer push service when that channel is unavailable.</li>
+      <li>Available-storage diagnostics are sent only when the selected webhook route is a local-network address and device registration is enabled.</li>
     </ul>
 
-    <h2>Credentials</h2>
+    <h2>Local Camera and Microphone Stream</h2>
     <ul>
-      <li>Your Home Assistant access token or OAuth credentials are stored locally in the iOS Keychain on your device.</li>
-      <li>Credentials are never transmitted to the developer or any third party.</li>
-      <li>Credentials are only sent to your configured Home Assistant server for authentication.</li>
+      <li>Local Camera Stream is off by default, requires iOS 10.3.3 or later, and requests Camera and Microphone access only after you enable it.</li>
+      <li>While foregrounded, the app arms H.264/AAC RTSP-over-TCP on its selected private primary (<code>en0</code>) address. Capture begins only after an RTSP client successfully authenticates and requests media, not merely because the toggle is on or an unauthenticated client reaches the port.</li>
+      <li>A single selected camera uses port 8554. On supported MultiCam devices, Both mode uses front on 8554 and rear on 8555.</li>
+      <li>Each device uses the fixed RTSP username <code>hadashboard</code> and its own cryptographically generated 32-character password. The password is stored in the platform Keychain as available only while the device is unlocked and is not synchronised to other devices.</li>
+      <li>The listener requires RTSP Digest authentication, but RTSP/RTP media remains plaintext and is <strong>not encrypted on the local network</strong>. A host with the password and network access can receive live camera and microphone media. Use it only on a trusted local network, never forward these ports or expose them through a VPN, and turn it off when not needed.</li>
+      <li>A visible <strong>Camera + mic live</strong> indicator appears above the dashboard, including in kiosk mode, whenever authenticated viewers have activated capture. Tapping it stops and disables Local Camera Stream.</li>
+      <li>Mute Camera Audio affects Home Assistant camera-card playback only. Local Camera Stream includes microphone AAC while viewed.</li>
+      <li>Capture stops after the final authenticated media client disconnects. Listener and capture stop when you disable it, leave the foreground, log out, lose permission, or encounter a failure. The app does not record media, show a hidden preview, capture in the background, or accept remote commands that enable capture.</li>
+    </ul>
+
+    <h2>Credentials and Local Storage</h2>
+    <ul>
+      <li>Home Assistant tokens are stored in the platform Keychain. Developer deployment values may bootstrap credentials once; persisted bootstrap values are removed after migration.</li>
+      <li>The Local Camera Stream password remains in the device-only Keychain when the stream is turned off. Rotating it disconnects current viewers and invalidates manually saved URLs. <strong>Log Out &amp; Reset</strong> deletes it; a new password is generated if the feature is used again.</li>
+      <li>The stream address shown in Settings and reported as a sensor attribute contains no credentials. The explicit <strong>Copy URL with Password</strong> action puts a sensitive connection URL on the system clipboard as a local-only item, so Universal Clipboard does not propagate it to another device. The app gives the system a 60-second expiration date and also clears an unchanged expired value itself while active or when it next becomes active. Other apps with clipboard access may be able to read the credential before it expires. A receiving RTSP client may retain a protected URL in its own history or logs; remove it there when no longer needed.</li>
+      <li>Preferences, cached Home Assistant state, stream mode/quality, and saved config-entry IDs and non-secret credential revisions remain in the app container.</li>
+      <li>When camera registration is enabled, Home Assistant stores Generic Camera entries with the bare RTSP URLs, username, and password on your server. Password rotation completes locally after the protected listener re-arms and does not wait for Home Assistant. While <strong>Register with Home Assistant</strong> remains enabled, the app then starts asynchronous reconciliation of the replacement credential through Home Assistant's camera config flow. It updates only entries whose IDs it saved, or creates a new entry when it has no saved ID; retryable failures continue while the same stream, registration setting, account, and Home Assistant origin remain active. Manually configured or unowned entries must be updated manually. Home Assistant backups may therefore contain the stream password; protect them as you would other Home Assistant credentials.</li>
+      <li>Camera registration sends the username and password to the configured Home Assistant URL using that server connection. HTTPS protects that submission in transit. For a loopback, <code>.local</code>, link-local, RFC1918, or IPv6 unique-local Home Assistant address, automatic registration may instead use HTTP without another per-server prompt. <strong>HTTP provides no transport encryption: another host able to monitor that LAN may recover the camera username and password.</strong> Use this only on a trusted local network. Non-local HTTP is never accepted for automatic camera credential registration.</li>
+      <li>Live camera and microphone media is not written to the app container, Photos, iCloud, or a developer service.</li>
     </ul>
 
     <h2>Local Network Access</h2>
-    <p>The app uses local network access (mDNS/Bonjour) to discover Home Assistant servers on your network. This requires the Local Network permission on iOS. The discovery data does not leave your device.</p>
+    <p>The app uses Bonjour/mDNS to discover Home Assistant and may host the optional RTSP listener. iOS and iPadOS 14 or later request Local Network permission; earlier supported releases do not show that system permission. Discovery results stay on the device.</p>
 
-    <h2>Cookies and Web Tracking</h2>
-    <p>The app does not use cookies, web views, or any form of web-based tracking.</p>
+    <h2>User Controls and Retention</h2>
+    <p>Turning off Register with Home Assistant stops reporting and removes local webhook credentials. Log Out &amp; Reset clears local Home Assistant and stream credentials, registration identity, preferences, cached Home Assistant state/history, local logs, and stream configuration. Devices and Generic Camera entries, including their saved stream credentials, remain in Home Assistant until you remove them there.</p>
 
-    <h2>Data Storage</h2>
-    <p>All app data (server configuration, dashboard preferences, cached entity states) is stored locally on your device. No data is synced to cloud services.</p>
-
-    <h2>Third-Party Services</h2>
-    <p>The app does not integrate with any third-party services, SDKs, or APIs beyond your own Home Assistant server.</p>
+    <h2>Cookies, Tracking, and Third-Party SDKs</h2>
+    <p>The app does not use cookies, advertising identifiers, tracking, web analytics, or third-party analytics/advertising SDKs. Home Assistant and optional Home Assistant Cloud routes are services configured by the user, not developer collection services.</p>
 
     <h2>Children's Privacy</h2>
-    <p>The app does not knowingly collect any data from anyone, including children.</p>
+    <p>The developer does not knowingly collect data from anyone, including children.</p>
 
     <h2>Changes to This Policy</h2>
     <p>If this policy changes, the updated version will be published at this URL.</p>
 
     <h2>Contact</h2>
-    <p>For questions about this privacy policy, <a href="https://github.com/ha-dashboard/ios-app/issues/new?labels=question">open an issue</a> on the GitHub repository.</p>
+    <p>For privacy questions, <a href="https://github.com/ha-dashboard/ios-app/issues/new?labels=question">open a GitHub issue</a>. A separate non-GitHub support address has not yet been published.</p>
   </main>
 
   <footer>

--- a/docs/releases/v1.2.6-github.md
+++ b/docs/releases/v1.2.6-github.md
@@ -1,0 +1,93 @@
+# HA Dashboard 1.2.6
+
+These are the public notes for the verified v1.2.6 tag workflow.
+
+## Highlights
+
+- Added foreground-only, client-gated H.264/AAC RTSP streaming on iOS 10.3.3+;
+  the same source also supports the developer-only Mac Catalyst build.
+- Added a unique generated stream password on every device, RTSP Digest
+  authentication, password rotation, and an explicit sensitive-URL copy action.
+- Fixed sandboxed Catalyst Keychain provisioning and made Register with Home
+  Assistant retain its enabled intent while registration reconnects or retries.
+- Added front/rear camera selection and simultaneous MultiCam streams on
+  supported iOS 13+ hardware.
+- Added support for concurrent viewers, capability-based quality controls, and
+  orientation/quality changes without reopening connected clients.
+- Added Home Assistant Generic Camera config flows for administrator accounts
+  with protected credential registration/rotation, plus credential-free
+  camera-stream diagnostics through the optional mobile-app integration. Saved
+  entries use Digest/TCP and the selected profile's actual 15/30 fps rate.
+- Added bounded ordered TCP output buffering and stale-Digest reconnect handling
+  so remote VLC clients survive transient backpressure instead of starting and
+  immediately stopping.
+- Added longer 75/120-second Home Assistant camera-flow timeouts and continuous,
+  cancellable, context-bound retries capped at a 60-second delay, plus iOS 10
+  audio compatibility so legacy hardware can finish protected registration and
+  keep producing AAC after the first packet.
+- Added an always-visible authenticated-media-client indicator above dashboard and
+  kiosk screens, with a tap-to-stop control.
+- Fixed Home Assistant `command_screen_on` for an already-open kiosk so it uses
+  Wake on Touch and restarts the one-minute timer, resolving #13.
+- Kept remote controls local to Home Assistant's WebSocket channel and added
+  the documented 0–255 brightness payload; older registrations are refreshed
+  to remove placeholder cloud-push fields.
+- Added a privacy manifest and clearer camera, microphone, local-network,
+  credential, diagnostic-data, and reset behavior.
+- Updated the Xcode 26/27 pipeline so both armv7 and arm64 device slices carry
+  a true iOS 9.0 minimum, with matching universal dSYM verification.
+- Improved CoreDevice, MobileDevice, jailbroken SSH, and validated USB
+  deployment paths.
+
+## Compatibility
+
+The dashboard app targets iOS 9.0 and supports armv7 and arm64. Local Camera
+Stream requires iOS 10.3.3 or later. Both-camera mode additionally requires
+MultiCam-capable iOS 13+ hardware.
+
+Legacy x86_64 simulator testing requires macOS 26 with Xcode 26; macOS/Xcode 27
+cannot build and boot those legacy simulator runtimes. Physical iOS 9 device
+builds remain supported through the direct-clang universal pipeline.
+
+## Remote control
+
+When **Register with Home Assistant** is enabled and HA Dashboard remains open
+and connected, `notify.mobile_app_<device>` commands can wake or dim the screen,
+set brightness, switch dashboards or views, change theme/gradient/kiosk state,
+and reload. Normal messages appear as in-app banners. Remote wake follows the
+same state transition as a physical touch and restarts Wake on Touch's
+one-minute timer.
+
+Commands use Home Assistant's local WebSocket push channel. They cannot unlock
+the device, launch a closed/backgrounded app, or remotely enable Local Camera
+Stream. See the support guide for payload examples. Resolves #13.
+
+## Local-stream security boundary
+
+Each device uses the fixed username `hadashboard` and its own generated
+32-character password, stored in its device-only Keychain. RTSP Digest
+authentication is required before a media request can activate camera and
+microphone capture. Settings copies bare addresses by default; **Copy URL with
+Password** is an explicit sensitive action. While **Register with Home
+Assistant** is enabled, password rotation completes locally after the listener
+re-arms and does not wait for Home Assistant; the app then starts asynchronous
+reconciliation of entries it owns, with transient failures retried while the
+same context remains active.
+Credential registration uses HTTPS when configured. A loopback, `.local`,
+link-local, RFC1918, or IPv6 unique-local Home Assistant address may instead use
+HTTP automatically; non-local HTTP is refused. **Local HTTP has no transport
+encryption, so another host able to monitor that LAN may recover the camera
+username and password. Use it only on a trusted local network.**
+
+RTSP is TCP-only, but its control and camera/microphone media remain plaintext
+and unencrypted on the LAN. Digest is access control, not transport encryption.
+Anyone with the password and network access to port 8554 (or 8555 in Both mode)
+can receive live media while HA Dashboard is foregrounded. Use the feature only
+on a trusted local network, never forward those ports, and turn it off when it
+is not needed. Camera/microphone media uses no developer relay or cloud media
+service.
+
+See the [streaming contract](https://github.com/ha-dashboard/ios-app/blob/main/docs/live-camera-streaming-v1.md),
+[privacy policy](https://ha-dashboard.github.io/ios-app/privacy.html), and
+[support guide](https://ha-dashboard.github.io/ios-app/support.html) for
+operational details and limitations.

--- a/docs/releases/v1.2.6.md
+++ b/docs/releases/v1.2.6.md
@@ -1,0 +1,266 @@
+# HA Dashboard 1.2.6 Release Notes
+
+Status: **Approved scope for the v1.2.6 GitHub release and TestFlight build.**
+This release does not create or submit a production App Store version.
+
+These notes are curated from the source shipped as App Store build 158, not
+only from the older `v1.2.5` Git tag. Markdown/template rendering, conditional
+rows, alarm labels, and the other changes already present in build 158 are
+therefore not repeated as new 1.2.6 features.
+
+## App Store — What's New
+
+New local camera streaming for Home Assistant:
+
+- Turn an iPhone or iPad into a foreground-only H.264/AAC RTSP stream.
+- Choose the front or rear camera, or use both on supported devices.
+- Connect two simultaneous viewers and adjust device-supported quality while the
+  stream remains open.
+- Protect every device with its own generated stream password and rotate it
+  from the app when needed.
+- Home Assistant administrators can add the active streams and their protected
+  credentials as Generic Camera entries from the app.
+- See an always-visible indicator whenever camera and microphone capture is
+  active, including over a kiosk dashboard, and tap it to stop streaming.
+- Camera orientation now follows the device.
+- Home Assistant's screen-on command now wakes an open kiosk dashboard through
+  the same path as Wake on Touch and restarts its one-minute timer (issue #13).
+- Registered, open dashboards also support local WebSocket commands for display
+  brightness/sleep, dashboard and view navigation, appearance, kiosk mode, and
+  reload.
+
+Streaming is off by default, requires Camera and Microphone permission, and
+stops when HA Dashboard leaves the foreground. Authenticated access uses the
+fixed username `hadashboard` and a unique password generated on each device.
+RTSP media remains plaintext and is not encrypted on the LAN; use it only on a
+trusted local network and do not forward ports 8554 or 8555.
+
+The dashboard app remains compatible with iOS 9.3.3 and later. Local Camera
+Stream requires iOS 10.3.3 or later, and simultaneous front/rear capture
+requires supported iOS 13-or-later hardware.
+
+## App Store — Product Description Replacement
+
+Control your smart home from a native iPhone and iPad app. HA Dash renders Home
+Assistant dashboards without an embedded web view, giving wall-mounted legacy
+iPads and current mobile devices a fast, kiosk-friendly interface.
+
+Features include native Home Assistant dashboard layouts and cards, real-time
+WebSocket updates, kiosk mode, Bonjour discovery, trusted-network/token/OAuth
+login, themes, dashboard switching, graphs, climate controls, camera cards,
+media controls, device registration, local WebSocket kiosk controls, and a
+built-in Demo Mode.
+
+On iOS 10.3.3 or later, the optional Local Camera Stream can expose foreground
+H.264/AAC RTSP from the device's front or rear camera. Supported iOS 13+
+hardware can expose both cameras at once. Capture starts only when a reachable
+viewer authenticates with the device's generated password and requests the
+stream. Capture stops after the final authenticated viewer leaves or the app
+leaves the foreground. An always-visible live indicator appears while capture
+is active. RTSP media is not encrypted, so use it only on a trusted local
+network and never forward its ports.
+
+HA Dash communicates with the Home Assistant infrastructure you configure.
+Optional device diagnostics may use a Home Assistant Cloud or remote UI
+webhook returned by your server. Camera and microphone media never passes
+through a developer relay or cloud media service. The developer receives no
+personal data, analytics, tracking, telemetry, or advertising data from the
+app.
+
+Requires a Home Assistant server accessible from the device, or use Demo Mode
+without a server. The dashboard app supports iOS 9.3.3 and later; Local Camera
+Stream requires iOS 10.3.3 or later.
+
+## TestFlight — What to Test
+
+Please test Local Camera Stream on a trusted network:
+
+1. Enable the feature and grant Camera and Microphone access.
+2. Confirm the displayed address and its normal tap-to-copy action contain no
+   credentials. Open **Protected access**, choose **Copy URL with Password**,
+   and open that sensitive URL with VLC's **Open Network Stream** or FFmpeg.
+   VLC starts playback automatically; pressing its play/pause control after the
+   stream opens pauses it.
+3. Confirm a bare URL and an incorrect password receive an authentication
+   challenge without activating camera/microphone capture. Confirm the
+   protected URL provides video and audio to two simultaneous clients.
+4. While streaming, confirm the red **Camera + mic live** indicator remains
+   visible over settings, the dashboard, and kiosk mode. Tap it and confirm it
+   immediately stops capture and disables the stream.
+5. Test Front, Rear, and Both on a MultiCam-capable device. A single selected
+   camera uses port 8554; Both uses front on 8554 and rear on 8555.
+6. Move the quality slider and rotate the device without reconnecting clients.
+7. Disconnect every viewer and confirm the camera/microphone indicators turn
+   off. Reconnect and confirm capture restarts. Background the app and confirm
+   both listeners stop.
+8. Enable Register with Home Assistant using an administrator account and
+   confirm the Generic Camera entries load with Digest authentication, TCP
+   transport, and the selected stream profile's actual frame rate. Rotate
+   the password, confirm current viewers disconnect and the old URL fails, then
+   confirm local rotation/re-arm completes without waiting for Home Assistant.
+   Watch Settings show asynchronous reconciliation, then confirm Home Assistant
+   keeps the same entry ID and that its proxy and the newly copied direct URL
+   reconnect successfully.
+   Confirm a non-admin receives a clear error without breaking direct RTSP.
+   With loopback, `.local`, link-local, RFC1918, and IPv6 unique-local HTTP Home
+   Assistant URLs, confirm registration proceeds without a separate consent
+   prompt. Confirm non-local HTTP remains blocked and HTTPS remains allowed.
+   Temporarily make validation unavailable and confirm isolated 75-second
+   request/120-second resource limits. After each retryable failed attempt,
+   confirm delays of 2, 4, 8, 16, and 32 seconds, then 60 seconds between
+   attempts while the same stream, registration setting, account, and origin
+   remain active. Restore validation and confirm registration completes without
+   retoggling.
+9. Confirm the password survives disabling/re-enabling and app relaunch.
+   Confirm the protected URL remains available after switching to an RTSP
+   client, is not propagated through Universal Clipboard, and an unchanged
+   value expires after 60 seconds. Confirm sensor attributes/logs contain no
+   password and Log Out & Reset deletes the local stream credential.
+10. With HA Dashboard open and connected, test `command_screen_on`,
+   `command_screen_off`, standard `command_screen_brightness_level` with
+   `data.command` from 0–255, dashboard/view navigation, theme/gradient/kiosk
+   changes, reload, and a normal notification banner. Confirm screen-on follows
+   Wake on Touch and restarts its one-minute timer. Background or close the app
+   and confirm Home Assistant reports that local push is unavailable rather
+   than using a developer cloud-push fallback.
+11. On iOS 9.3.3/9.3.5, verify launch, login, dashboard rendering, Settings,
+   kiosk mode, and logout/reset. Confirm Local Camera Stream remains disabled
+   and never requests Camera or Microphone permission.
+
+Also verify that the Home Assistant host can route to the displayed device
+address. A DHCP reservation is recommended so Generic Camera URLs do not
+become stale when the device's address changes.
+
+## Technical changelog
+
+- Added client-gated H.264/AAC RTSP-over-TCP streaming on iOS 10.3.3+ and Mac
+  Catalyst, with no relay, cloud media service, recording, or hidden preview.
+- Added front/rear selection and simultaneous MultiCam tracks on supported
+  iOS 13+ hardware.
+- Added multiple concurrent consumers and in-session quality/orientation
+  updates with fresh SPS/PPS and keyframes.
+- Added per-device RTSP credentials: fixed username `hadashboard`, a
+  cryptographically generated 32-character password stored in the device-only
+  Keychain, and Digest authentication before media requests activate capture.
+- Added the Catalyst Keychain access-group entitlement and API-key automatic
+  provisioning so its sandboxed build can persist Home Assistant and stream
+  credentials reliably.
+- Added bare-address copy by default, an explicit auto-cleared sensitive URL
+  clipboard action, confirmed password rotation, and credential deletion on
+  Log Out & Reset.
+- Added authenticated Home Assistant Generic Camera config flows using the
+  logged-in administrator token, with separate bare URL, Digest username and
+  password fields, TCP transport, and the selected 15/30 fps profile rate. While
+  registration is enabled, credential rotation or a frame-rate/profile change
+  starts asynchronous reconciliation of app-owned entries without blocking the
+  local stream operation.
+- Added an ordered 1 MiB per-client RTSP output queue with write-readiness
+  flushing, so a remote VLC receiver is not disconnected on the first transient
+  nonblocking socket backpressure event.
+- Added verified stale-nonce Digest challenges for reconnecting VLC/FFmpeg
+  clients while retaining a fresh nonce and full authentication on every new
+  TCP connection.
+- Gave camera config flows isolated 75-second request/120-second resource
+  limits plus continuous cancellable retries after 2/4/8/16/32 seconds, capped
+  at 60 seconds thereafter, best-effort failed-flow cleanup, immediate
+  supersession when the credential/profile/address changes, and exact
+  cancellation on stream/integration/account/origin/reset changes.
+- Kept microphone capture active on iOS 10 with video session presets and a
+  dedicated audio callback queue, and prevented temporary live PCM exhaustion
+  from finalizing the reusable AAC converter after its first packet.
+- Allowed automatic camera credential registration over loopback, `.local`,
+  link-local, RFC1918, and IPv6 unique-local HTTP servers without a redundant
+  per-origin prompt, while continuing to refuse non-local HTTP.
+- Blocked cross-origin HTTP redirects and absolute cross-origin API paths for
+  login, token-refresh, device-registration, and config-flow requests so a
+  redirect cannot forward credentials beyond the configured origin.
+- Bound camera config flows to the active Home Assistant account/origin and
+  cancelled in-flight requests and scheduled retries on server changes, stream
+  disable, or full reset so in-memory credentials and late callbacks cannot
+  outlive the active account or registration intent.
+- Added camera-stream diagnostics to the optional mobile-app integration.
+- Kept the Register with Home Assistant switch tied to persisted user intent,
+  with incomplete registration shown explicitly and retried after reconnect.
+- Added client-gated capture, foreground shutdown, exact-interface listener
+  binding, and updated camera/microphone/local-network disclosures.
+- Added an always-on-top authenticated-media-client indicator with a tap-to-stop
+  control, plus bounded RTSP request, connection, idle, and failed-auth limits.
+- Fixed Home Assistant remote screen-on handling for an already-open kiosk
+  dashboard so it uses the Wake on Touch path and restarts the one-minute timer,
+  resolving issue #13. Existing local WebSocket controls cover screen sleep and
+  brightness, dashboard/view navigation, appearance, kiosk mode, reload, and
+  in-app notification banners.
+- Made mobile-app notification registration WebSocket-only, refreshing older
+  registrations to remove placeholder cloud-push fields; standard brightness
+  commands now accept Home Assistant's documented `data.command` 0–255 payload.
+- Added a privacy manifest for app-only defaults, in-app elapsed-time logging,
+  and user-approved local display of available storage.
+- Added true iOS 9 minimum load commands to both armv7 and arm64 slices when
+  building with Xcode 27 plus Xcode 13 SDK stubs.
+- Forced the legacy armv7 slice to ARM instruction mode and added entry-mode
+  gates because Xcode 27 can drop Thumb bits from `LC_MAIN` and Objective-C IMP
+  relocations, which otherwise crashes iOS 10 before application startup.
+- Improved CoreDevice, MobileDevice, jailbroken SSH, and USB deployment safety,
+  including preserving the iPad 4 application/Keychain identity through ldid.
+
+## Known boundaries
+
+- Local Camera Stream is foreground-only and cannot launch, unlock, or capture
+  while HA Dashboard is backgrounded.
+- RTSP is TCP-only and requires per-device Digest credentials, but control and
+  media remain plaintext and unencrypted on the LAN. Anyone with the password
+  and access to the armed device ports can receive camera and microphone media.
+- Digest uses MD5 without `qop` for compatibility with legacy RTSP clients. It
+  is access control, not modern encrypted transport; do not expose the listener
+  to the Internet or an untrusted network.
+- A receiver whose ordered pending output reaches 1 MiB or stops making write
+  progress for two seconds is disconnected to bound memory and live latency.
+- Home Assistant camera creation requires an administrator. Leaving Both mode
+  does not delete the previously created rear-camera entry from Home Assistant;
+  remove it there if it is no longer wanted.
+- Home Assistant stores the camera username and password in its Generic Camera
+  entry, so Home Assistant backups may contain the stream password.
+- Camera registration sends the credential over the configured Home Assistant
+  HTTPS route or automatically over a loopback, `.local`, link-local, RFC1918,
+  or IPv6 unique-local HTTP route. Local HTTP has no transport encryption, so a
+  host able to monitor that LAN may recover the camera username and password.
+- Stream URLs contain the device's current local address and do not update a
+  Home Assistant entry until the app re-arms and runs its registration flow.
+- The Mute Camera Audio setting controls playback of Home Assistant camera
+  cards. It does not remove AAC audio from Local Camera Stream.
+
+## Release decision and evidence
+
+The owner approved v1.2.6 for a GitHub release and TestFlight setup. Before the
+annotated tag is created, the tag operator must verify that the feature branch
+is merged into current `origin/main`, the exact merged-main CI run passes, the
+tree is clean, and the derived build number is greater than shipped build 158.
+The guarded `scripts/release.sh` enforces the branch, cleanliness, remote-main,
+notes, and tag-existence checks.
+
+Completed development evidence is recorded in
+`docs/live-camera-streaming-v1.md`: signed focused streaming/credential tests,
+Digest gates, Keychain and clipboard behavior, continuous HA reconciliation,
+dual minimum-iOS-9.0 slices, matching dSYM UUIDs, privacy manifests, Catalyst,
+iPhone, Mini 4, iPad 4 and Home Assistant H.264/AAC acceptance, plus exact
+install evidence for Mini 5 and iPad Pro.
+
+Accepted release boundaries are stated rather than presented as completed
+tests: no physical iOS 9 device was available for this candidate; Mini 5 needed
+a user restart after Guided Access and iPad Pro was installed but locked; a
+non-GitHub support address is still unavailable. Compatibility is instead
+guarded by iOS 9 load commands, availability-error compilation, iOS-safe APIs,
+and the documented Local Camera Stream iOS 10.3.3 runtime gate.
+
+After tagging, the operator must verify the exact build reaches `VALID` in App
+Store Connect, apply the TestFlight text above, add it to external `HA Testers`,
+complete beta review if required, and verify external testing. This post-tag
+verification is not a prerequisite that can be truthfully completed before the
+upload exists.
+
+## Release-policy references
+
+- [Apple: Describing use of required-reason APIs](https://developer.apple.com/documentation/bundleresources/describing-use-of-required-reason-api)
+- [Apple: Adding a privacy manifest](https://developer.apple.com/documentation/bundleresources/adding-a-privacy-manifest-to-your-app-or-third-party-sdk)
+- [Apple: App privacy details and the definition of collection](https://developer.apple.com/app-store/app-privacy-details/)
+- [Apple: AVCaptureMultiCamSession](https://developer.apple.com/documentation/avfoundation/avcapturemulticamsession)

--- a/docs/rosettasim-deployment.md
+++ b/docs/rosettasim-deployment.md
@@ -1,85 +1,107 @@
 # RosettaSim Legacy Simulator Deployment
 
-Deploying HA Dashboard to legacy iOS simulators (iOS 9.3–14.x) running under RosettaSim (x86_64).
+RosettaSim runs x86_64 iOS 9–14 simulator runtimes on a compatible host. It is
+useful for legacy UI testing, but it is not the build path for the universal
+physical-device product.
 
-## Prerequisites
+## Host support
 
-- **RosettaSim** installed with `rosettasim-ctl` built at `~/Projects/rosetta/src/build/rosettasim-ctl`
-- **Xcode 26** at `/Applications/Xcode.app`
-- Legacy iOS simulator runtimes installed (iOS 9.3, 10.3, etc.)
-- `coreutils` installed (`brew install coreutils`) for the `gtimeout` binary
+| Host | Status |
+|------|--------|
+| macOS 26 + Xcode 26 | Supported legacy build/install/boot path |
+| Xcode 27 | Unsupported: xcodebuild rejects simulator targets below iOS 15 |
+| macOS 27 | Unsupported: CoreSimulator cannot construct an x86 launch host for the legacy runtime |
 
-## Building
+`scripts/build.sh rosettasim` detects Xcode 27 and fails with this explanation
+instead of producing a misleading partial artifact. The physical-device path
+remains available on Xcode 27: `scripts/build.sh device` compiles armv7 and
+arm64 directly with an iOS 9 minimum.
+
+## Prerequisites on a supported host
+
+- macOS 26
+- Xcode 26 selected through `/Applications/Xcode.app` or `XCODE_PATH`
+- RosettaSim with `rosettasim-ctl` built at
+  `~/Projects/rosetta/src/build/rosettasim-ctl`
+- The required legacy simulator runtime installed with RosettaSim's installer
+- `coreutils` (`brew install coreutils`) for `gtimeout`
+
+## Build
 
 ```bash
 scripts/build.sh rosettasim
 ```
 
-This produces an x86_64 simulator binary at:
-```
+The output is an x86_64 app at:
+
+```text
 build/rosettasim/Build/Products/Debug-iphonesimulator/HA Dashboard.app
 ```
 
-Uses standard Xcode 26 xcodebuild with `MERGED_BINARY_TYPE=none`. This is critical — the default Debug configuration uses mergeable libraries (stub binary + debug dylib) which crashes on legacy runtimes due to libdispatch incompatibility.
+The build uses `MERGED_BINARY_TYPE=none` and `ENABLE_DEBUG_DYLIB=NO`. Without
+those settings, modern Xcode's stub executable/debug-dylib layout crashes in
+legacy libdispatch before the app launches.
 
-## Installing and Launching
+## Discover, install, and launch
 
-Use `rosettasim-ctl` for all legacy simulator operations. Do **not** use `xcrun simctl install/launch/terminate` — they hang on legacy runtimes.
+Do not copy a saved simulator UDID from documentation; recreating a device
+changes it. Discover the current IDs first:
 
 ```bash
+export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
 RSCTL=~/Projects/rosetta/src/build/rosettasim-ctl
 APP="build/rosettasim/Build/Products/Debug-iphonesimulator/HA Dashboard.app"
-UDID="D9DCA298-C3D2-4B68-9501-E5279A1B96B6"  # iOS 9.3 iPad Pro
 
-$RSCTL boot $UDID
-$RSCTL install $UDID "$APP"
-$RSCTL launch $UDID com.hadashboard.app
+$RSCTL list
+$RSCTL boot <legacy-udid>
+$RSCTL install <legacy-udid> "$APP"
+$RSCTL launch <legacy-udid> com.hadashboard.app
 ```
 
-## rosettasim-ctl Commands
+Standard `xcrun simctl install`, `launch`, and `terminate` may hang against
+legacy runtimes. Use `rosettasim-ctl` for those operations.
+
+Useful commands include:
 
 | Command | Description |
 |---------|-------------|
-| `list` | List all devices with status (marks legacy runtimes) |
-| `boot <UDID>` | Boot device |
-| `shutdown <UDID\|all>` | Shutdown device(s) |
-| `install <UDID> <path.app>` | Install app (MobileInstallation for legacy) |
-| `launch <UDID> <bundle-id>` | Launch app (SpringBoard injection for legacy) |
-| `terminate <UDID> <bundle-id>` | Kill running app |
-| `screenshot <UDID> <output>` | Screenshot from daemon framebuffer |
-| `listapps <UDID>` | List installed apps |
-| `appinfo <UDID> <bundle-id>` | JSON app info |
-| `status <UDID>` | Full device status with daemon/IO info |
-| `privacy <UDID> grant <service> <bundle-id>` | Grant TCC permissions |
+| `list` | Show current runtimes and devices |
+| `status <UDID>` | Show the selected device/runtime state |
+| `boot <UDID>` | Boot a supported legacy device |
+| `shutdown <UDID\|all>` | Shut down devices |
+| `install <UDID> <app>` | Install through legacy MobileInstallation |
+| `launch <UDID> <bundle-id>` | Launch through the legacy SpringBoard path |
+| `terminate <UDID> <bundle-id>` | Stop the app |
+| `screenshot <UDID> <output>` | Capture the legacy framebuffer |
+| `privacy <UDID> grant <service> <bundle-id>` | Set a simulator TCC grant |
 
-For native runtimes (iOS 16+), `rosettasim-ctl` transparently passes through to `xcrun simctl`.
+## iOS 9.3.3 acceptance
 
-## Device UDIDs
-
-| Device | iOS | UDID |
-|--------|-----|------|
-| iPad Pro | 9.3 | `D9DCA298-C3D2-4B68-9501-E5279A1B96B6` |
-| iPad (5th gen) | 10.3 | `261D4B19-BE81-42F2-A646-3EF6F668DD84` |
-| iPad (10th gen) | 16.4 | `87E82E85-7B26-480C-B5A2-6D68403CF920` |
-| iPad (A16) | 26.2 | `6937E3CC-604A-4E46-A356-17E82351093A` |
-
-## Native Simulators (iOS 16+)
-
-```bash
-scripts/build.sh sim
-xcrun simctl install <UDID> "build/sim/.../HA Dashboard.app"
-xcrun simctl launch <UDID> com.hadashboard.app
-```
-
-Or use `scripts/deploy.sh sim` which handles build + install + launch.
+A successful RosettaSim run is useful evidence but does not replace physical
+armv7/arm64 validation. For a release candidate, also inspect both Mach-O
+slices for minimum iOS 9.0 and launch the exact universal artifact on reachable
+legacy hardware. Local Camera Stream must remain disabled below iOS 10.3.3 and
+must not request Camera or Microphone permission there.
 
 ## Troubleshooting
 
-### "BUG in libdispatch" crash on launch
-The app was built without `MERGED_BINARY_TYPE=none`. Rebuild with `scripts/build.sh rosettasim`.
+### Deployment target must be iOS 15 or later
 
-### `rosettasim-ctl` commands fail with "timeout not found"
-Install coreutils: `brew install coreutils`. The tool resolves `gtimeout` from `/opt/homebrew/bin/`.
+Xcode 27 is selected. Move the test to a macOS 26/Xcode 26 host; do not patch
+the app's plist and call that an iOS 9 simulator build, because the executable
+load command would still require iOS 15.
 
-### `xcrun simctl install` hangs on legacy sim
-Use `rosettasim-ctl install` instead. Standard simctl hangs on iOS 7–14 runtimes.
+### Runtime unavailable or liblaunch_sim could not be opened
+
+First confirm the host is macOS 26. On macOS 27 this is an architectural host
+block, not a missing app setting. On a supported host, reinstall the legacy
+runtime with RosettaSim's installer and re-run `rosettasim-ctl list`.
+
+### BUG in libdispatch at launch
+
+Rebuild through `scripts/build.sh rosettasim`; the app was likely built with a
+mergeable debug dylib.
+
+### timeout not found
+
+Install coreutils: `brew install coreutils`.

--- a/docs/support.html
+++ b/docs/support.html
@@ -159,13 +159,13 @@
       <div class="support-card">
         <h3>Report a Bug</h3>
         <p>Found something that isn't working correctly? Let us know by opening a bug report on GitHub. Please include the steps to reproduce the issue and your device/iOS version.</p>
-        <a href="https://github.com/ha-dashboard/ios-app/issues/new?labels=bug&template=bug_report.md" class="btn">Open a Bug Report</a>
+        <a href="https://github.com/ha-dashboard/ios-app/issues/new?labels=bug" class="btn">Open a Bug Report</a>
       </div>
 
       <div class="support-card">
         <h3>Request a Feature</h3>
         <p>Have an idea for a new feature or an improvement? Open a feature request on GitHub and describe what you'd like to see.</p>
-        <a href="https://github.com/ha-dashboard/ios-app/issues/new?labels=enhancement&template=feature_request.md" class="btn">Request a Feature</a>
+        <a href="https://github.com/ha-dashboard/ios-app/issues/new?labels=enhancement" class="btn">Request a Feature</a>
       </div>
 
       <div class="support-card">
@@ -185,7 +185,7 @@
 
     <div class="faq">
       <h3>How do I connect to my Home Assistant server?</h3>
-      <p>Open the app and tap Settings. Enter your Home Assistant server URL (e.g., <code>http://homeassistant.local:8123</code>) and either a long-lived access token or log in via OAuth.</p>
+      <p>Open the app and tap Settings. Enter your Home Assistant server URL (e.g., <code>http://homeassistant.local:8123</code>). Use trusted-network access when your Home Assistant configuration permits this device, paste a long-lived access token, or log in through OAuth.</p>
 
       <h3>The app can't find my server on the network</h3>
       <p>Make sure your device is on the same network as your Home Assistant server. The app uses mDNS (Bonjour) for discovery, which requires the Local Network permission. Check Settings &gt; Privacy &gt; Local Network on your device.</p>
@@ -198,6 +198,29 @@
 
       <h3>Can a Home Assistant automation wake my kiosk dashboard?</h3>
       <p>Yes. In Settings, enable <strong>Register with Home Assistant</strong>, then enable both Kiosk Mode and Wake on Touch. Call the generated <code>notify.mobile_app_&lt;device&gt;</code> action with <code>message: command_screen_on</code>. This wakes the app’s dimmed dashboard and restarts its one-minute wake timer. It works while HA Dashboard remains open in kiosk mode; it cannot unlock or launch a backgrounded iPad.</p>
+
+      <h3>Which Home Assistant remote commands are supported?</h3>
+      <p>Commands use the generated <code>notify.mobile_app_&lt;device&gt;</code> action and Home Assistant's local WebSocket push channel. HA Dashboard must be open, connected, and registered. There is no developer cloud-push fallback, and commands cannot unlock a device or launch the app from the background.</p>
+      <ul>
+        <li><code>command_screen_on</code> and <code>command_screen_off</code> wake or dim the display. With Kiosk Mode and Wake on Touch enabled, screen-on restarts the one-minute timer.</li>
+        <li><code>command_screen_brightness_level</code> uses <code>data.command</code> from <code>0</code> to <code>255</code>. The custom <code>set_brightness</code> command accepts percentage <code>data.level</code> or byte-scale <code>data.brightness</code>.</li>
+        <li><code>switch_dashboard</code> uses <code>data.dashboard</code>; <code>switch_view</code> or <code>command_navigate</code> uses <code>data.path</code>, <code>data.view</code>, or numeric <code>data.index</code>.</li>
+        <li><code>set_theme</code> uses <code>data.mode</code> (<code>auto</code>, <code>dark</code>, or <code>light</code>); <code>set_gradient</code> accepts a preset, two custom hex colours, or <code>data.enabled: false</code>.</li>
+        <li><code>set_kiosk_mode</code> uses boolean <code>data.enabled</code>; <code>reload</code> reconnects and reloads the dashboard. A normal notification message displays as an in-app banner.</li>
+      </ul>
+      <p>Example: <code>action: notify.mobile_app_&lt;device&gt;</code> with <code>data: { message: command_screen_brightness_level, data: { command: 128 } }</code>.</p>
+
+      <h3>How do I use this device as a Home Assistant camera?</h3>
+      <p>Local Camera Stream requires iOS 10.3.3 or later; the rest of HA Dashboard remains available on iOS 9. In Settings, enable <strong>Local Camera Stream</strong> and grant Camera and Microphone access. Choose Front, Rear, or Both when supported, then use the capability-based quality slider. The dashboard remains visible, but capture starts only after an RTSP client authenticates and requests media.</p>
+      <p>A single selected camera uses port <code>8554</code>. In Both mode, front uses <code>8554</code> and rear uses <code>8555</code>; both use the same credentials. The displayed addresses and their normal tap-to-copy action omit credentials. Open <strong>Protected access</strong> and explicitly choose <strong>Copy URL with Password</strong> for a client-ready sensitive URL. Its username is <code>hadashboard</code>; the app generates a strong, unique password for each device and retains it in that device's Keychain. The copied item is local-only, remains available long enough to switch to VLC, and expires after 60 seconds if unchanged. VLC or another RTSP client may retain the protected URL in its own recent-items history, which the app cannot clear.</p>
+      <p>When <strong>Register with Home Assistant</strong> is enabled and the logged-in user is an administrator, HA Dashboard validates active URLs and creates or updates only Generic Camera entries whose IDs it saved previously. It sends the bare URL, username, password, Digest authentication mode, and TCP transport as separate Generic Camera settings. HTTPS protects that credential submission. For a loopback, <code>.local</code>, link-local, RFC1918, or IPv6 unique-local Home Assistant address, registration proceeds over HTTP without another per-server prompt; non-local HTTP is refused. <strong>Local HTTP is still plaintext: another host able to monitor that LAN may recover the camera username and password.</strong> Use it only on a trusted local network. Camera-flow requests use isolated 75-second request and 120-second resource timeouts. After each retryable failed attempt, the app waits 2, 4, 8, 16, and 32 seconds, then 60 seconds between attempts while the same listener, registration setting, account, and Home Assistant origin remain active; Settings shows that state. Those delays begin after the preceding attempt ends, so they are not an end-to-end completion deadline. Home Assistant stores those credentials and its backups may contain them. For manual setup, have a Home Assistant administrator add Generic Camera with the bare URL, username <code>hadashboard</code>, the password from between <code>hadashboard:</code> and <code>@</code> in the explicitly copied protected URL, Digest authentication, and TCP transport. Leaving Both mode does not delete the rear entry from Home Assistant; remove it there if it is no longer wanted.</p>
+      <p>Use <strong>Rotate Stream Password</strong> if access may have been shared too widely. Rotation disconnects current viewers, invalidates old protected URLs, and completes locally after the listener re-arms; it does not wait for Home Assistant. While <strong>Register with Home Assistant</strong> is enabled, the app then starts asynchronous reconciliation of app-owned camera entries and keeps retrying transient failures while the same registration context remains active. Manually configured clients and unowned entries need the new URL or password set manually.</p>
+      <p>The server supports concurrent authenticated clients. VLC uses a roughly one-second network cache by default; for low-latency testing start it with <code>--network-caching=100 --rtsp-tcp</code>. VLC begins playback when the URL opens, so pressing its play/pause control at that point pauses the stream.</p>
+      <p><strong>Security:</strong> RTSP Digest authentication blocks clients without the device password from requesting capture, but camera and microphone media is plaintext and not encrypted on the LAN. Use it only on a trusted local network, do not forward ports 8554/8555 or expose them through a VPN, and turn it off when not needed. A red <strong>Camera + mic live</strong> indicator appears above the dashboard, including in kiosk mode, while capture is active; tap it to stop and disable the stream. The feature has no relay, cloud media stream, recording, hidden preview, or background capture.</p>
+      <p>Mute Camera Audio controls playback of Home Assistant camera cards only. Local Camera Stream always includes microphone AAC while viewed.</p>
+
+      <h3>What does Log Out &amp; Reset remove?</h3>
+      <p>It clears Home Assistant and Local Camera Stream credentials, registration identity, preferences, cached Home Assistant state/history, local logs, and stream configuration stored by this app. Home Assistant devices and Generic Camera entries, including the stream credentials saved in those entries, remain until you remove them in Home Assistant.</p>
     </div>
   </main>
 

--- a/project.yml
+++ b/project.yml
@@ -49,7 +49,15 @@ targets:
         CFBundleDisplayName: "HA Dashboard"
         NSAppTransportSecurity:
           NSAllowsArbitraryLoads: true
-        NSLocalNetworkUsageDescription: "Discover Home Assistant servers on your network"
+        NSLocalNetworkUsageDescription: "Discover Home Assistant servers and host explicitly enabled camera and microphone streams for RTSP clients that connect to this device."
+        NSCameraUsageDescription: "Allow HA Dashboard to stream live video to RTSP clients while Local Camera Stream is enabled."
+        NSMicrophoneUsageDescription: "Allow HA Dashboard to include live audio in Local Camera Streams you enable."
+        UIApplicationSceneManifest:
+          UIApplicationSupportsMultipleScenes: false
+          UISceneConfigurations:
+            UIWindowSceneSessionRoleApplication:
+              - UISceneConfigurationName: "Default Configuration"
+                UISceneDelegateClassName: HAAppSceneDelegate
         NSBonjourServices:
           - _home-assistant._tcp
         UILaunchStoryboardName: LaunchScreen
@@ -82,6 +90,7 @@ targets:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF: NO
         GCC_WARN_INHIBIT_ALL_WARNINGS: NO
+        "CODE_SIGN_ENTITLEMENTS[sdk=macosx*]": HADashboard/HADashboard-Catalyst.entitlements
       configs:
         Debug:
           SWIFT_OPTIMIZATION_LEVEL: "-Onone"
@@ -94,7 +103,12 @@ targets:
           GCC_OPTIMIZATION_LEVEL: "s"
           DEBUG_INFORMATION_FORMAT: "dwarf-with-dsym"
           VALIDATE_PRODUCT: YES
-    dependencies: []
+    dependencies:
+      - sdk: AVFoundation.framework
+      - sdk: AudioToolbox.framework
+      - sdk: CoreMedia.framework
+      - sdk: CoreVideo.framework
+      - sdk: VideoToolbox.framework
     preBuildScripts: []
     postBuildScripts: []
     scheme:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,10 +7,10 @@ set -euo pipefail
 #
 # Usage:
 #   scripts/build.sh sim           # Simulator build (arm64, iOS 15+)
-#   scripts/build.sh rosettasim    # Legacy simulator build (x86_64, iOS 9.0+, RosettaSim)
+#   scripts/build.sh rosettasim    # Legacy simulator build (requires macOS 26 + Xcode 26)
 #   scripts/build.sh device        # Universal device build (armv7+arm64)
 #
-# The rosettasim target builds with Xcode 26 xcodebuild but sets
+# The rosettasim target builds with Xcode 26 xcodebuild and sets
 # MERGED_BINARY_TYPE=none to disable mergeable libraries — the default
 # Debug stub+dylib pattern crashes on legacy runtimes' libdispatch.
 #
@@ -18,19 +18,38 @@ set -euo pipefail
 #   Prints the path to the built .app on success
 
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CALLER_FORCE_SIGNING_STYLE="${HADASHBOARD_FORCE_SIGNING_STYLE:-}"
+CALLER_FORCE_SIGNING_DEVICE_ID="${HADASHBOARD_FORCE_SIGNING_DEVICE_ID:-}"
 
 # ── Load .env ─────────────────────────────────────────────────────────
-if [[ -f "$PROJECT_DIR/.env" ]]; then
-    set -a; source "$PROJECT_DIR/.env"; set +a
+ENV_FILE="$PROJECT_DIR/.env"
+if [[ ! -f "$ENV_FILE" ]]; then
+    # Linked worktrees share the main checkout's .git directory. Reuse that
+    # checkout's ignored .env instead of copying secrets into every worktree.
+    GIT_COMMON_DIR=$(git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+    if [[ -n "$GIT_COMMON_DIR" && "$(basename "$GIT_COMMON_DIR")" == ".git" ]]; then
+        COMMON_CHECKOUT_ENV="$(dirname "$GIT_COMMON_DIR")/.env"
+        if [[ -f "$COMMON_CHECKOUT_ENV" ]]; then
+            ENV_FILE="$COMMON_CHECKOUT_ENV"
+        fi
+    fi
 fi
+if [[ -f "$ENV_FILE" ]]; then
+    # Keep secrets as shell variables. Commands receive only the individual
+    # non-secret values passed explicitly below.
+    source "$ENV_FILE"
+fi
+# The build never needs a Home Assistant token.
+unset HA_TOKEN HADASHBOARD_TOKEN_OVERRIDE 2>/dev/null || true
+# Fleet-only force values supplied by deploy.sh outrank persisted .env defaults.
+[[ -n "$CALLER_FORCE_SIGNING_STYLE" ]] && HADASHBOARD_FORCE_SIGNING_STYLE="$CALLER_FORCE_SIGNING_STYLE"
+[[ -n "$CALLER_FORCE_SIGNING_DEVICE_ID" ]] && HADASHBOARD_FORCE_SIGNING_DEVICE_ID="$CALLER_FORCE_SIGNING_DEVICE_ID"
 
 XCODE13="${XCODE13_PATH:-/Applications/Xcode-13.2.1.app}"
-if [[ -n "${XCODE_PATH:-}" ]]; then
-    XCODE26="$XCODE_PATH"
-elif [[ -d "/Applications/Xcode.app" ]]; then
-    XCODE26="/Applications/Xcode.app"
-else
-    # Beta macOS hosts commonly keep the active toolchain under this name.
+XCODE26="${XCODE_PATH:-/Applications/Xcode.app}"
+# Keep the documented stable path first, but permit a deliberately selected
+# Xcode 27 beta when it is the only installed modern toolchain on this host.
+if [[ ! -d "$XCODE26" && -d "/Applications/Xcode-beta.app" ]]; then
     XCODE26="/Applications/Xcode-beta.app"
 fi
 
@@ -53,7 +72,7 @@ if [[ -z "$TARGET" ]]; then
     echo "Usage: scripts/build.sh <sim|device|mac>"
     echo ""
     echo "Targets:"
-    echo "  sim      Simulator build (arm64, Xcode 26)"
+    echo "  sim      Simulator build (arm64, Xcode 26/27)"
     echo "  device   Universal device build (armv7+arm64, matches CI)"
     echo "  mac      Mac Catalyst build (arm64, macOS)"
     exit 1
@@ -109,6 +128,15 @@ build_rosettasim() {
     fi
     export DEVELOPER_DIR="$XCODE26/Contents/Developer"
 
+    local XCODE_MAJOR
+    XCODE_MAJOR=$("$DEVELOPER_DIR/usr/bin/xcodebuild" -version | awk '/^Xcode / { split($2, v, "."); print v[1] }')
+    if [[ -n "$XCODE_MAJOR" && "$XCODE_MAJOR" -ge 27 ]]; then
+        echo "RosettaSim iOS 9-14 builds require macOS 26 with Xcode 26." >&2
+        echo "Xcode $XCODE_MAJOR rejects simulator deployment targets below iOS 15, and macOS 27 cannot boot the x86-only legacy runtimes." >&2
+        echo "Use scripts/build.sh device for the iOS 9-compatible physical armv7/arm64 product on this host." >&2
+        exit 1
+    fi
+
     local BUILD_DIR="$PROJECT_DIR/build/rosettasim"
 
     xcodebuild \
@@ -141,10 +169,10 @@ build_rosettasim() {
 
 # ── Universal device build (armv7+arm64) ──────────────────────────────
 build_device() {
-    echo "Building universal armv7+arm64 (Xcode 26 clang + Xcode 13 SDK)..." >&2
+    echo "Building universal armv7+arm64 (modern Xcode clang + Xcode 13 SDK stubs)..." >&2
 
     if [ ! -d "$XCODE26" ]; then
-        echo "Xcode 26 not found at $XCODE26" >&2
+        echo "Modern Xcode not found at $XCODE26" >&2
         exit 1
     fi
     export DEVELOPER_DIR="$XCODE26/Contents/Developer"
@@ -157,7 +185,7 @@ build_device() {
         echo "Set XCODE13_SDK_PATH to an extracted iPhoneOS.sdk if using cached SDK stubs." >&2
         exit 1
     fi
-    echo "   armv7 link SDK: $XCODE13_SDK" >&2
+    echo "   iOS 9 link SDK: $XCODE13_SDK" >&2
     local SDK_VER=$(plutil -extract Version raw "$XCODE26_SDK/SDKSettings.plist")
     local SRC_ICON="$PROJECT_DIR/HADashboard/Assets.xcassets/AppIcon.appiconset/icon-1024.png"
 
@@ -165,9 +193,6 @@ build_device() {
     # Clean previous build to avoid stale artifacts
     rm -rf "$BUILD_DIR"
     mkdir -p "$BUILD_DIR"
-
-    # ── Step 1: Compile armv7 with Xcode 26 clang ──────────────────────
-    echo "   Compiling armv7 objects..." >&2
 
     # Collect include directories
     local INCLUDE_FLAGS=()
@@ -187,71 +212,164 @@ build_device() {
         -not -path '*/iOSSnapshotTestCase/*' \
         -not -path '*/MDI/*' 2>/dev/null)
 
-    # Compile all .m files
-    mkdir -p "$BUILD_DIR/armv7-obj"
-    local ERRORS=0
-    local COMPILED=0
-    for src in "${SOURCES[@]}"; do
-        local OBJ_NAME=$(echo "$src" | sed 's|/|_|g; s|\.m$|.o|')
-        if "$CLANG" \
-            --target=armv7-apple-ios9.0 \
-            -isysroot "$XCODE26_SDK" \
-            -x objective-c -fobjc-arc -fmodules -Os -DNDEBUG -g -w \
-            "${INCLUDE_FLAGS[@]}" \
-            -c "$PROJECT_DIR/$src" -o "$BUILD_DIR/armv7-obj/$OBJ_NAME" 2>/dev/null; then
-            COMPILED=$((COMPILED + 1))
-        else
-            ERRORS=$((ERRORS + 1))
-            if [ $ERRORS -le 3 ]; then
-                echo "   FAIL: $src" >&2
-                "$CLANG" --target=armv7-apple-ios9.0 -isysroot "$XCODE26_SDK" \
-                    -x objective-c -fobjc-arc -fmodules -Os -DNDEBUG \
-                    "${INCLUDE_FLAGS[@]}" -c "$PROJECT_DIR/$src" -o /dev/null 2>&1 | grep 'error:' | head -3 >&2
+    # Xcode 27 no longer lets xcodebuild target pre-iOS 15, so compile both
+    # device slices directly with the modern compiler and link against the
+    # Xcode 13 SDK stubs. The Xcode build below is retained only as the signed
+    # bundle/resource template.
+    compile_ios9_slice() {
+        local arch="$1"
+        local target="$arch-apple-ios9.0"
+        local object_dir="$BUILD_DIR/$arch-obj"
+        local architecture_flags=()
+        local errors=0
+        local compiled=0
+        if [[ "$arch" == "armv7" ]]; then
+            # Xcode 27 ld can drop Thumb mode bits from LC_MAIN and Objective-C
+            # method IMP relocations. Compile the legacy slice in ARM mode so
+            # every even entry point is unambiguous on A5/A6-era devices.
+            architecture_flags=(-marm)
+        fi
+        mkdir -p "$object_dir"
+        echo "   Compiling $arch objects for iOS 9..." >&2
+
+        for src in "${SOURCES[@]}"; do
+            local object_name
+            local compile_output
+            object_name=$(echo "$src" | sed 's|/|_|g; s|\.m$|.o|')
+            if compile_output=$("$CLANG" \
+                --target="$target" \
+                -isysroot "$XCODE26_SDK" \
+                -x objective-c -fobjc-arc -fmodules -Os -DNDEBUG -g \
+                -Werror=unguarded-availability \
+                ${architecture_flags[@]+"${architecture_flags[@]}"} \
+                "${INCLUDE_FLAGS[@]}" \
+                -c "$PROJECT_DIR/$src" -o "$object_dir/$object_name" 2>&1); then
+                compiled=$((compiled + 1))
+            else
+                errors=$((errors + 1))
+                if [ "$errors" -le 3 ]; then
+                    echo "   FAIL ($arch): $src" >&2
+                    if [[ -n "$compile_output" ]]; then
+                        printf '%s\n' "$compile_output" | sed -n '1,12p' >&2
+                    else
+                        echo "   Compiler exited without a diagnostic." >&2
+                    fi
+                fi
+            fi
+        done
+
+        if [ "$errors" -gt 0 ]; then
+            echo "$arch compile failed: $compiled/$((compiled + errors)) files" >&2
+            exit 1
+        fi
+
+        echo "   Linking $arch for iOS 9..." >&2
+        "$CLANG" \
+            --target="$target" \
+            -isysroot "$XCODE13_SDK" \
+            -framework Foundation -framework UIKit -framework CoreFoundation \
+            -framework CoreGraphics -framework CoreText -framework QuartzCore \
+            -framework Security -framework CFNetwork -framework AVFoundation \
+            -framework AudioToolbox -framework CoreMedia -framework CoreVideo \
+            -framework VideoToolbox \
+            -fobjc-arc -dead_strip \
+            ${architecture_flags[@]+"${architecture_flags[@]}"} \
+            -Xlinker -platform_version -Xlinker ios -Xlinker 9.0 -Xlinker "$SDK_VER" \
+            "$object_dir"/*.o \
+            -o "$BUILD_DIR/$arch-thin"
+        echo "   $arch slice: $(du -h "$BUILD_DIR/$arch-thin" | cut -f1)" >&2
+    }
+
+    # ── Step 1: Build true iOS 9 armv7 and arm64 executables ───────────
+    compile_ios9_slice armv7
+    compile_ios9_slice arm64
+
+    assert_ios9_slice() {
+        local binary="$1"
+        local arch="$2"
+        local actual_arch
+        local minimum
+        actual_arch=$(lipo -archs "$binary")
+        if [[ "$actual_arch" != "$arch" ]]; then
+            echo "Unexpected architecture for $binary: $actual_arch (expected $arch)" >&2
+            exit 1
+        fi
+        minimum=$(otool -l -arch "$arch" "$binary" | awk '
+            $1 == "cmd" && $2 == "LC_VERSION_MIN_IPHONEOS" { wanted = 1; next }
+            wanted && $1 == "version" { print $2; wanted = 0 }
+        ')
+        if [[ "$minimum" != "9.0" ]]; then
+            echo "$arch slice minimum is '${minimum:-missing}', expected 9.0" >&2
+            exit 1
+        fi
+        if [[ "$arch" == "armv7" ]]; then
+            local entryoff
+            entryoff=$(otool -l -arch armv7 "$binary" | awk '
+                $1 == "cmd" && $2 == "LC_MAIN" { wanted = 1; next }
+                wanted && $1 == "entryoff" { print $2; exit }
+            ')
+            if [[ -z "$entryoff" || $((entryoff % 2)) -ne 0 ]]; then
+                echo "armv7 ARM-mode LC_MAIN entryoff is unexpectedly odd: ${entryoff:-missing}" >&2
+                exit 1
+            fi
+            if nm -arch armv7 -m "$binary" | grep ' _main$' | grep -q '\[Thumb\]'; then
+                echo "armv7 main is unexpectedly marked as Thumb" >&2
+                exit 1
             fi
         fi
-    done
+    }
+    assert_ios9_slice "$BUILD_DIR/armv7-thin" armv7
+    assert_ios9_slice "$BUILD_DIR/arm64-thin" arm64
 
-    if [ $ERRORS -gt 0 ]; then
-        echo "armv7 compile failed: $COMPILED/$((COMPILED + ERRORS)) files" >&2
-        exit 1
+    if [[ "${HADASHBOARD_SLICES_ONLY:-NO}" == "YES" ]]; then
+        lipo -create "$BUILD_DIR/armv7-thin" "$BUILD_DIR/arm64-thin" \
+            -output "$BUILD_DIR/universal-thin"
+        echo "   Verified iOS 9 armv7+arm64 release slices" >&2
+        echo "$BUILD_DIR"
+        return
     fi
-    echo "   Compiled $COMPILED files" >&2
 
-    # Link against Xcode 13 SDK with platform_version override
-    echo "   Linking armv7..." >&2
-    "$CLANG" \
-        --target=armv7-apple-ios9.0 \
-        -isysroot "$XCODE13_SDK" \
-        -framework Foundation -framework UIKit -framework CoreFoundation \
-        -framework CoreGraphics -framework CoreText -framework QuartzCore \
-        -framework Security -framework CFNetwork \
-        -fobjc-arc -dead_strip \
-        -Xlinker -platform_version -Xlinker ios -Xlinker 9.0 -Xlinker "$SDK_VER" \
-        "$BUILD_DIR/armv7-obj"/*.o \
-        -o "$BUILD_DIR/armv7-thin"
-
-    # Generate armv7 dSYM
-    "$DSYMUTIL" "$BUILD_DIR/armv7-thin" -o "$BUILD_DIR/armv7.dSYM"
-    mv "$BUILD_DIR/armv7.dSYM/Contents/Resources/DWARF/armv7-thin" \
-       "$BUILD_DIR/armv7.dSYM/Contents/Resources/DWARF/HA Dashboard" 2>/dev/null || true
-
-    echo "   armv7 slice: $(du -h "$BUILD_DIR/armv7-thin" | cut -f1)" >&2
-
-    # ── Step 2: Build arm64 with Xcode 26 xcodebuild ───────────────────
-    echo "   Building arm64..." >&2
+    # ── Step 2: Build a signed arm64 bundle/resource template ──────────
+    echo "   Building signed bundle template..." >&2
     local ARM64_BUILD="$BUILD_DIR/arm64"
 
     local SIGNING_FLAGS=(
         CODE_SIGN_IDENTITY="Apple Development"
-        CODE_SIGN_STYLE=Manual
         "DEVELOPMENT_TEAM=$APPLE_TEAM_ID"
-        PROVISIONING_PROFILE_SPECIFIER="HADashboard Development"
     )
+    local PROVISIONING_UPDATE_FLAGS=()
+    local DEVICE_DESTINATION_FLAGS=()
+    local APP_STORE_CONNECT_FLAGS=()
+    local SIGNING_STYLE="${HADASHBOARD_FORCE_SIGNING_STYLE:-${HADASHBOARD_SIGNING_STYLE:-manual}}"
+    local SIGNING_DEVICE_ID="${HADASHBOARD_FORCE_SIGNING_DEVICE_ID:-${HADASHBOARD_SIGNING_DEVICE_ID:-}}"
+    if [[ "$SIGNING_STYLE" == "automatic" ]]; then
+        # Use when a newly connected device is absent from the named local
+        # profile. This permits Xcode to fetch/create a matching development
+        # profile for the user-selected team during an authorized deployment.
+        SIGNING_FLAGS+=(CODE_SIGN_STYLE=Automatic)
+        PROVISIONING_UPDATE_FLAGS=(-allowProvisioningUpdates -allowProvisioningDeviceRegistration)
+        if [[ -n "$SIGNING_DEVICE_ID" ]]; then
+            # Xcode destinations require the physical hardware UDID (for
+            # example 000081xx-...), not devicectl's CoreDevice UUID.
+            DEVICE_DESTINATION_FLAGS=(-destination "id=${SIGNING_DEVICE_ID}")
+        fi
+        if [[ -n "${ASC_KEY_PATH:-}" && -n "${ASC_KEY_ID:-}" && -n "${ASC_ISSUER_ID:-}" ]]; then
+            APP_STORE_CONNECT_FLAGS=(
+                -authenticationKeyPath "$ASC_KEY_PATH"
+                -authenticationKeyID "$ASC_KEY_ID"
+                -authenticationKeyIssuerID "$ASC_ISSUER_ID"
+            )
+        fi
+    else
+        SIGNING_FLAGS+=(CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE_SPECIFIER="HADashboard Development")
+    fi
 
     xcodebuild \
         -project "$PROJECT_DIR/HADashboard.xcodeproj" \
         -scheme HADashboard \
+        ${APP_STORE_CONNECT_FLAGS[@]+"${APP_STORE_CONNECT_FLAGS[@]}"} \
         -sdk iphoneos \
+        ${DEVICE_DESTINATION_FLAGS[@]+"${DEVICE_DESTINATION_FLAGS[@]}"} \
         -configuration Debug \
         -derivedDataPath "$ARM64_BUILD" \
         ARCHS=arm64 \
@@ -262,6 +380,7 @@ build_device() {
         "MARKETING_VERSION=$APP_VERSION" \
         "CURRENT_PROJECT_VERSION=$BUILD_NUMBER" \
         "${SIGNING_FLAGS[@]}" \
+        ${PROVISIONING_UPDATE_FLAGS[@]+"${PROVISIONING_UPDATE_FLAGS[@]}"} \
         build 2>&1 | grep -E '(error:|BUILD)' | tail -5 >&2
 
     local ARM64_APP="$ARM64_BUILD/Build/Products/Debug-iphoneos/HA Dashboard.app"
@@ -269,7 +388,7 @@ build_device() {
         echo "arm64 build failed" >&2
         exit 1
     fi
-    echo "   arm64 slice: $(du -h "$ARM64_APP/HA Dashboard" | cut -f1)" >&2
+    echo "   Bundle template: $(du -sh "$ARM64_APP" | cut -f1)" >&2
 
     # ── Step 3: Create universal app bundle ────────────────────────────
     echo "   Merging universal binary..." >&2
@@ -278,7 +397,7 @@ build_device() {
     cp -R "$ARM64_APP" "$APP"
 
     # Merge binaries
-    lipo -create "$BUILD_DIR/armv7-thin" "$APP/HA Dashboard" \
+    lipo -create "$BUILD_DIR/armv7-thin" "$BUILD_DIR/arm64-thin" \
         -output "$APP/HA Dashboard.tmp"
     mv "$APP/HA Dashboard.tmp" "$APP/HA Dashboard"
 
@@ -314,19 +433,11 @@ build_device() {
         sips -z 180 180 "$SRC_ICON" --out "$APP/AppIcon60x60@3x.png" >/dev/null 2>&1
     fi
 
-    # Merge dSYMs
-    local ARM64_DSYM="$ARM64_BUILD/Build/Products/Debug-iphoneos/HA Dashboard.app.dSYM"
-    if [ -d "$ARM64_DSYM" ] && [ -d "$BUILD_DIR/armv7.dSYM" ]; then
-        echo "   Merging dSYMs..." >&2
-        local DSYM_OUT="$BUILD_DIR/HA Dashboard.app.dSYM"
-        cp -R "$ARM64_DSYM" "$DSYM_OUT"
-        local ARM64_DWARF="$DSYM_OUT/Contents/Resources/DWARF/HA Dashboard"
-        local ARMV7_DWARF="$BUILD_DIR/armv7.dSYM/Contents/Resources/DWARF/HA Dashboard"
-        if [ -f "$ARM64_DWARF" ] && [ -f "$ARMV7_DWARF" ]; then
-            lipo -create "$ARMV7_DWARF" "$ARM64_DWARF" -output "${ARM64_DWARF}.universal"
-            mv "${ARM64_DWARF}.universal" "$ARM64_DWARF"
-        fi
-    fi
+    # Generate one dSYM from the final replacement executable so both UUIDs
+    # match the shipped armv7/arm64 slices. The Xcode template dSYM belongs to
+    # the discarded iOS 15 executable and must not be reused.
+    echo "   Generating universal dSYM..." >&2
+    "$DSYMUTIL" "$APP/HA Dashboard" -o "$BUILD_DIR/HA Dashboard.app.dSYM"
 
     # Re-sign with entitlements from arm64 build
     echo "   Re-signing..." >&2
@@ -347,8 +458,38 @@ build_device() {
         echo "   Warning: No signing identity found, app may need manual signing" >&2
     fi
 
-    echo "   Universal binary: $(lipo -archs "$APP/HA Dashboard")" >&2
-    echo "   MinOS: $(plutil -extract MinimumOSVersion raw "$PLIST")" >&2
+    local FINAL_ARCHS
+    FINAL_ARCHS=$(lipo -archs "$APP/HA Dashboard")
+    if [[ "$FINAL_ARCHS" != "armv7 arm64" ]]; then
+        echo "Unexpected universal architecture set: $FINAL_ARCHS" >&2
+        exit 1
+    fi
+    assert_ios9_slice "$BUILD_DIR/armv7-thin" armv7
+    assert_ios9_slice "$BUILD_DIR/arm64-thin" arm64
+    if [[ "$(plutil -extract MinimumOSVersion raw "$PLIST")" != "9.0" ]]; then
+        echo "Bundle MinimumOSVersion is not 9.0" >&2
+        exit 1
+    fi
+    if [[ ! -f "$APP/PrivacyInfo.xcprivacy" ]]; then
+        echo "PrivacyInfo.xcprivacy is missing from the iOS app root" >&2
+        exit 1
+    fi
+    plutil -lint "$APP/PrivacyInfo.xcprivacy" >/dev/null
+
+    local BINARY_UUIDS
+    local DSYM_UUIDS
+    BINARY_UUIDS=$(dwarfdump --uuid "$APP/HA Dashboard" | awk '{print $2, $3}' | sort)
+    DSYM_UUIDS=$(dwarfdump --uuid "$BUILD_DIR/HA Dashboard.app.dSYM" | awk '{print $2, $3}' | sort)
+    if [[ "$BINARY_UUIDS" != "$DSYM_UUIDS" ]]; then
+        echo "Universal dSYM UUIDs do not match the final executable" >&2
+        exit 1
+    fi
+    if [[ -n "$IDENTITY" ]]; then
+        codesign --verify --deep --strict "$APP"
+    fi
+
+    echo "   Universal binary: $FINAL_ARCHS" >&2
+    echo "   MinOS: 9.0 (armv7, arm64, and bundle)" >&2
 
     echo "$APP"
 }
@@ -364,32 +505,64 @@ build_mac() {
     export DEVELOPER_DIR="$XCODE26/Contents/Developer"
 
     local BUILD_DIR="$PROJECT_DIR/build/mac"
+    # Catalyst derives macOS 10.15 from the app's iOS 9 target. Xcode 27 no
+    # longer supports that macOS SDK target, so lift *only Catalyst* to iOS 15
+    # (macOS 12 equivalent); the standalone iOS product stays at iOS 9.
+    local CATALYST_IOS_MIN="${CATALYST_IPHONEOS_DEPLOYMENT_TARGET:-15.0}"
 
     local SIGNING_FLAGS=(
         CODE_SIGN_IDENTITY="Apple Development"
         CODE_SIGN_STYLE=Automatic
         "DEVELOPMENT_TEAM=$APPLE_TEAM_ID"
     )
+    local APP_STORE_CONNECT_FLAGS=()
+    if [[ -n "${ASC_KEY_PATH:-}" && -n "${ASC_KEY_ID:-}" && -n "${ASC_ISSUER_ID:-}" ]]; then
+        APP_STORE_CONNECT_FLAGS=(
+            -authenticationKeyPath "$ASC_KEY_PATH"
+            -authenticationKeyID "$ASC_KEY_ID"
+            -authenticationKeyIssuerID "$ASC_ISSUER_ID"
+        )
+    fi
 
     xcodebuild \
         -project "$PROJECT_DIR/HADashboard.xcodeproj" \
         -scheme HADashboard \
+        ${APP_STORE_CONNECT_FLAGS[@]+"${APP_STORE_CONNECT_FLAGS[@]}"} \
+        -allowProvisioningUpdates \
         -destination 'platform=macOS,variant=Mac Catalyst' \
         -configuration Debug \
         -derivedDataPath "$BUILD_DIR" \
         ARCHS=arm64 \
         ONLY_ACTIVE_ARCH=YES \
+        ENABLE_DEBUG_DYLIB=NO \
+        MERGED_BINARY_TYPE=none \
+        "IPHONEOS_DEPLOYMENT_TARGET=$CATALYST_IOS_MIN" \
         "PRODUCT_BUNDLE_IDENTIFIER=$BUNDLE_ID" \
         "MARKETING_VERSION=$APP_VERSION" \
         "CURRENT_PROJECT_VERSION=$BUILD_NUMBER" \
         "${SIGNING_FLAGS[@]}" \
-        build 2>&1 | grep -E '(error:|BUILD)' | tail -5 >&2
+        clean build 2>&1 | grep -E '(error:|BUILD)' | tail -5 >&2
 
     local APP="$BUILD_DIR/Build/Products/Debug-maccatalyst/HA Dashboard.app"
     if [ ! -d "$APP" ]; then
         echo "Build failed" >&2
         exit 1
     fi
+    local EXECUTABLE="$APP/Contents/MacOS/HA Dashboard"
+    if [[ ! -f "$EXECUTABLE" || -f "$APP/Contents/MacOS/HA Dashboard.debug.dylib" ]]; then
+        echo "Catalyst build must contain one non-mergeable main executable" >&2
+        exit 1
+    fi
+    if [[ $(stat -f %z "$EXECUTABLE") -lt 1000000 ]]; then
+        echo "Catalyst main executable is unexpectedly small" >&2
+        exit 1
+    fi
+    if [[ ! -f "$APP/Contents/Resources/PrivacyInfo.xcprivacy" ]]; then
+        echo "PrivacyInfo.xcprivacy is missing from Catalyst resources" >&2
+        exit 1
+    fi
+    plutil -lint "$APP/Contents/Resources/PrivacyInfo.xcprivacy" >/dev/null
+    codesign --verify --deep --strict "$APP"
 
     echo "$APP"
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,18 +6,20 @@ set -euo pipefail
 #   scripts/deploy.sh sim          # Build + run in iPad 10th gen simulator
 #   scripts/deploy.sh sim iphone   # Build + run in iPhone 15 Pro simulator
 #   scripts/deploy.sh iphone       # Build + deploy + launch on physical iPhone
-#   scripts/deploy.sh mini5        # Build + deploy to iPad Mini 5 (wired devicectl)
-#   scripts/deploy.sh mini4        # Build + deploy to iPad Mini 4 (WiFi, ideviceinstaller)
+#   scripts/deploy.sh mini5        # Build + deploy to iPad Mini 5 (CoreDevice/MobileDevice WiFi)
+#   scripts/deploy.sh mini4        # Build + deploy to iPad Mini 4 (MobileDevice WiFi)
+#   scripts/deploy.sh ipadpro      # Build + deploy + launch on physical iPad Pro
 #   scripts/deploy.sh ipad2        # Build + deploy to iPad 2 via WiFi SSH (jailbroken)
 #   scripts/deploy.sh ipad3        # Build + deploy to iPad 3 via WiFi SSH (jailbroken)
 #   scripts/deploy.sh mac          # Build + launch Mac Catalyst app locally
 #
 # Options:
 #   --no-build    Skip build step
+#   --dry-run     Resolve configuration and targets without building or deploying
 #   --dashboard X Override dashboard (default: living-room)
 #   --default     Use default (overview) dashboard instead of living-room
 #   --server URL  Override HA server URL
-#   --token TOKEN Override access token (for this launch only)
+#   --token-file X Read an access-token override from X without putting it in argv
 #   --kiosk       Start in kiosk mode
 #   --no-kiosk    Disable kiosk mode
 #   --reset       Clear credentials and start at login screen
@@ -25,18 +27,48 @@ set -euo pipefail
 
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 BUNDLE_ID="${BUNDLE_ID:-com.hadashboard.app}"
+_SENSITIVE_PREFS_FILE=""
+_CLEANUP_DIRS=()
+
+cleanup_sensitive_files() {
+    if [[ -n "$_SENSITIVE_PREFS_FILE" && -f "$_SENSITIVE_PREFS_FILE" ]]; then
+        rm -f "$_SENSITIVE_PREFS_FILE"
+    fi
+    local cleanup_dir
+    for cleanup_dir in ${_CLEANUP_DIRS[@]+"${_CLEANUP_DIRS[@]}"}; do
+        case "$cleanup_dir" in
+            "$PROJECT_DIR"/build/*.deploy.*|/tmp/hadashboard-*)
+                [[ -d "$cleanup_dir" ]] && rm -rf "$cleanup_dir"
+                ;;
+        esac
+    done
+}
+trap cleanup_sensitive_files EXIT
 
 # ── Load secrets from .env ────────────────────────────────────────────
 ENV_FILE="$PROJECT_DIR/.env"
+if [[ ! -f "$ENV_FILE" ]]; then
+    # A linked worktree's common Git directory belongs to the main checkout.
+    # Reuse its ignored .env without copying or printing any secret values.
+    GIT_COMMON_DIR=$(git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+    if [[ -n "$GIT_COMMON_DIR" && "$(basename "$GIT_COMMON_DIR")" == ".git" ]]; then
+        COMMON_CHECKOUT_ENV="$(dirname "$GIT_COMMON_DIR")/.env"
+        if [[ -f "$COMMON_CHECKOUT_ENV" ]]; then
+            ENV_FILE="$COMMON_CHECKOUT_ENV"
+        fi
+    fi
+fi
 if [[ -f "$ENV_FILE" ]]; then
-    set -a
+    # Do not export the complete secret file into every build/install process.
+    # Fleet children source the same file independently.
     source "$ENV_FILE"
-    set +a
 fi
 
 # ── Defaults (overridden by .env) ─────────────────────────────────────
 HA_SERVER="${HA_SERVER:-}"
 HA_TOKEN="${HA_TOKEN:-}"
+ENV_HA_TOKEN="$HA_TOKEN"
+unset HA_TOKEN
 HA_DASHBOARD="${HA_DASHBOARD:-living-room}"
 APPLE_TEAM_ID="${APPLE_TEAM_ID:-}"
 ASC_KEY_ID="${ASC_KEY_ID:-}"
@@ -48,11 +80,14 @@ IPHONE_UDID="${IPHONE_UDID:-}"
 IPAD_MINI5_DEVICECTL_ID="${IPAD_MINI5_DEVICECTL_ID:-}"
 IPAD_MINI5_UDID="${IPAD_MINI5_UDID:-}"
 IPAD_MINI4_UDID="${IPAD_MINI4_UDID:-}"
+IPAD_PRO_DEVICECTL_ID="${IPAD_PRO_DEVICECTL_ID:-}"
 IPAD2_UDID="${IPAD2_UDID:-}"
 IPAD2_IP="${IPAD2_IP:-}"
 IPAD2_SSH_PASS="${IPAD2_SSH_PASS:-alpine}"
+IPAD3_UDID="${IPAD3_UDID:-}"
 IPAD3_IP="${IPAD3_IP:-}"
 IPAD3_SSH_PASS="${IPAD3_SSH_PASS:-alpine}"
+IPAD4_UDID="${IPAD4_UDID:-}"
 IPAD4_IP="${IPAD4_IP:-}"
 IPAD4_SSH_PASS="${IPAD4_SSH_PASS:-alpine}"
 UNRAID_HOST="${UNRAID_HOST:-}"
@@ -67,19 +102,26 @@ SIM_IOS93_UDID="${SIM_IOS93_UDID:-D9DCA298-C3D2-4B68-9501-E5279A1B96B6}"
 SIM_IOS103_UDID="${SIM_IOS103_UDID:-1197AD51-2DD7-48B4-B1E5-2EFC3DCAD610}"
 
 # ── Xcode path (for devicectl/simctl commands) ────────────────────────
-XCODE26="/Applications/Xcode.app"
+XCODE26="${XCODE_PATH:-/Applications/Xcode.app}"
+if [[ ! -d "$XCODE26" && -d "/Applications/Xcode-beta.app" ]]; then
+    XCODE26="/Applications/Xcode-beta.app"
+fi
 
 # ── Parse arguments ─────────────────────────────────────────────────────
 TARGET=""
 NO_BUILD=false
+DRY_RUN=false
 KIOSK_MODE=""
 RESET_MODE=false
 DEMO_MODE=""
 TOKEN_OVERRIDE=""
+TOKEN_FILE=""
+SERVER_OVERRIDE_SET=false
+DASHBOARD_OVERRIDE_SET=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        sim|sim-ios93|sim-ios103|iphone|mini5|mini4|ipad2|ipad2-usb|ipad3|ipad4|ipad4-usb|mac|all)
+        sim|sim-ios93|sim-ios103|iphone|mini5|mini4|ipadpro|ipad-pro|ipad2|ipad2-usb|ipad3|ipad4|ipad4-usb|mac|all)
             if [[ -z "$TARGET" ]]; then
                 TARGET="$1"
             else
@@ -89,10 +131,15 @@ while [[ $# -gt 0 ]]; do
             fi
             shift ;;
         --no-build)   NO_BUILD=true; shift ;;
-        --server)     HA_SERVER="$2"; shift 2 ;;
-        --token)      TOKEN_OVERRIDE="$2"; shift 2 ;;
-        --dashboard)  HA_DASHBOARD="$2"; shift 2 ;;
-        --default)    HA_DASHBOARD=""; shift ;;
+        --dry-run)    DRY_RUN=true; shift ;;
+        --server)     HA_SERVER="$2"; SERVER_OVERRIDE_SET=true; shift 2 ;;
+        --token)
+            echo "❌ --token is intentionally unsupported because it exposes the HA token in process arguments"
+            echo "   Put HA_TOKEN in .env or use --token-file PATH"
+            exit 1 ;;
+        --token-file) TOKEN_FILE="$2"; shift 2 ;;
+        --dashboard)  HA_DASHBOARD="$2"; DASHBOARD_OVERRIDE_SET=true; shift 2 ;;
+        --default)    HA_DASHBOARD=""; DASHBOARD_OVERRIDE_SET=true; shift ;;
         --kiosk)      KIOSK_MODE="YES"; shift ;;
         --no-kiosk)   KIOSK_MODE="NO"; shift ;;
         --reset)      RESET_MODE=true; shift ;;
@@ -101,8 +148,21 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+[[ "$TARGET" == "ipad-pro" ]] && TARGET="ipadpro"
+
+if [[ -n "$TOKEN_FILE" ]]; then
+    if [[ ! -f "$TOKEN_FILE" ]]; then
+        echo "❌ Token file not found: $TOKEN_FILE"
+        exit 1
+    fi
+    IFS= read -r TOKEN_OVERRIDE < "$TOKEN_FILE" || true
+elif [[ -n "${HADASHBOARD_TOKEN_OVERRIDE:-}" ]]; then
+    TOKEN_OVERRIDE="$HADASHBOARD_TOKEN_OVERRIDE"
+fi
+unset HADASHBOARD_TOKEN_OVERRIDE 2>/dev/null || true
+
 if [[ -z "$TARGET" ]]; then
-    echo "Usage: scripts/deploy.sh <sim|iphone|mini5|mini4|ipad2> [options]"
+    echo "Usage: scripts/deploy.sh <all|sim|sim-ios93|sim-ios103|iphone|mini5|mini4|ipadpro|ipad2|ipad3|ipad4|mac> [options]"
     echo ""
     echo "Targets:"
     echo "  all            Deploy to all targets (builds once, deploys everywhere)"
@@ -111,8 +171,9 @@ if [[ -z "$TARGET" ]]; then
     echo "  sim-ios93      iOS 9.3 iPad Pro simulator (RosettaSim, x86_64)"
     echo "  sim-ios103     iOS 10.3 iPad Pro 10.5\" simulator (RosettaSim, x86_64)"
     echo "  iphone         Physical iPhone (via devicectl)"
-    echo "  mini5          iPad Mini 5 — iPadOS 26 (wired devicectl)"
+    echo "  mini5          iPad Mini 5 — iPadOS 26 (CoreDevice/MobileDevice WiFi)"
     echo "  mini4          iPad Mini 4 — iPadOS 15 (WiFi, ideviceinstaller)"
+    echo "  ipadpro        Physical iPad Pro (configured ID or one reachable physical iPad Pro)"
     echo "  ipad2          iPad 2 — iOS 9 (WiFi SSH, jailbroken)"
     echo "  ipad2-usb      iPad 2 — iOS 9 (Unraid USB fallback)"
     echo "  ipad3          iPad 3 — (WiFi SSH, jailbroken)"
@@ -122,8 +183,9 @@ if [[ -z "$TARGET" ]]; then
     echo ""
     echo "Options:"
     echo "  --no-build     Skip build step"
+    echo "  --dry-run      Resolve fleet/configuration only; no build, install, or launch"
     echo "  --server URL   Override HA server URL"
-    echo "  --token TOKEN  Override access token (this launch only)"
+    echo "  --token-file X Read access-token override from X (never forwarded in argv)"
     echo "  --dashboard X  Set dashboard path (default: living-room)"
     echo "  --default      Use default overview dashboard"
     echo "  --kiosk        Start in kiosk mode (hides nav, disables sleep)"
@@ -131,7 +193,7 @@ if [[ -z "$TARGET" ]]; then
     echo "  --reset        Clear credentials, start at login screen"
     echo "  --demo         Start in demo mode (no server needed)"
     echo ""
-    echo "Secrets are loaded from .env in project root."
+    echo "Secrets are loaded from the worktree .env, or the main checkout .env when absent."
     exit 1
 fi
 
@@ -154,70 +216,282 @@ deploy_with_retry() {
     return 1
 }
 
-# ── "all" target: build all first, then deploy in parallel ───────────
+resolve_ipad_pro_id() {
+    if [[ -n "$IPAD_PRO_DEVICECTL_ID" ]]; then
+        printf '%s\n' "$IPAD_PRO_DEVICECTL_ID"
+        return 0
+    fi
+
+    if [[ ! -d "$XCODE26" ]]; then
+        return 1
+    fi
+
+    local device_line
+    local candidate
+    local candidates=()
+    while IFS= read -r device_line; do
+        candidate=$(printf '%s\n' "$device_line" | awk '{
+            for (i = 1; i <= NF; i++) {
+                if ($i ~ /^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/) {
+                    print $i
+                    exit
+                }
+            }
+        }')
+        [[ -n "$candidate" ]] && candidates+=("$candidate")
+    done < <(
+        DEVELOPER_DIR="$XCODE26/Contents/Developer" xcrun devicectl list devices 2>/dev/null |
+            awk '/iPad Pro/ && /physical/'
+    )
+
+    if [[ ${#candidates[@]} -eq 1 ]]; then
+        printf '%s\n' "${candidates[0]}"
+        return 0
+    fi
+    if [[ ${#candidates[@]} -gt 1 ]]; then
+        echo "❌ More than one physical iPad Pro is visible; set IPAD_PRO_DEVICECTL_ID" >&2
+    fi
+    return 1
+}
+
+resolve_coredevice_hardware_udid() {
+    local coredevice_id="$1"
+    local details_dir
+    local details_json
+    COREDEVICE_HARDWARE_UDID=""
+    [[ -n "$coredevice_id" && -d "$XCODE26" ]] || return 1
+
+    details_dir=$(mktemp -d /tmp/hadashboard-coredevice-details.XXXXXX)
+    _CLEANUP_DIRS+=("$details_dir")
+    details_json="$details_dir/device.json"
+    if ! DEVELOPER_DIR="$XCODE26/Contents/Developer" \
+        xcrun devicectl device info details \
+            --device "$coredevice_id" \
+            --json-output "$details_json" >/dev/null 2>&1; then
+        return 1
+    fi
+    COREDEVICE_HARDWARE_UDID=$(plutil -extract result.properties.hardware.udid raw "$details_json" 2>/dev/null || true)
+    [[ -n "$COREDEVICE_HARDWARE_UDID" ]]
+}
+
+artifact_sha256() {
+    shasum -a 256 "$1" | awk '{print $1}'
+}
+
+verify_profile_contains_udids() {
+    local app="$1"
+    shift
+    local profile="$app/embedded.mobileprovision"
+    local profile_dir
+    local profile_plist
+    local provisioned_devices
+    local required_udid
+
+    if [[ ! -f "$profile" ]]; then
+        echo "❌ Universal app has no embedded development provisioning profile"
+        return 1
+    fi
+    profile_dir=$(mktemp -d /tmp/hadashboard-profile-check.XXXXXX)
+    _CLEANUP_DIRS+=("$profile_dir")
+    profile_plist="$profile_dir/profile.plist"
+    if ! security cms -D -i "$profile" > "$profile_plist" 2>/dev/null; then
+        echo "❌ Could not decode the universal app's provisioning profile"
+        return 1
+    fi
+    provisioned_devices=$(plutil -extract ProvisionedDevices json -o - "$profile_plist" 2>/dev/null || true)
+    if [[ -z "$provisioned_devices" ]]; then
+        echo "❌ Embedded profile is not a device development profile"
+        return 1
+    fi
+    for required_udid in "$@"; do
+        if ! printf '%s\n' "$provisioned_devices" | grep -Fiq "\"$required_udid\""; then
+            echo "❌ Embedded profile excludes a required fleet device"
+            return 1
+        fi
+    done
+}
+
+collect_fleet_targets() {
+    # `all` is the active six-target product fleet. Older iPad 2/3 endpoints
+    # remain explicit targets so stale-but-configured hosts cannot sink every
+    # current fleet deployment.
+    FLEET_TARGETS=(iphone mini5 mini4 ipad4)
+
+    IPAD_PRO_DEVICECTL_ID=$(resolve_ipad_pro_id || true)
+    if [[ -n "$IPAD_PRO_DEVICECTL_ID" ]]; then
+        FLEET_TARGETS+=(ipadpro)
+    fi
+    FLEET_TARGETS+=(mac)
+}
+
+if [[ "$DRY_RUN" == true ]]; then
+    echo "Dry run only — no build, install, launch, or remote connection will run."
+    echo "Environment: $ENV_FILE"
+    if [[ "$TARGET" == "all" ]]; then
+        collect_fleet_targets
+        echo "Fleet targets: ${FLEET_TARGETS[*]}"
+        [[ -n "$IPHONE_DEVICECTL_ID" ]] && echo "  iPhone: configured" || echo "  iPhone: missing IPHONE_DEVICECTL_ID"
+        if [[ -n "$IPAD_MINI5_DEVICECTL_ID" || -n "$IPAD_MINI5_UDID" ]]; then
+            echo "  iPad Mini 5: configured"
+        else
+            echo "  iPad Mini 5: missing CoreDevice ID and MobileDevice UDID"
+        fi
+        [[ -n "$IPAD_MINI4_UDID" ]] && echo "  iPad Mini 4: configured" || echo "  iPad Mini 4: missing IPAD_MINI4_UDID"
+        [[ -n "$IPAD4_IP" ]] && echo "  iPad 4: configured" || echo "  iPad 4: missing IPAD4_IP"
+        if [[ -n "$IPAD_PRO_DEVICECTL_ID" ]] && resolve_coredevice_hardware_udid "$IPAD_PRO_DEVICECTL_ID"; then
+            echo "  iPad Pro: uniquely resolved with an Xcode signing UDID"
+        else
+            echo "  iPad Pro: unresolved, ambiguous, or missing its signing UDID"
+        fi
+        echo "  Mac Catalyst: local"
+    else
+        echo "Target: $TARGET"
+    fi
+    exit 0
+fi
+
+# ── "all" target: one fleet build, then per-target evidence ──────────
 if [[ "$TARGET" == "all" ]]; then
-    # Collect pass-through options (exclude target and --no-build)
+    RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+    EVIDENCE_DIR="$PROJECT_DIR/build/deploy-evidence/$RUN_ID"
+    mkdir -p "$EVIDENCE_DIR"
+
+    # Collect only non-secret pass-through options. A token-file override is
+    # inherited through the environment and never copied into child argv.
     OPTS=()
-    [[ -n "$KIOSK_MODE" ]] && OPTS+=($([ "$KIOSK_MODE" == "YES" ] && echo "--kiosk" || echo "--no-kiosk"))
+    if [[ "$KIOSK_MODE" == "YES" ]]; then
+        OPTS+=(--kiosk)
+    elif [[ "$KIOSK_MODE" == "NO" ]]; then
+        OPTS+=(--no-kiosk)
+    fi
     [[ "$RESET_MODE" == true ]] && OPTS+=(--reset)
     [[ -n "$DEMO_MODE" ]] && OPTS+=(--demo)
-    [[ -n "$TOKEN_OVERRIDE" ]] && OPTS+=(--token "$TOKEN_OVERRIDE")
+    [[ "$SERVER_OVERRIDE_SET" == true ]] && OPTS+=(--server "$HA_SERVER")
+    if [[ "$DASHBOARD_OVERRIDE_SET" == true ]]; then
+        if [[ -n "$HA_DASHBOARD" ]]; then
+            OPTS+=(--dashboard "$HA_DASHBOARD")
+        else
+            OPTS+=(--default)
+        fi
+    fi
+    # Resolve every signed target before the expensive build. Xcode's
+    # destination accepts the hardware UDID, not devicectl's CoreDevice UUID.
+    collect_fleet_targets
+    export IPAD_PRO_DEVICECTL_ID
+    if [[ -z "$IPAD_PRO_DEVICECTL_ID" ]] || \
+       ! resolve_coredevice_hardware_udid "$IPAD_PRO_DEVICECTL_ID"; then
+        echo "❌ Fleet deployment requires one resolvable physical iPad Pro"
+        echo "   Set IPAD_PRO_DEVICECTL_ID if more than one is visible"
+        exit 1
+    fi
+    IPAD_PRO_SIGNING_UDID="$COREDEVICE_HARDWARE_UDID"
 
-    echo "🚀 Deploying to ALL targets..."
+    IPHONE_PROFILE_UDID="$IPHONE_UDID"
+    if [[ -z "$IPHONE_PROFILE_UDID" && -n "$IPHONE_DEVICECTL_ID" ]] && \
+       resolve_coredevice_hardware_udid "$IPHONE_DEVICECTL_ID"; then
+        IPHONE_PROFILE_UDID="$COREDEVICE_HARDWARE_UDID"
+    fi
+    MINI5_PROFILE_UDID="$IPAD_MINI5_UDID"
+    if [[ -z "$MINI5_PROFILE_UDID" && -n "$IPAD_MINI5_DEVICECTL_ID" ]] && \
+       resolve_coredevice_hardware_udid "$IPAD_MINI5_DEVICECTL_ID"; then
+        MINI5_PROFILE_UDID="$COREDEVICE_HARDWARE_UDID"
+    fi
+    if [[ -z "$IPHONE_PROFILE_UDID" || -z "$MINI5_PROFILE_UDID" || \
+          -z "$IPAD_MINI4_UDID" || -z "$IPAD4_UDID" ]]; then
+        echo "❌ Fleet UDIDs are incomplete; configure iPhone, both Minis, and iPad 4"
+        exit 1
+    fi
+    PROFILE_REQUIRED_UDIDS=(
+        "$IPHONE_PROFILE_UDID"
+        "$MINI5_PROFILE_UDID"
+        "$IPAD_MINI4_UDID"
+        "$IPAD4_UDID"
+        "$IPAD_PRO_SIGNING_UDID"
+    )
+
+    echo "🚀 Deploying one exact build across the configured physical fleet..."
+    echo "   Evidence: $EVIDENCE_DIR"
     echo ""
 
-    # ── Phase 1: Build all variants ──────────────────────────────────
+    # ── Phase 1: Build the two fleet artifacts once ──────────────────
     echo "── Phase 1: Building ──────────────────────────────────────"
-    echo "   Building simulator (arm64)..."
-    "$PROJECT_DIR/scripts/build.sh" sim > /dev/null
-    echo "   ✅ Simulator build complete"
+    if [[ "$NO_BUILD" == false ]]; then
+        echo "   Building device (universal armv7+arm64)..."
+        DEVICE_APP=$(HADASHBOARD_FORCE_SIGNING_STYLE=automatic \
+            HADASHBOARD_FORCE_SIGNING_DEVICE_ID="$IPAD_PRO_SIGNING_UDID" \
+            "$PROJECT_DIR/scripts/build.sh" device 2> "$EVIDENCE_DIR/build-device.log")
+        echo "   ✅ Device build complete"
 
-    echo "   Building device (universal armv7+arm64)..."
-    "$PROJECT_DIR/scripts/build.sh" device > /dev/null
-    echo "   ✅ Device build complete"
+        echo "   Building mac (Catalyst, arm64)..."
+        MAC_APP=$("$PROJECT_DIR/scripts/build.sh" mac 2> "$EVIDENCE_DIR/build-mac.log")
+        echo "   ✅ Mac Catalyst build complete"
+    else
+        DEVICE_APP="${HADASHBOARD_DEVICE_APP:-$PROJECT_DIR/build/universal/HA Dashboard.app}"
+        MAC_APP="${HADASHBOARD_MAC_APP:-$PROJECT_DIR/build/mac/Build/Products/Debug-maccatalyst/HA Dashboard.app}"
+        echo "   Reusing existing fleet artifacts (--no-build)"
+    fi
 
-    echo "   Building rosettasim (x86_64, iOS 9+)..."
-    "$PROJECT_DIR/scripts/build.sh" rosettasim > /dev/null
-    echo "   ✅ RosettaSim build complete"
+    DEVICE_BINARY="$DEVICE_APP/HA Dashboard"
+    MAC_BINARY="$MAC_APP/Contents/MacOS/HA Dashboard"
+    if [[ ! -f "$DEVICE_BINARY" || ! -f "$MAC_BINARY" ]]; then
+        echo "❌ One or more fleet artifacts are missing; see $EVIDENCE_DIR"
+        exit 1
+    fi
+    if ! verify_profile_contains_udids "$DEVICE_APP" "${PROFILE_REQUIRED_UDIDS[@]}"; then
+        echo "   No device deployment was attempted"
+        exit 1
+    fi
+    echo "   ✅ Embedded profile covers every signed fleet target"
+    HADASHBOARD_EXPECTED_DEVICE_SHA256=$(artifact_sha256 "$DEVICE_BINARY")
+    HADASHBOARD_EXPECTED_MAC_SHA256=$(artifact_sha256 "$MAC_BINARY")
+    export HADASHBOARD_DEVICE_APP="$DEVICE_APP"
+    export HADASHBOARD_MAC_APP="$MAC_APP"
+    export HADASHBOARD_EXPECTED_DEVICE_SHA256
+    export HADASHBOARD_EXPECTED_MAC_SHA256
 
-    echo "   Building mac (Catalyst, arm64)..."
-    "$PROJECT_DIR/scripts/build.sh" mac > /dev/null
-    echo "   ✅ Mac Catalyst build complete"
+    {
+        echo "run_id=$RUN_ID"
+        echo "git_commit=$(git -C "$PROJECT_DIR" rev-parse HEAD)"
+        echo "worktree_change_count=$(git -C "$PROJECT_DIR" status --porcelain | wc -l | tr -d ' ')"
+        echo "device_app=$DEVICE_APP"
+        echo "device_binary_sha256=$HADASHBOARD_EXPECTED_DEVICE_SHA256"
+        echo "mac_app=$MAC_APP"
+        echo "mac_binary_sha256=$HADASHBOARD_EXPECTED_MAC_SHA256"
+        echo "profile_verified_device_count=${#PROFILE_REQUIRED_UDIDS[@]}"
+        echo "targets=${FLEET_TARGETS[*]}"
+    } > "$EVIDENCE_DIR/manifest.txt"
     echo ""
 
     # ── Phase 2: Deploy in parallel with retries ─────────────────────
     echo "── Phase 2: Deploying (parallel, up to 3 retries) ───────"
-    LOGDIR=$(mktemp -d)
     PIDS=()
     LABELS=()
 
     deploy_bg() {
         local label="$1"; shift
-        deploy_with_retry "$@" > "$LOGDIR/$label.log" 2>&1 &
+        deploy_with_retry "$@" > "$EVIDENCE_DIR/$label.log" 2>&1 &
         PIDS+=($!)
         LABELS+=("$label")
     }
 
-    deploy_bg "sim"         sim         --no-build ${OPTS[@]+"${OPTS[@]}"}
-    # deploy_bg "sim-iphone"  sim iphone  --no-build ${OPTS[@]+"${OPTS[@]}"}
-    # deploy_bg "sim-ios93"   sim-ios93   --no-build ${OPTS[@]+"${OPTS[@]}"}
-    # deploy_bg "sim-ios103"  sim-ios103  --no-build ${OPTS[@]+"${OPTS[@]}"}
-    deploy_bg "iphone"      iphone      --no-build ${OPTS[@]+"${OPTS[@]}"}
-    deploy_bg "mini5"       mini5       --no-build ${OPTS[@]+"${OPTS[@]}"}
-    deploy_bg "mini4"       mini4       --no-build ${OPTS[@]+"${OPTS[@]}"}
-    deploy_bg "ipad2"       ipad2       --no-build ${OPTS[@]+"${OPTS[@]}"}
-    deploy_bg "ipad3"       ipad3       --no-build ${OPTS[@]+"${OPTS[@]}"}
-    deploy_bg "ipad4"       ipad4       --no-build ${OPTS[@]+"${OPTS[@]}"}
-    deploy_bg "mac"         mac         --no-build ${OPTS[@]+"${OPTS[@]}"}
+    if [[ -n "$TOKEN_OVERRIDE" ]]; then
+        export HADASHBOARD_TOKEN_OVERRIDE="$TOKEN_OVERRIDE"
+    fi
+    for fleet_target in "${FLEET_TARGETS[@]}"; do
+        deploy_bg "$fleet_target" "$fleet_target" --no-build ${OPTS[@]+"${OPTS[@]}"}
+    done
+    unset HADASHBOARD_TOKEN_OVERRIDE 2>/dev/null || true
 
     # Wait for all deploys and collect results
     FAILURES=()
     for i in "${!LABELS[@]}"; do
         if wait "${PIDS[$i]}"; then
             echo "   ✅ ${LABELS[$i]}"
+            echo "${LABELS[$i]}=success" >> "$EVIDENCE_DIR/manifest.txt"
         else
             echo "   ❌ ${LABELS[$i]} (see log below)"
             FAILURES+=("${LABELS[$i]}")
+            echo "${LABELS[$i]}=failed" >> "$EVIDENCE_DIR/manifest.txt"
         fi
     done
 
@@ -225,16 +499,16 @@ if [[ "$TARGET" == "all" ]]; then
     for label in ${FAILURES[@]+"${FAILURES[@]}"}; do
         echo ""
         echo "── $label deploy log ──────────────────────────────────"
-        cat "$LOGDIR/$label.log"
+        cat "$EVIDENCE_DIR/$label.log"
         echo "────────────────────────────────────────────────────────"
     done
-    rm -rf "$LOGDIR"
 
     echo ""
     if [[ ${#FAILURES[@]} -eq 0 ]]; then
-        echo "✅ All targets deployed"
+        echo "✅ All configured targets deployed; evidence retained at $EVIDENCE_DIR"
     else
         echo "⚠️  Deployed with failures: ${FAILURES[*]+"${FAILURES[*]}"}"
+        echo "   Evidence retained at $EVIDENCE_DIR"
         exit 1
     fi
     exit 0
@@ -257,18 +531,18 @@ case "$TARGET" in
             APP="$PROJECT_DIR/build/rosettasim/Build/Products/Debug-iphonesimulator/HA Dashboard.app"
         fi
         ;;
-    iphone|mini5|mini4|ipad2|ipad2-usb|ipad3|ipad4|ipad4-usb)
+    iphone|mini5|mini4|ipadpro|ipad2|ipad2-usb|ipad3|ipad4|ipad4-usb)
         if [[ "$NO_BUILD" == false ]]; then
             APP="$("$PROJECT_DIR/scripts/build.sh" device)"
         else
-            APP="$PROJECT_DIR/build/universal/HA Dashboard.app"
+            APP="${HADASHBOARD_DEVICE_APP:-$PROJECT_DIR/build/universal/HA Dashboard.app}"
         fi
         ;;
     mac)
         if [[ "$NO_BUILD" == false ]]; then
             APP="$("$PROJECT_DIR/scripts/build.sh" mac)"
         else
-            APP="$PROJECT_DIR/build/mac/Build/Products/Debug-maccatalyst/HA Dashboard.app"
+            APP="${HADASHBOARD_MAC_APP:-$PROJECT_DIR/build/mac/Build/Products/Debug-maccatalyst/HA Dashboard.app}"
         fi
         ;;
 esac
@@ -276,6 +550,24 @@ esac
 if [ ! -d "$APP" ]; then
     echo "❌ Build failed — app not found at $APP"
     exit 1
+fi
+
+# A fleet run exports the digest of each build it created. Every --no-build
+# child verifies the same executable before installing or launching it.
+if [[ "$TARGET" == "mac" ]]; then
+    ARTIFACT_BINARY="$APP/Contents/MacOS/HA Dashboard"
+    EXPECTED_ARTIFACT_SHA256="${HADASHBOARD_EXPECTED_MAC_SHA256:-}"
+else
+    ARTIFACT_BINARY="$APP/HA Dashboard"
+    EXPECTED_ARTIFACT_SHA256="${HADASHBOARD_EXPECTED_DEVICE_SHA256:-}"
+fi
+if [[ -n "$EXPECTED_ARTIFACT_SHA256" ]]; then
+    ACTUAL_ARTIFACT_SHA256=$(artifact_sha256 "$ARTIFACT_BINARY")
+    if [[ "$ACTUAL_ARTIFACT_SHA256" != "$EXPECTED_ARTIFACT_SHA256" ]]; then
+        echo "❌ Refusing deployment: the shared artifact changed after the fleet build"
+        exit 1
+    fi
+    echo "✅ Exact fleet artifact verified: $ACTUAL_ARTIFACT_SHA256"
 fi
 if [[ "$NO_BUILD" == false ]]; then
     # Catalyst binary is at Contents/MacOS/, iOS binary is at the app root
@@ -298,13 +590,14 @@ if [[ "$HA_DASHBOARD" == "living-room" ]]; then
 fi
 
 # ── Launch args ─────────────────────────────────────────────────────────
-# --reset takes priority: clear credentials first, then don't inject server/token
+# The Home Assistant token is deliberately never a process argument. Signed
+# device and Catalyst upgrades retain their Keychain; writable legacy targets
+# receive it through a protected plist written from stdin below.
+EFFECTIVE_TOKEN="${TOKEN_OVERRIDE:-$ENV_HA_TOKEN}"
 if [[ "$RESET_MODE" == true ]]; then
     LAUNCH_ARGS=(-HAClearCredentials YES)
 else
-    # Use token override if provided, otherwise fall back to .env token
-    EFFECTIVE_TOKEN="${TOKEN_OVERRIDE:-$HA_TOKEN}"
-    LAUNCH_ARGS=(-HAServerURL "$HA_SERVER" -HAAccessToken "$EFFECTIVE_TOKEN")
+    LAUNCH_ARGS=(-HAServerURL "$HA_SERVER")
 fi
 if [[ -n "$HA_DASHBOARD" ]]; then
     LAUNCH_ARGS+=(-HADashboard "$HA_DASHBOARD")
@@ -317,6 +610,51 @@ fi
 if [[ -n "$DEMO_MODE" ]]; then
     LAUNCH_ARGS+=(-HADemoMode "$DEMO_MODE")
 fi
+
+USB_LAUNCH_ARGS=("${LAUNCH_ARGS[@]}")
+
+write_ha_token_to_plist() {
+    local plist_path="$1"
+    if [[ -z "$EFFECTIVE_TOKEN" ]]; then
+        return 0
+    fi
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "❌ python3 is required to write HAAccessToken without exposing it in argv"
+        return 1
+    fi
+    printf '%s' "$EFFECTIVE_TOKEN" | python3 -c '
+import os
+import plistlib
+import sys
+
+path = sys.argv[1]
+try:
+    with open(path, "rb") as source:
+        values = plistlib.load(source)
+except (FileNotFoundError, plistlib.InvalidFileException):
+    values = {}
+values["HAAccessToken"] = sys.stdin.read()
+temporary = path + ".secret-tmp"
+descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+with os.fdopen(descriptor, "wb") as destination:
+    plistlib.dump(values, destination, fmt=plistlib.FMT_BINARY)
+os.replace(temporary, path)
+' "$plist_path"
+}
+
+unraid_ssh() {
+    SSHPASS="${UNRAID_PASS:-}" sshpass -e ssh \
+        -o StrictHostKeyChecking=no \
+        -o PreferredAuthentications=password \
+        "$UNRAID_USER@$UNRAID_HOST" "$@"
+}
+
+unraid_scp() {
+    SSHPASS="${UNRAID_PASS:-}" sshpass -e scp \
+        -o StrictHostKeyChecking=no \
+        -o PreferredAuthentications=password \
+        "$@"
+}
 
 # ── Deploy + Launch ─────────────────────────────────────────────────────
 case "$TARGET" in
@@ -347,7 +685,13 @@ case "$TARGET" in
         if [[ "$BOOT_STATE" != "Booted" ]]; then
             echo "   Booting simulator..."
             xcrun simctl boot "$SIM_UDID" 2>/dev/null || true
-            open -a Simulator
+            # The beta toolchain keeps Simulator inside its bundle and may not
+            # register a global application name on this host.
+            if [[ -d "$XCODE26/Contents/Developer/Applications/Simulator.app" ]]; then
+                open "$XCODE26/Contents/Developer/Applications/Simulator.app" || true
+            else
+                open -a Simulator || true
+            fi
             sleep 3
         fi
 
@@ -413,12 +757,15 @@ case "$TARGET" in
         if [[ -n "$PREFS_DIR" ]]; then
             echo "   Writing preferences..."
             PLIST="$PREFS_DIR/$BUNDLE_ID.plist"
-            defaults write "$PLIST" HAServerURL -string "$HA_SERVER"
-            defaults write "$PLIST" HAAccessToken -string "${TOKEN_OVERRIDE:-$HA_TOKEN}"
+            if [[ "$RESET_MODE" == true ]]; then
+                defaults write "$PLIST" HAClearCredentials -bool true
+            else
+                defaults write "$PLIST" HAServerURL -string "$HA_SERVER"
+                write_ha_token_to_plist "$PLIST"
+            fi
             defaults write "$PLIST" HADashboard -string "$HA_DASHBOARD"
             [[ -n "$KIOSK_MODE" ]] && defaults write "$PLIST" HAKioskMode -bool "$([ "$KIOSK_MODE" = "YES" ] && echo true || echo false)"
             [[ -n "$DEMO_MODE" ]] && defaults write "$PLIST" HADemoMode -bool true
-            [[ "$RESET_MODE" == true ]] && defaults write "$PLIST" HAClearCredentials -bool true
         else
             echo "   ⚠️  Could not find preferences directory — app will use cached credentials"
         fi
@@ -433,38 +780,168 @@ case "$TARGET" in
         echo "📱 Deploying to iPhone..."
         export DEVELOPER_DIR="$XCODE26/Contents/Developer"
 
-        echo "   Installing..."
+        if [[ -z "$IPHONE_DEVICECTL_ID" ]]; then
+            echo "❌ IPHONE_DEVICECTL_ID is not configured"
+            exit 1
+        fi
+        if ! xcrun devicectl device info details --device "$IPHONE_DEVICECTL_ID" >/dev/null 2>&1; then
+            echo "❌ Configured iPhone is not currently resolvable by CoreDevice"
+            exit 1
+        fi
+
+        echo "   Installing exact artifact..."
         xcrun devicectl device install app \
             --device "$IPHONE_DEVICECTL_ID" \
             "$APP" 2>&1 | tail -3
+        echo "   ✅ Exact artifact install completed on iPhone"
 
         echo "   Launching with dashboard: ${HA_DASHBOARD:-default}..."
-        xcrun devicectl device process launch \
+        set +e
+        _IPHONE_LAUNCH_OUTPUT=$(xcrun devicectl device process launch \
             --device "$IPHONE_DEVICECTL_ID" \
             --terminate-existing \
             -- "$BUNDLE_ID" \
-            "${LAUNCH_ARGS[@]}" 2>&1 | tail -3
+            "${LAUNCH_ARGS[@]}" 2>&1)
+        _IPHONE_LAUNCH_STATUS=$?
+        set -e
+        printf '%s\n' "$_IPHONE_LAUNCH_OUTPUT" | tail -3
 
-        echo "✅ Running on iPhone"
+        if [[ "$_IPHONE_LAUNCH_STATUS" -eq 0 ]]; then
+            echo "✅ Installed and running on iPhone"
+        elif printf '%s\n' "$_IPHONE_LAUNCH_OUTPUT" | grep -Fq 'FBSOpenApplicationErrorDomain' &&
+             printf '%s\n' "$_IPHONE_LAUNCH_OUTPUT" | grep -Fq 'Locked'; then
+            echo "✅ Installed-only success on iPhone; unlock it and open HA Dashboard to complete runtime launch acceptance"
+        else
+            echo "❌ iPhone runtime launch failed after a successful install"
+            exit "$_IPHONE_LAUNCH_STATUS"
+        fi
+        ;;
+
+    ipadpro)
+        echo "📱 Deploying to iPad Pro..."
+        export DEVELOPER_DIR="$XCODE26/Contents/Developer"
+        _IPAD_PRO_LAUNCHED=false
+
+        IPAD_PRO_DEVICECTL_ID=$(resolve_ipad_pro_id || true)
+        if [[ -z "$IPAD_PRO_DEVICECTL_ID" ]]; then
+            echo "❌ A unique physical iPad Pro is not resolvable; set IPAD_PRO_DEVICECTL_ID"
+            exit 1
+        fi
+        if ! xcrun devicectl device info details --device "$IPAD_PRO_DEVICECTL_ID" >/dev/null 2>&1; then
+            echo "❌ Configured iPad Pro is not currently resolvable by CoreDevice"
+            exit 1
+        fi
+
+        echo "   Installing exact artifact..."
+        xcrun devicectl device install app \
+            --device "$IPAD_PRO_DEVICECTL_ID" \
+            "$APP" 2>&1 | tail -3
+        echo "   ✅ Exact artifact install completed on iPad Pro"
+
+        echo "   Launching with dashboard: ${HA_DASHBOARD:-default}..."
+        set +e
+        _IPAD_PRO_LAUNCH_OUTPUT=$(xcrun devicectl device process launch \
+            --device "$IPAD_PRO_DEVICECTL_ID" \
+            --terminate-existing \
+            -- "$BUNDLE_ID" \
+            "${LAUNCH_ARGS[@]}" 2>&1)
+        _IPAD_PRO_LAUNCH_STATUS=$?
+        set -e
+        printf '%s\n' "$_IPAD_PRO_LAUNCH_OUTPUT" | tail -3
+
+        if [[ "$_IPAD_PRO_LAUNCH_STATUS" -eq 0 ]]; then
+            _IPAD_PRO_LAUNCHED=true
+            echo "   ✅ Runtime launch accepted on iPad Pro"
+        elif printf '%s\n' "$_IPAD_PRO_LAUNCH_OUTPUT" | grep -Fq 'FBSOpenApplicationErrorDomain' &&
+             printf '%s\n' "$_IPAD_PRO_LAUNCH_OUTPUT" | grep -Fq 'Locked'; then
+            echo "   ⚠️  Runtime launch not accepted because the iPad Pro is locked"
+        else
+            echo "❌ iPad Pro runtime launch failed after a successful install"
+            exit "$_IPAD_PRO_LAUNCH_STATUS"
+        fi
+
+        if [[ "$_IPAD_PRO_LAUNCHED" == true ]]; then
+            echo "✅ Installed and running on iPad Pro"
+        else
+            echo "✅ Installed-only success on iPad Pro; unlock it and open HA Dashboard to complete runtime launch acceptance"
+        fi
         ;;
 
     mini5)
-        echo "📱 Deploying to iPad Mini 5 (WiFi via devicectl)..."
+        echo "📱 Deploying to iPad Mini 5..."
         export DEVELOPER_DIR="$XCODE26/Contents/Developer"
+        _MINI5_LAUNCHED=false
 
-        echo "   Installing..."
-        xcrun devicectl device install app \
-            --device "$IPAD_MINI5_DEVICECTL_ID" \
-            "$APP" 2>&1 | tail -3
+        if [[ -n "$IPAD_MINI5_DEVICECTL_ID" ]] && \
+           xcrun devicectl device info details --device "$IPAD_MINI5_DEVICECTL_ID" >/dev/null 2>&1; then
+            echo "   Installing via CoreDevice..."
+            xcrun devicectl device install app \
+                --device "$IPAD_MINI5_DEVICECTL_ID" \
+                "$APP" 2>&1 | tail -3
 
-        echo "   Launching with dashboard: ${HA_DASHBOARD:-default}..."
-        xcrun devicectl device process launch \
-            --device "$IPAD_MINI5_DEVICECTL_ID" \
-            --terminate-existing \
-            -- "$BUNDLE_ID" \
-            "${LAUNCH_ARGS[@]}" 2>&1 | tail -3
+            echo "   Launching with dashboard: ${HA_DASHBOARD:-default}..."
+            xcrun devicectl device process launch \
+                --device "$IPAD_MINI5_DEVICECTL_ID" \
+                --terminate-existing \
+                -- "$BUNDLE_ID" \
+                "${LAUNCH_ARGS[@]}" 2>&1 | tail -3
+            _MINI5_LAUNCHED=true
+        elif [[ -n "$IPAD_MINI5_UDID" ]] && command -v ideviceinfo >/dev/null 2>&1 && \
+             ideviceinfo -n -u "$IPAD_MINI5_UDID" -k DeviceName >/dev/null 2>&1; then
+            echo "   CoreDevice record unavailable; using the validated MobileDevice WiFi pairing..."
+            _MINI5_PACKAGE_DIR="$(mktemp -d /tmp/hadashboard-mini5.XXXXXX)"
+            _CLEANUP_DIRS+=("$_MINI5_PACKAGE_DIR")
+            if command -v ios-deploy >/dev/null 2>&1; then
+                # iOS 26's installation-proxy upgrade can wait indefinitely
+                # after copying. ios-deploy uses the same paired Wi-Fi channel
+                # but gives observable install progress and a definitive
+                # InstallComplete marker. A missing personalized DDI may still
+                # prevent automatic launch after a successful installation.
+                _MINI5_INSTALL_LOG="$_MINI5_PACKAGE_DIR/ios-deploy.log"
+                set +e
+                if command -v gtimeout >/dev/null 2>&1; then
+                    gtimeout 120 ios-deploy -i "$IPAD_MINI5_UDID" -b "$APP" -L -I -t 20 \
+                        2>&1 | tee "$_MINI5_INSTALL_LOG"
+                else
+                    ios-deploy -i "$IPAD_MINI5_UDID" -b "$APP" -L -I -t 20 \
+                        2>&1 | tee "$_MINI5_INSTALL_LOG"
+                fi
+                _MINI5_IOS_DEPLOY_STATUS=${PIPESTATUS[0]}
+                set -e
+                if ! grep -Fq '[100%] Installed package' "$_MINI5_INSTALL_LOG"; then
+                    echo "❌ iPad Mini 5 ios-deploy install failed"
+                    [[ "${_MINI5_IOS_DEPLOY_STATUS:-1}" -ne 0 ]] || _MINI5_IOS_DEPLOY_STATUS=1
+                    exit "$_MINI5_IOS_DEPLOY_STATUS"
+                fi
+                if [[ "$_MINI5_IOS_DEPLOY_STATUS" -eq 0 ]]; then
+                    _MINI5_LAUNCHED=true
+                else
+                    echo "   Installed successfully; automatic launch needs the personalized Developer Disk Image or leaving Guided Access"
+                fi
+            elif command -v ideviceinstaller >/dev/null 2>&1; then
+                mkdir "$_MINI5_PACKAGE_DIR/Payload"
+                cp -R "$APP" "$_MINI5_PACKAGE_DIR/Payload/"
+                _MINI5_IPA="$_MINI5_PACKAGE_DIR/HA-Dashboard.ipa"
+                (cd "$_MINI5_PACKAGE_DIR" && zip -qry "$_MINI5_IPA" Payload)
+                if command -v gtimeout >/dev/null 2>&1; then
+                    gtimeout 120 ideviceinstaller -n -u "$IPAD_MINI5_UDID" upgrade "$_MINI5_IPA"
+                else
+                    ideviceinstaller -n -u "$IPAD_MINI5_UDID" upgrade "$_MINI5_IPA"
+                fi
+            else
+                echo "❌ Neither ios-deploy nor ideviceinstaller is available for iPad Mini 5"
+                exit 1
+            fi
+        else
+            echo "❌ iPad Mini 5 is not reachable through CoreDevice or its saved MobileDevice WiFi pairing"
+            exit 1
+        fi
 
-        echo "✅ Running on iPad Mini 5"
+        if [[ "$_MINI5_LAUNCHED" == true ]]; then
+            echo "✅ Running on iPad Mini 5"
+        else
+            echo "✅ Installed on iPad Mini 5; open HA Dashboard on the iPad to launch it"
+        fi
         ;;
 
     mini4)
@@ -480,6 +957,7 @@ case "$TARGET" in
 
         echo "📱 Deploying to iPad Mini 4 (WiFi via MobileInstallation)..."
         _MINI4_PACKAGE_DIR="$(mktemp -d /tmp/hadashboard-mini4.XXXXXX)"
+        _CLEANUP_DIRS+=("$_MINI4_PACKAGE_DIR")
         mkdir "$_MINI4_PACKAGE_DIR/Payload"
         cp -R "$APP" "$_MINI4_PACKAGE_DIR/Payload/"
         _MINI4_IPA="$_MINI4_PACKAGE_DIR/HA-Dashboard.ipa"
@@ -491,22 +969,45 @@ case "$TARGET" in
             exit 1
         fi
 
-        echo "✅ Upgraded iPad Mini 4; launch HA Dashboard on the device to retain its existing settings"
+        _MINI4_LAUNCHED=false
+        if command -v idevicedebug >/dev/null 2>&1 &&
+           idevicedebug -n -u "$IPAD_MINI4_UDID" --detach run "$BUNDLE_ID" >/dev/null 2>&1; then
+            _MINI4_LAUNCHED=true
+        fi
+        if [[ "$_MINI4_LAUNCHED" == true ]]; then
+            echo "✅ Upgraded and launched iPad Mini 4"
+        else
+            echo "✅ Upgraded iPad Mini 4; open HA Dashboard on the device to launch it"
+        fi
         ;;
 
     ipad2|ipad3|ipad4)
         # ── Shared jailbroken iPad deploy (SSH over WiFi) ─────────────
         case "$TARGET" in
-            ipad2) _IPAD_LABEL="iPad 2"; _IPAD_IP="$IPAD2_IP"; _IPAD_PASS="$IPAD2_SSH_PASS"
-                   _SSH_OPTS="-o HostkeyAlgorithms=ssh-rsa"
-                   _SCP_EXTRA="" ;;
-            ipad3) _IPAD_LABEL="iPad 3"; _IPAD_IP="$IPAD3_IP"; _IPAD_PASS="$IPAD3_SSH_PASS"
-                   _SSH_OPTS="-o HostkeyAlgorithms=ssh-rsa"
-                   _SCP_EXTRA="" ;;
-            ipad4) _IPAD_LABEL="iPad 4"; _IPAD_IP="$IPAD4_IP"; _IPAD_PASS="$IPAD4_SSH_PASS"
-                   _SSH_OPTS="-o HostkeyAlgorithms=ssh-rsa"
-                   _SCP_EXTRA="" ;;
+            ipad2) _IPAD_LABEL="iPad 2"; _IPAD_IP="$IPAD2_IP"; _IPAD_PASS="$IPAD2_SSH_PASS" ;;
+            ipad3) _IPAD_LABEL="iPad 3"; _IPAD_IP="$IPAD3_IP"; _IPAD_PASS="$IPAD3_SSH_PASS" ;;
+            ipad4) _IPAD_LABEL="iPad 4"; _IPAD_IP="$IPAD4_IP"; _IPAD_PASS="$IPAD4_SSH_PASS" ;;
         esac
+        _IPAD_CONTROL_PATH="/tmp/hadashboard-${TARGET}-ssh-$$.sock"
+        _SSH_OPTIONS=(
+            -o StrictHostKeyChecking=no
+            -o UserKnownHostsFile=/dev/null
+            -o HostkeyAlgorithms=ssh-rsa
+            -o ControlMaster=auto
+            -o ControlPersist=120
+            -o ControlPath="$_IPAD_CONTROL_PATH"
+            -o ConnectTimeout=12
+            -o ConnectionAttempts=1
+            -o NumberOfPasswordPrompts=1
+            -o PreferredAuthentications=password
+        )
+
+        ipad_ssh() {
+            SSHPASS="$_IPAD_PASS" sshpass -e ssh "${_SSH_OPTIONS[@]}" "root@$_IPAD_IP" "$@"
+        }
+        ipad_scp() {
+            SSHPASS="$_IPAD_PASS" sshpass -e scp "${_SSH_OPTIONS[@]}" "$@"
+        }
 
         echo "📱 Deploying to $_IPAD_LABEL via WiFi SSH ($_IPAD_IP)..."
 
@@ -515,15 +1016,10 @@ case "$TARGET" in
             exit 1
         fi
 
-        _IPAD_SSH="sshpass -p ${_IPAD_PASS} ssh -o StrictHostKeyChecking=no ${_SSH_OPTS} root@${_IPAD_IP}"
-        _IPAD_SCP="sshpass -p ${_IPAD_PASS} scp ${_SCP_EXTRA} -o StrictHostKeyChecking=no ${_SSH_OPTS}"
-        _IPAD_SSH_ARGS=(sshpass -p "$_IPAD_PASS" ssh -o StrictHostKeyChecking=no)
-        [[ -n "$_SSH_OPTS" ]] && _IPAD_SSH_ARGS+=($_SSH_OPTS)
-        _IPAD_SSH_ARGS+=("root@$_IPAD_IP")
-
-        if ! $_IPAD_SSH "echo ok" &>/dev/null; then
+        if ! ipad_ssh "echo ok" &>/dev/null; then
             echo "❌ Cannot SSH to $_IPAD_LABEL at $_IPAD_IP"
-            echo "   Ensure iPad is jailbroken, OpenSSH is installed, and WiFi is connected"
+            echo "   Ensure the iPad is jailbroken, WiFi is connected, and a compatible SSH daemon is running"
+            [[ "$TARGET" == "ipad4" ]] && echo "   h3lix/iOS 10.3.3 normally requires Dropbear; OpenSSH may accept port 22 but hang before its banner"
             exit 1
         fi
 
@@ -532,7 +1028,7 @@ case "$TARGET" in
         _BACKUP_ID="$(date +%Y%m%d-%H%M%S)"
         _BACKUP_DIR="/var/mobile/Library/HADashboard-backups/$BUNDLE_ID/$_BACKUP_ID"
         echo "   Backing up existing app and preferences..."
-        if ! "${_IPAD_SSH_ARGS[@]}" "
+        if ! ipad_ssh "
             set -e
             mkdir -p '$_BACKUP_DIR'
             echo 'backup: directory ready'
@@ -558,35 +1054,48 @@ case "$TARGET" in
             exit 1
         fi
 
-        APP_TAR="$PROJECT_DIR/build/HADashboard.app.tar.gz"
+        _DEPLOY_WORK_DIR=$(mktemp -d "$PROJECT_DIR/build/${TARGET}.deploy.XXXXXX")
+        _CLEANUP_DIRS+=("$_DEPLOY_WORK_DIR")
+        APP_TAR="$_DEPLOY_WORK_DIR/HADashboard.app.tar.gz"
         echo "   Packaging .app..."
         if [[ "$TARGET" == "ipad4" ]]; then
             # iOS 10+: strip Apple codesign (conflicts with ldid on-device)
-            _STAGE="$PROJECT_DIR/build/stage-jb"
-            rm -rf "$_STAGE"
+            _STAGE="$_DEPLOY_WORK_DIR/stage-jb"
             mkdir -p "$_STAGE"
             cp -R "$APP" "$_STAGE/"
             _STAGED_APP="$_STAGE/$(basename "$APP")"
+            _JB_ENTITLEMENTS="$_STAGED_APP/HA-Dashboard.jailbreak.entitlements"
+            if ! codesign -d --entitlements :- "$_STAGED_APP/HA Dashboard" \
+                > "$_JB_ENTITLEMENTS" 2>/dev/null ||
+               ! plutil -lint "$_JB_ENTITLEMENTS" >/dev/null 2>&1; then
+                echo "❌ Could not preserve the signed app entitlements for iPad 4 Keychain access"
+                exit 1
+            fi
+            if ! plutil -extract application-identifier raw "$_JB_ENTITLEMENTS" >/dev/null 2>&1 &&
+               ! plutil -extract com.apple.application-identifier raw "$_JB_ENTITLEMENTS" >/dev/null 2>&1; then
+                echo "❌ The iPad 4 signing entitlements do not contain an application identifier"
+                exit 1
+            fi
             codesign --remove-signature "$_STAGED_APP/HA Dashboard" 2>/dev/null || true
             rm -f "$_STAGED_APP/embedded.mobileprovision"
             tar -czf "$APP_TAR" -C "$_STAGE" "$(basename "$APP")"
-            rm -rf "$_STAGE"
         else
             # iOS 9: ldid -S works fine over Apple-signed binaries
             tar -czf "$APP_TAR" -C "$(dirname "$APP")" "$(basename "$APP")"
         fi
 
         # Merge deploy preferences into existing plist on device
-        _PLIST="$PROJECT_DIR/build/${TARGET}-prefs.plist"
+        _PLIST="$_DEPLOY_WORK_DIR/${TARGET}-prefs.plist"
+        _SENSITIVE_PREFS_FILE="$_PLIST"
         PREFS_PATH="/var/mobile/Library/Preferences/$BUNDLE_ID.plist"
         rm -f "$_PLIST"
-        $_IPAD_SCP "root@${_IPAD_IP}:$PREFS_PATH" "$_PLIST" 2>/dev/null || true
+        ipad_scp "root@${_IPAD_IP}:$PREFS_PATH" "$_PLIST" 2>/dev/null || true
         _PLIST_BASE="${_PLIST%.plist}"
         if [ "$RESET_MODE" = "true" ]; then
             defaults write "$_PLIST_BASE" HAClearCredentials -bool true
         else
             defaults write "$_PLIST_BASE" HAServerURL -string "$HA_SERVER"
-            defaults write "$_PLIST_BASE" HAAccessToken -string "${EFFECTIVE_TOKEN}"
+            write_ha_token_to_plist "$_PLIST"
         fi
         defaults write "$_PLIST_BASE" HADashboard -string "$HA_DASHBOARD"
         defaults write "$_PLIST_BASE" HAKioskMode -bool "$([ "$KIOSK_MODE" = "YES" ] && echo true || echo false)"
@@ -594,42 +1103,77 @@ case "$TARGET" in
         plutil -convert binary1 "$_PLIST"
 
         echo "   Transferring to $_IPAD_LABEL ($_IPAD_IP)..."
-        $_IPAD_SCP "$APP_TAR" "root@${_IPAD_IP}:/tmp/HADashboard.app.tar.gz"
-        $_IPAD_SCP "$_PLIST" "root@${_IPAD_IP}:/tmp/ha-prefs.plist"
+        ipad_scp "$APP_TAR" "root@${_IPAD_IP}:/tmp/HADashboard.app.tar.gz"
+        ipad_scp "$_PLIST" "root@${_IPAD_IP}:/tmp/ha-prefs.plist"
 
         echo "   Installing..."
-        $_IPAD_SSH "
-            cd /Applications
-            rm -rf 'HA Dashboard.app'
-            tar xzf /tmp/HADashboard.app.tar.gz
-            rm /tmp/HADashboard.app.tar.gz
+        if ! ipad_ssh sh -s -- "$BUNDLE_ID" <<'REMOTE_INSTALL'
+set -e
+BUNDLE_ID="$1"
+APP_DIR='/Applications/HA Dashboard.app'
+APP_EXEC="$APP_DIR/HA Dashboard"
 
-            which ldid >/dev/null 2>&1 && ldid -S 'HA Dashboard.app/HA Dashboard'
-            killall 'HA Dashboard' 2>/dev/null || true
-            uicache 2>/dev/null || true
+# The jailbroken iOS 9/10 userland has pgrep but no awk. Anchor the full
+# executable path so only this app is signalled; a generic process-name kill is
+# deliberately avoided.
+if command -v pgrep >/dev/null 2>&1; then
+    APP_PIDS=$(pgrep -f "^$APP_EXEC([[:space:]].*)?$" 2>/dev/null || true)
+    for APP_PID in $APP_PIDS; do
+        kill "$APP_PID" 2>/dev/null || true
+    done
+fi
 
-            # Clear only this app's caches. Other apps and their data remain untouched.
-            rm -rf /var/mobile/Library/Caches/$BUNDLE_ID 2>/dev/null || true
-            rm -rf /var/mobile/tmp/$BUNDLE_ID* 2>/dev/null || true
+cd /Applications
+rm -rf 'HA Dashboard.app'
+tar xzf /tmp/HADashboard.app.tar.gz
+rm /tmp/HADashboard.app.tar.gz
 
-            PREFS_DIR=/var/mobile/Library/Preferences
-            mkdir -p \$PREFS_DIR
-            mv /tmp/ha-prefs.plist \$PREFS_DIR/$BUNDLE_ID.plist
-            chmod 644 \$PREFS_DIR/$BUNDLE_ID.plist
-            chown mobile:mobile \$PREFS_DIR/$BUNDLE_ID.plist
+if ! command -v ldid >/dev/null 2>&1; then
+    echo 'ldid is required to install this jailbreak build' >&2
+    exit 1
+fi
+if [ -f 'HA Dashboard.app/HA-Dashboard.jailbreak.entitlements' ]; then
+    ldid -S'HA Dashboard.app/HA-Dashboard.jailbreak.entitlements' 'HA Dashboard.app/HA Dashboard'
+    rm -f 'HA Dashboard.app/HA-Dashboard.jailbreak.entitlements'
+else
+    ldid -S 'HA Dashboard.app/HA Dashboard'
+fi
+uicache 2>/dev/null || true
 
-            rm -f /tmp/ha-log.txt
-            sleep 2
-            open $BUNDLE_ID 2>/dev/null || true
-        "
+# Clear only this app's caches. Other apps and their data remain untouched.
+rm -rf "/var/mobile/Library/Caches/$BUNDLE_ID" 2>/dev/null || true
+find /var/mobile/tmp -maxdepth 1 -name "$BUNDLE_ID*" -exec rm -rf {} \; 2>/dev/null || true
+
+PREFS_DIR=/var/mobile/Library/Preferences
+mkdir -p "$PREFS_DIR"
+mv /tmp/ha-prefs.plist "$PREFS_DIR/$BUNDLE_ID.plist"
+chmod 644 "$PREFS_DIR/$BUNDLE_ID.plist"
+chown mobile:mobile "$PREFS_DIR/$BUNDLE_ID.plist"
+
+rm -f /tmp/ha-log.txt
+sleep 2
+open "$BUNDLE_ID" 2>/dev/null || true
+REMOTE_INSTALL
+        then
+            echo "❌ Remote installation failed on $_IPAD_LABEL"
+            exit 1
+        fi
 
         echo "   Waiting for startup log..."
         sleep 8
         echo ""
         echo "── $_IPAD_LABEL log ─────────────────────────────────────"
-        $_IPAD_SSH "cat /var/mobile/Documents/ha-log.txt 2>/dev/null || echo '(no log file found)'"
+        ipad_ssh '
+            LOG_PATH=$(find /var/mobile/Containers/Data/Application -path "*/Documents/ha-log.txt" -type f 2>/dev/null | head -1)
+            if [ -n "$LOG_PATH" ]; then
+                tail -160 "$LOG_PATH"
+            else
+                echo "(no app-container log file found)"
+            fi
+        '
         echo "────────────────────────────────────────────────────────"
         echo "   Backup retained at: $_BACKUP_DIR"
+        ssh "${_SSH_OPTIONS[@]}" -O exit "root@$_IPAD_IP" >/dev/null 2>&1 || true
         echo ""
         echo "✅ Deployed to $_IPAD_LABEL (WiFi)"
         ;;
@@ -637,24 +1181,42 @@ case "$TARGET" in
     mac)
         echo "🖥  Deploying to Mac (Catalyst)..."
 
-        # Write launch args to NSUserDefaults for the app's bundle ID
-        if [[ "$RESET_MODE" == true ]]; then
-            defaults write "$BUNDLE_ID" HAClearCredentials -bool true
-        else
-            EFFECTIVE_TOKEN="${TOKEN_OVERRIDE:-$HA_TOKEN}"
-            defaults write "$BUNDLE_ID" HAServerURL -string "$HA_SERVER"
-            defaults write "$BUNDLE_ID" HAAccessToken -string "$EFFECTIVE_TOKEN"
-        fi
-        defaults write "$BUNDLE_ID" HADashboard -string "$HA_DASHBOARD"
-        [[ -n "$KIOSK_MODE" ]] && defaults write "$BUNDLE_ID" HAKioskMode -bool "$([ "$KIOSK_MODE" = "YES" ] && echo true || echo false)"
-        [[ -n "$DEMO_MODE" ]] && defaults write "$BUNDLE_ID" HADemoMode -bool true
-
-        # Kill existing instance if running
-        killall "HA Dashboard" 2>/dev/null || true
+        # Discover by this exact app executable path, verify every candidate,
+        # and terminate only those PIDs. Do not use a generic process name.
+        MAC_EXECUTABLE="$APP/Contents/MacOS/HA Dashboard"
+        MAC_EXECUTABLE_PATTERN=$(printf '%s' "$MAC_EXECUTABLE" | sed 's/[][\\.^$*+?(){}|]/\\&/g')
+        while IFS= read -r MAC_PID; do
+            [[ -n "$MAC_PID" ]] || continue
+            MAC_COMMAND=$(ps -p "$MAC_PID" -o command= 2>/dev/null || true)
+            case "$MAC_COMMAND" in
+                "$MAC_EXECUTABLE"|"$MAC_EXECUTABLE "*) kill "$MAC_PID" ;;
+            esac
+        done < <(pgrep -f "^${MAC_EXECUTABLE_PATTERN}([[:space:]]|$)" 2>/dev/null || true)
         sleep 0.5
 
         echo "   Launching with dashboard: ${HA_DASHBOARD:-default}..."
-        open "$APP"
+        # A sandboxed Catalyst app reads its own container preferences, so
+        # global `defaults write` cannot seed this app. Pass only non-secret
+        # settings; the existing Home Assistant token remains in the Keychain.
+        open -n "$APP" --args "${LAUNCH_ARGS[@]}"
+
+        MAC_LAUNCH_PID=""
+        for _ in 1 2 3 4 5 6 7 8 9 10; do
+            while IFS= read -r MAC_PID; do
+                [[ -n "$MAC_PID" ]] || continue
+                MAC_COMMAND=$(ps -p "$MAC_PID" -o command= 2>/dev/null || true)
+                case "$MAC_COMMAND" in
+                    "$MAC_EXECUTABLE"|"$MAC_EXECUTABLE "*) MAC_LAUNCH_PID="$MAC_PID"; break ;;
+                esac
+            done < <(pgrep -f "^${MAC_EXECUTABLE_PATTERN}([[:space:]]|$)" 2>/dev/null || true)
+            [[ -n "$MAC_LAUNCH_PID" ]] && break
+            sleep 0.2
+        done
+        if [[ -z "$MAC_LAUNCH_PID" ]]; then
+            echo "❌ Catalyst launch was not observed at the exact executable path"
+            exit 1
+        fi
+        echo "   Launch verified: pid $MAC_LAUNCH_PID"
 
         echo "✅ Running on Mac"
         ;;
@@ -664,6 +1226,10 @@ case "$TARGET" in
 
         if [[ -z "$UNRAID_HOST" ]]; then
             echo "❌ UNRAID_HOST not set in .env"
+            exit 1
+        fi
+        if [[ -z "$IPAD2_UDID" ]]; then
+            echo "❌ IPAD2_UDID is required for exact USB targeting"
             exit 1
         fi
 
@@ -677,31 +1243,22 @@ case "$TARGET" in
 
         # Transfer to Unraid
         echo "   Transferring to $UNRAID_HOST..."
-        sshpass -p "${UNRAID_PASS:-}" scp -o StrictHostKeyChecking=no \
-            -o PreferredAuthentications=password \
-            "$IPA" "$UNRAID_USER@$UNRAID_HOST:/tmp/HADashboard.ipa"
+        unraid_scp "$IPA" "$UNRAID_USER@$UNRAID_HOST:/tmp/HADashboard.ipa"
 
         # Transfer developer disk image if not already on server
         DDI_DIR="/Applications/Xcode-13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/DeviceSupport/9.3"
-        sshpass -p "${UNRAID_PASS:-}" ssh -o StrictHostKeyChecking=no \
-            -o PreferredAuthentications=password \
-            "$UNRAID_USER@$UNRAID_HOST" 'test -f /tmp/ios-ddi/DeveloperDiskImage.dmg && echo EXISTS || echo MISSING' 2>/dev/null | grep -q EXISTS
-        if [[ $? -ne 0 ]] && [[ -f "$DDI_DIR/DeveloperDiskImage.dmg" ]]; then
+        if ! unraid_ssh 'test -f /tmp/ios-ddi/DeveloperDiskImage.dmg' 2>/dev/null && \
+            [[ -f "$DDI_DIR/DeveloperDiskImage.dmg" ]]; then
             echo "   Uploading developer disk image..."
-            sshpass -p "${UNRAID_PASS:-}" ssh -o StrictHostKeyChecking=no \
-                -o PreferredAuthentications=password \
-                "$UNRAID_USER@$UNRAID_HOST" 'mkdir -p /tmp/ios-ddi'
-            sshpass -p "${UNRAID_PASS:-}" scp -o StrictHostKeyChecking=no \
-                -o PreferredAuthentications=password \
+            unraid_ssh 'mkdir -p /tmp/ios-ddi'
+            unraid_scp \
                 "$DDI_DIR/DeveloperDiskImage.dmg" "$DDI_DIR/DeveloperDiskImage.dmg.signature" \
                 "$UNRAID_USER@$UNRAID_HOST:/tmp/ios-ddi/"
         fi
 
         # Install via Docker + libimobiledevice
         echo "   Installing on iPad 2..."
-        sshpass -p "${UNRAID_PASS:-}" ssh -o StrictHostKeyChecking=no \
-            -o PreferredAuthentications=password \
-            "$UNRAID_USER@$UNRAID_HOST" '
+        unraid_ssh '
 mkdir -p /tmp/ios-lockdown
 docker run --rm --privileged \
   -v /dev/bus/usb:/dev/bus/usb \
@@ -715,36 +1272,41 @@ docker run --rm --privileged \
     usbmuxd -f &
     sleep 3
     UDID=\$(idevice_id -l 2>/dev/null | head -1)
+    EXPECTED_UDID='"$IPAD2_UDID"'
     if [ -z \"\$UDID\" ]; then
       echo \"❌ No iOS device found on USB\"
+      exit 1
+    fi
+    if [ -n \"\$EXPECTED_UDID\" ] && [ \"\$UDID\" != \"\$EXPECTED_UDID\" ]; then
+      echo \"❌ Connected USB device does not match configured iPad 2 UDID\"
       exit 1
     fi
     echo \"   Device: \$UDID\"
 
     # Ensure device is paired
-    if ! idevicepair validate 2>/dev/null; then
+    if ! idevicepair -u \"\$UDID\" validate 2>/dev/null; then
       echo \"   Pairing (tap Trust on iPad if prompted)...\"
-      idevicepair pair 2>&1 || true
+      idevicepair -u \"\$UDID\" pair 2>&1 || true
       sleep 5
-      idevicepair validate 2>/dev/null || echo \"⚠️  Not paired — tap Trust on iPad, then retry\"
+      idevicepair -u \"\$UDID\" validate 2>/dev/null || echo \"⚠️  Not paired — tap Trust on iPad, then retry\"
     fi
 
     # Install app
-    ideviceinstaller -i /tmp/HADashboard.ipa 2>&1 | grep -E \"(Install:|ERROR|DONE|Copying)\"
+    ideviceinstaller -u \"\$UDID\" -i /tmp/HADashboard.ipa 2>&1 | grep -E \"(Install:|ERROR|DONE|Copying)\"
 
     # Mount developer disk image if available
     if [ -f /tmp/ddi/DeveloperDiskImage.dmg ]; then
-      if ! ideviceimagemounter -l 2>&1 | grep -q \"ImagePresent: true\"; then
+      if ! ideviceimagemounter -u \"\$UDID\" -l 2>&1 | grep -q \"ImagePresent: true\"; then
         echo \"   Mounting developer disk image...\"
-        ideviceimagemounter /tmp/ddi/DeveloperDiskImage.dmg /tmp/ddi/DeveloperDiskImage.dmg.signature 2>&1
+        ideviceimagemounter -u \"\$UDID\" /tmp/ddi/DeveloperDiskImage.dmg /tmp/ddi/DeveloperDiskImage.dmg.signature 2>&1
       fi
     else
       echo \"   ⚠️  No developer disk image at /tmp/ddi/\"
     fi
 
-    # Launch the app with credentials and dashboard args
-    echo \"   Launch args: '"${LAUNCH_ARGS[*]}"'\"
-    idevicedebug run '"$BUNDLE_ID"' '"${LAUNCH_ARGS[*]}"' 2>&1 &
+    # Launch without putting the Home Assistant token in process arguments.
+    echo \"   Launching with non-secret arguments (token redacted)\"
+    idevicedebug -u \"\$UDID\" run '"$BUNDLE_ID"' '"${USB_LAUNCH_ARGS[*]}"' 2>&1 &
     DBGPID=\\\$!
     sleep 5
     kill \\\$DBGPID 2>/dev/null || true
@@ -761,6 +1323,10 @@ docker run --rm --privileged \
             echo "❌ UNRAID_HOST not set in .env"
             exit 1
         fi
+        if [[ -z "$IPAD4_UDID" ]]; then
+            echo "❌ IPAD4_UDID is required for exact USB targeting"
+            exit 1
+        fi
 
         # Package as IPA
         IPA="$PROJECT_DIR/build/HADashboard.ipa"
@@ -772,31 +1338,22 @@ docker run --rm --privileged \
 
         # Transfer to Unraid
         echo "   Transferring to $UNRAID_HOST..."
-        sshpass -p "${UNRAID_PASS:-}" scp -o StrictHostKeyChecking=no \
-            -o PreferredAuthentications=password \
-            "$IPA" "$UNRAID_USER@$UNRAID_HOST:/tmp/HADashboard.ipa"
+        unraid_scp "$IPA" "$UNRAID_USER@$UNRAID_HOST:/tmp/HADashboard.ipa"
 
         # Transfer developer disk image for iOS 10.3 if needed
         DDI_DIR="/Applications/Xcode-13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/DeviceSupport/10.3"
-        sshpass -p "${UNRAID_PASS:-}" ssh -o StrictHostKeyChecking=no \
-            -o PreferredAuthentications=password \
-            "$UNRAID_USER@$UNRAID_HOST" 'test -f /tmp/ios-ddi-10/DeveloperDiskImage.dmg && echo EXISTS || echo MISSING' 2>/dev/null | grep -q EXISTS
-        if [[ $? -ne 0 ]] && [[ -d "$DDI_DIR" ]]; then
+        if ! unraid_ssh 'test -f /tmp/ios-ddi-10/DeveloperDiskImage.dmg' 2>/dev/null && \
+            [[ -d "$DDI_DIR" ]]; then
             echo "   Uploading developer disk image (iOS 10.3)..."
-            sshpass -p "${UNRAID_PASS:-}" ssh -o StrictHostKeyChecking=no \
-                -o PreferredAuthentications=password \
-                "$UNRAID_USER@$UNRAID_HOST" 'mkdir -p /tmp/ios-ddi-10'
-            sshpass -p "${UNRAID_PASS:-}" scp -o StrictHostKeyChecking=no \
-                -o PreferredAuthentications=password \
+            unraid_ssh 'mkdir -p /tmp/ios-ddi-10'
+            unraid_scp \
                 "$DDI_DIR/DeveloperDiskImage.dmg" "$DDI_DIR/DeveloperDiskImage.dmg.signature" \
                 "$UNRAID_USER@$UNRAID_HOST:/tmp/ios-ddi-10/"
         fi
 
         # Install via Docker + libimobiledevice
         echo "   Installing on iPad 4..."
-        sshpass -p "${UNRAID_PASS:-}" ssh -o StrictHostKeyChecking=no \
-            -o PreferredAuthentications=password \
-            "$UNRAID_USER@$UNRAID_HOST" '
+        unraid_ssh '
 mkdir -p /tmp/ios-lockdown
 docker run --rm --privileged \
   -v /dev/bus/usb:/dev/bus/usb \
@@ -810,36 +1367,41 @@ docker run --rm --privileged \
     usbmuxd -f &
     sleep 3
     UDID=\$(idevice_id -l 2>/dev/null | head -1)
+    EXPECTED_UDID='"$IPAD4_UDID"'
     if [ -z \"\$UDID\" ]; then
       echo \"❌ No iOS device found on USB\"
+      exit 1
+    fi
+    if [ -n \"\$EXPECTED_UDID\" ] && [ \"\$UDID\" != \"\$EXPECTED_UDID\" ]; then
+      echo \"❌ Connected USB device does not match configured iPad 4 UDID\"
       exit 1
     fi
     echo \"   Device: \$UDID\"
 
     # Ensure device is paired
-    if ! idevicepair validate 2>/dev/null; then
+    if ! idevicepair -u \"\$UDID\" validate 2>/dev/null; then
       echo \"   Pairing (tap Trust on iPad if prompted)...\"
-      idevicepair pair 2>&1 || true
+      idevicepair -u \"\$UDID\" pair 2>&1 || true
       sleep 5
-      idevicepair validate 2>/dev/null || echo \"⚠️  Not paired — tap Trust on iPad, then retry\"
+      idevicepair -u \"\$UDID\" validate 2>/dev/null || echo \"⚠️  Not paired — tap Trust on iPad, then retry\"
     fi
 
     # Install app
-    ideviceinstaller -i /tmp/HADashboard.ipa 2>&1 | grep -E \"(Install:|ERROR|DONE|Copying)\"
+    ideviceinstaller -u \"\$UDID\" -i /tmp/HADashboard.ipa 2>&1 | grep -E \"(Install:|ERROR|DONE|Copying)\"
 
     # Mount developer disk image if available
     if [ -f /tmp/ddi/DeveloperDiskImage.dmg ]; then
-      if ! ideviceimagemounter -l 2>&1 | grep -q \"ImagePresent: true\"; then
+      if ! ideviceimagemounter -u \"\$UDID\" -l 2>&1 | grep -q \"ImagePresent: true\"; then
         echo \"   Mounting developer disk image...\"
-        ideviceimagemounter /tmp/ddi/DeveloperDiskImage.dmg /tmp/ddi/DeveloperDiskImage.dmg.signature 2>&1
+        ideviceimagemounter -u \"\$UDID\" /tmp/ddi/DeveloperDiskImage.dmg /tmp/ddi/DeveloperDiskImage.dmg.signature 2>&1
       fi
     else
       echo \"   ⚠️  No developer disk image at /tmp/ddi/\"
     fi
 
-    # Launch the app
-    echo \"   Launch args: '"${LAUNCH_ARGS[*]}"'\"
-    idevicedebug run '"$BUNDLE_ID"' '"${LAUNCH_ARGS[*]}"' 2>&1 &
+    # Launch without putting the Home Assistant token in process arguments.
+    echo \"   Launching with non-secret arguments (token redacted)\"
+    idevicedebug -u \"\$UDID\" run '"$BUNDLE_ID"' '"${USB_LAUNCH_ARGS[*]}"' 2>&1 &
     DBGPID=\\\$!
     sleep 5
     kill \\\$DBGPID 2>/dev/null || true

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 # Example: scripts/release.sh 1.0.0
 
 VERSION="${1:-}"
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_DIR"
 if [[ -z "$VERSION" ]]; then
     echo "Usage: scripts/release.sh <version>"
     echo "Example: scripts/release.sh 1.0.0"
@@ -20,15 +22,53 @@ if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 fi
 
 TAG="v${VERSION}"
+NOTES_FILE="docs/releases/${TAG}.md"
+PUBLIC_NOTES_FILE="docs/releases/${TAG}-github.md"
+
+BRANCH=$(git branch --show-current)
+if [[ "$BRANCH" != "main" ]]; then
+    echo "Release tags must be created from main; current branch is '${BRANCH:-detached HEAD}'."
+    exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Working tree is not clean. Commit and verify every release file before tagging."
+    exit 1
+fi
+
+REMOTE_MAIN=$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')
+LOCAL_HEAD=$(git rev-parse HEAD)
+if [[ -z "$REMOTE_MAIN" || "$LOCAL_HEAD" != "$REMOTE_MAIN" ]]; then
+    echo "Local main is not the exact current origin/main commit."
+    echo "Local:  $LOCAL_HEAD"
+    echo "Remote: ${REMOTE_MAIN:-unavailable}"
+    exit 1
+fi
+
+if [[ ! -f "$NOTES_FILE" ]]; then
+    echo "Curated release notes are required at $NOTES_FILE"
+    exit 1
+fi
+if [[ ! -f "$PUBLIC_NOTES_FILE" ]]; then
+    echo "Public GitHub release notes are required at $PUBLIC_NOTES_FILE"
+    exit 1
+fi
+if grep -Fq 'Status: **Draft' "$NOTES_FILE" ||
+   grep -Fq 'Status: **Draft' "$PUBLIC_NOTES_FILE" ||
+   grep -Fq -- '- [ ]' "$NOTES_FILE"; then
+    echo "Release notes are still marked as draft or contain incomplete release gates."
+    exit 1
+fi
 
 # Check if tag already exists
-if git rev-parse "$TAG" >/dev/null 2>&1; then
+if git rev-parse --verify "refs/tags/$TAG" >/dev/null 2>&1; then
     echo "Tag $TAG already exists"
     exit 1
 fi
 
 # Show what will be tagged
 echo "Creating release $TAG at $(git rev-parse --short HEAD)"
+echo "Release notes: $NOTES_FILE"
 echo ""
 echo "Commits since last tag:"
 LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
@@ -46,8 +86,8 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     exit 0
 fi
 
-git tag "$TAG"
-git push origin "$TAG"
+git tag -a "$TAG" -m "$TAG: verified release candidate"
+git push origin "refs/tags/$TAG"
 
 REMOTE_URL=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||; s|\.git$||')
 echo ""


### PR DESCRIPTION
## Summary

- add foreground-only, authenticated H.264/AAC RTSP streaming with front/rear selection, supported-device MultiCam, concurrent clients, live quality/orientation updates, and client-gated capture
- add per-device Keychain credentials, Digest auth, password rotation, safe clipboard handling, Home Assistant Generic Camera reconciliation, continuous retries, and privacy/security disclosures
- make mobile-app commands WebSocket-only; fix `command_screen_on`, documented 0-255 brightness payloads, notification confirmation, navigation/appearance/kiosk/reload commands, and registration migration
- harden iOS 9 armv7+arm64, Xcode 26/27, Catalyst, CI, signing, release, and six-target deployment paths
- prepare curated v1.2.6 GitHub and TestFlight notes; no production App Store submission is included

## Verification

- rebased CI-equivalent Catalyst run: 97 selected tests, 0 failures (7 expected unsigned Keychain skips)
- signed Catalyst streaming/credential run: 37/37, 0 skips
- exact build 162 fleet run `20260901T141019Z-23305`: iPhone, Mini 5, Mini 4, iPad 4, iPad Pro, and Catalyst all accepted the same guarded artifacts; locked/Guided Access launch boundaries are recorded separately
- universal executable: armv7 + arm64, minimum iOS 9.0 in both slices; signatures, privacy manifests, profile coverage, and Catalyst non-mergeable executable verified
- iPad 4 / iOS 10.3.3: HA-mediated HLS delivered 7,089,608 media bytes over 12.613s with H.264, AAC, sustained microphone PCM, and one loaded app-owned camera entry
- live local-push acceptance: Home Assistant accepted the WebSocket-only channel, delivered `command_screen_on`, restored brightness through the standard payload, and remained connected beyond the 10-second confirmation window

Closes #13
